### PR TITLE
Feature/enemy teams

### DIFF
--- a/doc/source/user-api.rst
+++ b/doc/source/user-api.rst
@@ -43,7 +43,7 @@ Convenience Properties of ``AbstractPlayer``
 
 .. autosummary::
 
-    enemy_teams
+    enemy_team
     enemy_bots
     enemy_food
 
@@ -113,7 +113,7 @@ Interfacing with the ``CTFUniverse``
     bot_positions
     food_list
     pretty
-    enemy_teams
+    enemy_team
     enemy_bots
     enemy_food
     get_legal_moves

--- a/pelita/datamodel.py
+++ b/pelita/datamodel.py
@@ -646,13 +646,10 @@ class CTFUniverse(object):
         enemy_bots : list of Bot objects
 
         """
-        other_team_bots = []
-        for t in self.enemy_teams(team_index):
-            other_team_bots.extend(t.bots)
-        return [self.bots[i] for i in other_team_bots]
+        return [self.bots[i] for i in self.enemy_team(team_index).bots]
 
-    def enemy_teams(self, team_index):
-        """ Obtain the enemy teams.
+    def enemy_team(self, team_index):
+        """ Obtain the enemy team.
 
         Parameters
         ----------
@@ -661,11 +658,18 @@ class CTFUniverse(object):
 
         Returns
         -------
-        enemy_teams : list of Team objects
+        enemy_team : Team object
+
+        Raises
+        ------
+        UniverseException
+            if there is more than one enemy team
         """
         other_teams = self.teams[:]
         other_teams.remove(self.teams[team_index])
-        return other_teams
+        if len(other_teams) != 1:
+            raise UniverseException("Expecting one enemy team. Found %i." % len(other_teams))
+        return other_teams[0]
 
     def team_border(self, team_index):
         """ Positions of the border positions.

--- a/pelita/game_master.py
+++ b/pelita/game_master.py
@@ -266,9 +266,8 @@ class GameMaster(object):
             self.game_state["timeout_teams"][bot.team_index] += 1
 
             if self.game_state["timeout_teams"][bot.team_index] == self.game_state["max_timeouts"]:
-                other_teams = self.universe.enemy_teams(bot.team_index)
-                other_team_idx = other_teams[0].index
-                self.game_state["team_wins"] = other_team_idx
+                other_team = self.universe.enemy_team(bot.team_index)
+                self.game_state["team_wins"] = other_team.index
                 sys.stderr.write("Timeout #%r for team %r (bot index %r). Team disqualified.\n" % (
                                   self.game_state["timeout_teams"][bot.team_index],
                                   bot.team_index,
@@ -287,9 +286,8 @@ class GameMaster(object):
                 self.game_state[k] += v
 
         except PlayerDisconnected:
-            other_teams = self.universe.enemy_teams(bot.team_index)
-            other_team_idx = other_teams[0].index
-            self.game_state["team_wins"] = other_team_idx
+            other_team = self.universe.enemy_team(bot.team_index)
+            self.game_state["team_wins"] = other_team.index
 
             sys.stderr.write("Team %r (bot index %r) disconnected. Team disqualified.\n" % (
                               bot.team_index,
@@ -356,7 +354,7 @@ class GameMaster(object):
         winning_team = self.game_state.get("team_wins")
         if winning_team is not None:
             winner = self.universe.teams[winning_team]
-            loser = self.universe.enemy_teams(winning_team)[0]
+            loser = self.universe.enemy_team(winning_team)
             msg = "Finished. %r won over %r. (%r:%r)" % (
                     winner.name, loser.name,
                     winner.score, loser.score

--- a/pelita/player.py
+++ b/pelita/player.py
@@ -253,15 +253,15 @@ class AbstractPlayer(object):
         return self.current_uni.enemy_bots(self.me.team_index)
 
     @property
-    def enemy_teams(self):
-        """ A list of enemy Teams.
+    def enemy_team(self):
+        """ The enemy Team.
 
         Returns
         -------
-        enemy_teams : list of Team objects
-            all enemy teams
+        enemy_team : Team object
+            the enemy teams
         """
-        return self.current_uni.enemy_teams(self.me.team_index)
+        return self.current_uni.enemy_team(self.me.team_index)
 
     @property
     def current_pos(self):

--- a/test/test_datmodel.py
+++ b/test/test_datmodel.py
@@ -417,8 +417,8 @@ class TestCTFUniverse(unittest.TestCase):
         self.assertEqual([universe.bots[i] for i in 1,3], universe.team_bots(1))
         self.assertEqual([universe.bots[i] for i in 1,3], universe.enemy_bots(0))
 
-        self.assertEqual(universe.enemy_teams(0), [universe.teams[1]])
-        self.assertEqual(universe.enemy_teams(1), [universe.teams[0]])
+        self.assertEqual(universe.enemy_team(0), universe.teams[1])
+        self.assertEqual(universe.enemy_team(1), universe.teams[0])
 
         self.assertEqual([(8, 1), (8, 2)], universe.team_border(0))
         self.assertEqual([(9, 2), (9, 3)], universe.team_border(1))
@@ -594,6 +594,18 @@ class TestCTFUniverse(unittest.TestCase):
         universe = create_CTFUniverse(test_layout3, 4)
         universe_json = json_converter.dumps(universe)
         self.assertEqual(json_converter.loads(universe_json), universe)
+
+    def test_too_many_enemy_teams(self):
+        test_layout3 = (
+        """ ##################
+            #0#.  .  # .     #
+            #1#####    #####2#
+            #     . #  .  .#3#
+            ################## """)
+        universe = create_CTFUniverse(test_layout3, 4)
+        # cheating
+        universe.teams.append(Team(2, "noname", ()))
+        self.assertRaises(UniverseException, universe.enemy_team, 0)
 
 
 class TestCTFUniverseRules(unittest.TestCase):

--- a/test/test_player.py
+++ b/test/test_player.py
@@ -59,10 +59,10 @@ class TestAbstractPlayer(unittest.TestCase):
         self.assertEqual(universe.teams[1], player_1.team)
         self.assertEqual(universe.teams[1], player_3.team)
 
-        self.assertEqual([universe.teams[1]], player_0.enemy_teams)
-        self.assertEqual([universe.teams[1]], player_2.enemy_teams)
-        self.assertEqual([universe.teams[0]], player_1.enemy_teams)
-        self.assertEqual([universe.teams[0]], player_3.enemy_teams)
+        self.assertEqual(universe.teams[1], player_0.enemy_team)
+        self.assertEqual(universe.teams[1], player_2.enemy_team)
+        self.assertEqual(universe.teams[0], player_1.enemy_team)
+        self.assertEqual(universe.teams[0], player_3.enemy_team)
 
         self.assertEqual({(0, 1): (1, 2), (0, 0): (1, 1)},
                 player_0.legal_moves)


### PR DESCRIPTION
Adds ‘enemy_teams’ to CTFUniverse and AbstractPlayer. Avoids doing `1 - team_idx`.
