### PR TITLE
NF: Experimental bash completion.

### DIFF
--- a/pelita-complete.sh
+++ b/pelita-complete.sh
@@ -1,0 +1,8 @@
+PELITADIR=$(pwd)
+
+_pelitagame()
+{
+  _init_completion || return
+  COMPREPLY=( $( compgen -W '$( $PELITADIR/pelitagame --print-args )' -- "$cur" ) )
+} && complete -F _pelitagame pelitagame
+

--- a/pelitagame
+++ b/pelitagame
@@ -215,6 +215,8 @@ parser.add_argument('--standalone-left', const=True, action='store_const', dest=
 parser.add_argument('--standalone-right', const=True, action='store_const', dest='standalone_right',
                     help='run standalone game for the right team')
 
+parser.add_argument('--print-args', const=True, action='store_const')
+
 parser.epilog = """\
 Team Specification:
   - Using predefined players:
@@ -314,6 +316,12 @@ def run_game():
     if args.viewer.startswith('tk') and not args.publish_to:
         raise ValueError("Options --tk (or --tk-no-sync) and --no-publish are mutually exclusive.")
 
+    if args.print_args:
+        option_strings = []
+        for action in parser._actions:
+            option_strings += action.option_strings
+        print " ".join(option_strings)
+        exit(0)
 
     try:
         start_logging(args.log or 'pelita.log')


### PR DESCRIPTION
:)

```
user@bash-4.2$ . pelita-complete.sh
user@bash-4.2$ ./pelitagame <TAB>
--ascii              --layout             --print-args         --standalone-right
--controller         --layoutfile         --progress           --timeout
--dry-run            --log                --publish            --tk
--dump               --max-timeouts       --rounds             --tk-no-sync
--filter             --no-publish         --seed               -h
--geometry           --no-timeout         --standalone-client  
--help               --null               --standalone-left    
```
