### PR TITLE
NF: when binding fails, show address and hint how to change it

### DIFF
--- a/pelita/simplesetup.py
+++ b/pelita/simplesetup.py
@@ -49,8 +49,9 @@ def bind_socket(socket, address, option_hint=None):
         socket.bind(address)
     except zmq.core.error.ZMQError as e:
         print >>sys.stderr, 'error binding to address %s: %s' % (address, e)
-        print >>sys.stderr, 'use %s <address> to specify a different port' %\
-            (option_hint,)
+        if option_hint:
+            print >>sys.stderr, 'use %s <address> to specify a different port' %\
+                (option_hint,)
         raise
 
 class UnknownMessageId(Exception):


### PR DESCRIPTION
There's more than one address-changing option, but we can tell
the user which one to use.
