### PR TITLE
Factory methods should have an universal name

### DIFF
--- a/pelita/datamodel.py
+++ b/pelita/datamodel.py
@@ -359,64 +359,6 @@ def extract_initial_positions(mesh, number_bots):
     return start
 
 
-def create_CTFUniverse(layout_str, number_bots,
-        team_names=None):
-    """ Factory to create a 2-Player Capture The Flag Universe.
-
-    Parameters
-    ----------
-    layout_str : str
-        the string encoding the maze layout
-    number_bots : int
-        the number of bots in the game
-    team_names : length 2 list of strings, optional
-        default = None -> ['black', 'white']
-        the names of the playing teams
-
-    Raises
-    ------
-    UniverseException
-        if the number of bots or layout width are odd
-    LayoutEncodingException
-        if there is something wrong with the layout_str, see `Layout()`
-
-    """
-    if team_names is None:
-        team_names = ["black", "white"]
-
-    layout_chars = maze_components
-
-    if number_bots % 2 != 0:
-        raise UniverseException(
-            "Number of bots in CTF must be even, is: %i"
-            % number_bots)
-    layout = Layout(layout_str, layout_chars, number_bots)
-    layout_mesh = layout.as_mesh()
-    initial_pos = extract_initial_positions(layout_mesh, number_bots)
-    maze = create_maze(layout_mesh)
-    if maze.width % 2 != 0:
-        raise UniverseException(
-            "Width of a layout for CTF must be even, is: %i"
-            % maze.width)
-    homezones = [(0, maze.width // 2 - 1),
-            (maze.width // 2, maze.width - 1)]
-
-    teams = []
-    teams.append(Team(0, team_names[0], homezones[0], bots=range(0,
-        number_bots, 2)))
-    teams.append(Team(1, team_names[1], homezones[1], bots=range(1,
-        number_bots, 2)))
-
-    bots = []
-    for bot_index in range(number_bots):
-        team_index = bot_index % 2
-        bot = Bot(bot_index, initial_pos[bot_index],
-                team_index, homezones[team_index])
-        bots.append(bot)
-
-    return CTFUniverse(maze, teams, bots)
-
-
 class UniverseException(Exception):
     """ Standard error in the Universe. """
     pass
@@ -447,6 +389,63 @@ class CTFUniverse(object):
         the positions of all edible food
 
     """
+
+    @classmethod
+    def create(cls, layout_str, number_bots, team_names=None):
+        """ Factory to create a 2-Player Capture The Flag Universe.
+
+        Parameters
+        ----------
+        layout_str : str
+            the string encoding the maze layout
+        number_bots : int
+            the number of bots in the game
+        team_names : length 2 list of strings, optional
+            default = None -> ['black', 'white']
+            the names of the playing teams
+
+        Raises
+        ------
+        UniverseException
+            if the number of bots or layout width are odd
+        LayoutEncodingException
+            if there is something wrong with the layout_str, see `Layout()`
+
+        """
+        if team_names is None:
+            team_names = ["black", "white"]
+
+        layout_chars = maze_components
+
+        if number_bots % 2 != 0:
+            raise UniverseException(
+                "Number of bots in CTF must be even, is: %i"
+                % number_bots)
+        layout = Layout(layout_str, layout_chars, number_bots)
+        layout_mesh = layout.as_mesh()
+        initial_pos = extract_initial_positions(layout_mesh, number_bots)
+        maze = create_maze(layout_mesh)
+        if maze.width % 2 != 0:
+            raise UniverseException(
+                "Width of a layout for CTF must be even, is: %i"
+                % maze.width)
+        homezones = [(0, maze.width // 2 - 1),
+                (maze.width // 2, maze.width - 1)]
+
+        teams = []
+        teams.append(Team(0, team_names[0], homezones[0], bots=range(0,
+            number_bots, 2)))
+        teams.append(Team(1, team_names[1], homezones[1], bots=range(1,
+            number_bots, 2)))
+
+        bots = []
+        for bot_index in range(number_bots):
+            team_index = bot_index % 2
+            bot = Bot(bot_index, initial_pos[bot_index],
+                    team_index, homezones[team_index])
+            bots.append(bot)
+
+        return cls(maze, teams, bots)
 
 
     def __init__(self, maze, teams, bots):

--- a/pelita/game_master.py
+++ b/pelita/game_master.py
@@ -56,7 +56,7 @@ class GameMaster(object):
     def __init__(self, layout, number_bots, game_time, noise=True, noiser=None,
                  initial_delay=0.0, max_timeouts=5, timeout_length=3, layout_name=None,
                  seed=None, parseable_output=False):
-        self.universe = datamodel.create_CTFUniverse(layout, number_bots)
+        self.universe = datamodel.CTFUniverse.create(layout, number_bots)
         self.number_bots = number_bots
         if noiser is None:
             noiser = ManhattanNoiser

--- a/test/test_datmodel.py
+++ b/test/test_datmodel.py
@@ -8,7 +8,7 @@ from pelita.messaging.json_convert import json_converter
 
 
 # the legal chars for a basic CTFUniverse
-# see also: create_CTFUniverse factory.
+# see also: CTFUniverse.create factory.
 layout_chars = maze_components
 
 class TestStaticmethods(unittest.TestCase):
@@ -338,7 +338,7 @@ class TestCTFUniverse(unittest.TestCase):
             #1#####    #####2#
             #     . #  .  .#3#
             ################## """)
-        universe = create_CTFUniverse(test_layout3, 4)
+        universe = CTFUniverse.create(test_layout3, 4)
         # this checks that the methods extracts the food, and the initial
         # positions from the raw layout
         target_mesh = Mesh(18, 5, data = list('################### #.  .  # .     #'+\
@@ -377,16 +377,16 @@ class TestCTFUniverse(unittest.TestCase):
             """ #####
                 #0 1#
                 ##### """)
-        self.assertRaises(UniverseException, create_CTFUniverse, odd_layout, 2)
+        self.assertRaises(UniverseException, CTFUniverse.create, odd_layout, 2)
 
         odd_bots = (
             """ ####
                 #01#
                 #2 #
                 #### """)
-        self.assertRaises(UniverseException, create_CTFUniverse, odd_bots, 3)
+        self.assertRaises(UniverseException, CTFUniverse.create, odd_bots, 3)
 
-        universe = create_CTFUniverse(test_layout3, 4, team_names=['orange', 'purple'])
+        universe = CTFUniverse.create(test_layout3, 4, team_names=['orange', 'purple'])
         self.assertEqual(universe.teams[0].name, 'orange')
         self.assertEqual(universe.teams[1].name, 'purple')
 
@@ -397,7 +397,7 @@ class TestCTFUniverse(unittest.TestCase):
                 #    #
                 #    #
                 ###### """)
-        universe = create_CTFUniverse(test_layout, 0)
+        universe = CTFUniverse.create(test_layout, 0)
         current_position = (2, 2)
         new = universe.neighbourhood(current_position)
         target = { north : (2, 1),
@@ -414,7 +414,7 @@ class TestCTFUniverse(unittest.TestCase):
             #1#####    #####2#
             #     . #  .  .#3#
             ################## """)
-        universe = create_CTFUniverse(test_layout3, 4)
+        universe = CTFUniverse.create(test_layout3, 4)
 
         test_layout3_2 = (
         """ ##################
@@ -422,7 +422,7 @@ class TestCTFUniverse(unittest.TestCase):
             #1#####    #####2#
             #     . #  .  .#3#
             ################## """)
-        universe2 = create_CTFUniverse(test_layout3_2, 4)
+        universe2 = CTFUniverse.create(test_layout3_2, 4)
 
         self.assertEqual(universe, universe2)
         self.assertEqual(universe, eval(repr(universe)))
@@ -435,7 +435,7 @@ class TestCTFUniverse(unittest.TestCase):
             #1#####    #####2#
             #     . #  .  .#3#
             ################## """)
-        universe = create_CTFUniverse(test_layout3, 4)
+        universe = CTFUniverse.create(test_layout3, 4)
         uni_copy = universe.copy()
         self.assertEqual(universe, uni_copy)
         # this is just a smoke test for the most volatile aspect of
@@ -452,7 +452,7 @@ class TestCTFUniverse(unittest.TestCase):
             #1#####    #####2#
             #     . #  .  .#3#
             ################## """)
-        universe = create_CTFUniverse(test_layout3, 4)
+        universe = CTFUniverse.create(test_layout3, 4)
         compact_str_target = (
             '##################\n'
             '#0#.  .  # .     #\n'
@@ -489,7 +489,7 @@ class TestCTFUniverse(unittest.TestCase):
                 #0  1#
                 #2  3#
                 ###### """)
-        universe = create_CTFUniverse(test_layout4, 4)
+        universe = CTFUniverse.create(test_layout4, 4)
 
         team_black = Team(0, 'black', (0, 2), bots=[0, 2])
         team_white = Team(1, 'white', (3, 5), bots=[1, 3])
@@ -512,7 +512,7 @@ class TestCTFUniverse(unittest.TestCase):
                 #1  0#
                 #3  2#
                 ###### """)
-        universe = create_CTFUniverse(test_layout4, 4)
+        universe = CTFUniverse.create(test_layout4, 4)
 
         self.assertFalse(universe.bots[0].in_own_zone)
         self.assertFalse(universe.bots[1].in_own_zone)
@@ -524,7 +524,7 @@ class TestCTFUniverse(unittest.TestCase):
                 #0 2 #
                 # 1 3#
                 ###### """)
-        universe = create_CTFUniverse(test_layout4, 4)
+        universe = CTFUniverse.create(test_layout4, 4)
         self.assertTrue(universe.bots[1].is_harvester)
         self.assertTrue(universe.bots[2].is_harvester)
         self.assertFalse(universe.bots[0].is_harvester)
@@ -541,7 +541,7 @@ class TestCTFUniverse(unittest.TestCase):
             #1#####    #####2#
             #     . #  .  .#3#
             ################## """)
-        universe = create_CTFUniverse(test_layout3, 4)
+        universe = CTFUniverse.create(test_layout3, 4)
         universe_json = json_converter.dumps(universe)
         self.assertEqual(json_converter.loads(universe_json), universe)
 
@@ -552,7 +552,7 @@ class TestCTFUniverse(unittest.TestCase):
             #1#####    #####2#
             #     . #  .  .#3#
             ################## """)
-        universe = create_CTFUniverse(test_layout3, 4)
+        universe = CTFUniverse.create(test_layout3, 4)
         # cheating
         universe.teams.append(Team(2, "noname", ()))
         self.assertRaises(UniverseException, universe.enemy_team, 0)
@@ -564,7 +564,7 @@ class TestCTFUniverse(unittest.TestCase):
             #2#####    ##### #
             #     . #  .  .#3#
             ################## """)
-        universe = create_CTFUniverse(test_layout, 4)
+        universe = CTFUniverse.create(test_layout, 4)
         reachable = [universe.reachable([bot.initial_pos]) for bot in universe.bots]
         self.assertTrue(bot.initial_pos in reachable[i] for i, bot in enumerate(universe.bots))
         self.assertTrue(universe.bots[0].initial_pos in dict(reachable[1]))
@@ -580,7 +580,7 @@ class TestCTFUniverseRules(unittest.TestCase):
                 #   ##
                 #    #
                 ###### """)
-        universe = create_CTFUniverse(test_legal, 0)
+        universe = CTFUniverse.create(test_legal, 0)
         legal_moves_1_1 = universe.legal_moves((1, 1))
         target = {east  : (2, 1),
                   south : (1, 2),
@@ -636,7 +636,7 @@ class TestCTFUniverseRules(unittest.TestCase):
                 #   ##
                 #    #
                 ###### """)
-        universe = create_CTFUniverse(test_legal, 0)
+        universe = CTFUniverse.create(test_legal, 0)
         legal_moves_1_1 = universe.legal_moves_or_stop((1, 1))
         target = {east  : (2, 1),
                   south : (1, 2)}
@@ -684,7 +684,7 @@ class TestCTFUniverseRules(unittest.TestCase):
                 # 3 ##
                 #2  1#
                 ###### """)
-        universe = create_CTFUniverse(test_move_bot, 4)
+        universe = CTFUniverse.create(test_move_bot, 4)
 
         self.assertRaises(IllegalMoveException, universe.move_bot, 0, 'FOOBAR')
         self.assertRaises(IllegalMoveException, universe.move_bot, 0, (0, 2))
@@ -710,7 +710,7 @@ class TestCTFUniverseRules(unittest.TestCase):
                 #     1#
                 ######## """)
         number_bots = 4
-        universe = create_CTFUniverse(test_reset_bot, number_bots)
+        universe = CTFUniverse.create(test_reset_bot, number_bots)
         self.assertEqual(str(universe),
                 str(Layout(test_reset_bot, layout_chars, number_bots).as_mesh()))
         self.assertEqual(universe.bot_positions,
@@ -753,7 +753,7 @@ class TestCTFUniverseRules(unittest.TestCase):
 
         def create_TestUniverse(layout, black_score=0, white_score=0):
             initial_pos = [(1, 1), (4, 2)]
-            universe = create_CTFUniverse(layout, number_bots)
+            universe = CTFUniverse.create(layout, number_bots)
             universe.teams[0].score = black_score
             universe.teams[1].score = white_score
             for i, pos in enumerate(initial_pos):
@@ -769,7 +769,7 @@ class TestCTFUniverseRules(unittest.TestCase):
                 #0 . #
                 #.  1#
                 ###### """)
-        universe = create_CTFUniverse(test_start, number_bots)
+        universe = CTFUniverse.create(test_start, number_bots)
         game_state = universe.move_bot(1, west)
         test_first_move = (
             """ ######
@@ -855,7 +855,7 @@ class TestCTFUniverseRules(unittest.TestCase):
                 #.  1#
                 ###### """)
         number_bots = 2
-        universe = create_CTFUniverse(test_start, number_bots)
+        universe = CTFUniverse.create(test_start, number_bots)
         universe.move_bot(1, north)
         game_state = universe.move_bot(1, west)
         self.assertEqual(universe.food_list, [(3, 1), (1, 2)])
@@ -867,7 +867,7 @@ class TestCTFUniverseRules(unittest.TestCase):
                 #0 .1#
                 #.   #
                 ###### """)
-        universe = create_CTFUniverse(test, 2)
+        universe = CTFUniverse.create(test, 2)
         universe.move_bot(0, east)
         universe.move_bot(1, west)
         game_state = universe.move_bot(0, east)

--- a/test/test_game_master.py
+++ b/test/test_game_master.py
@@ -4,7 +4,7 @@ import unittest
 import time
 import collections
 import pelita
-from pelita.datamodel import Wall, Free, Food, create_CTFUniverse, KILLPOINTS
+from pelita.datamodel import Wall, Free, Food, CTFUniverse, KILLPOINTS
 
 from pelita.game_master import GameMaster, UniverseNoiser, AStarNoiser, ManhattanNoiser, PlayerTimeout
 from pelita.player import AbstractPlayer, SimpleTeam, TestPlayer, StoppingPlayer
@@ -125,7 +125,7 @@ class TestUniverseNoiser(unittest.TestCase):
             # #####    ##### #
             #  0  . #  .  .#1#
             ################## """)
-        universe = create_CTFUniverse(test_layout, 2)
+        universe = CTFUniverse.create(test_layout, 2)
         noiser = AStarNoiser(universe.copy())
 
         position_bucket = collections.defaultdict(int)
@@ -147,7 +147,7 @@ class TestUniverseNoiser(unittest.TestCase):
             # #####    ##### #
             #  0  . #  .  .#1#
             ################## """)
-        universe = create_CTFUniverse(test_layout, 2)
+        universe = CTFUniverse.create(test_layout, 2)
         noiser = ManhattanNoiser(universe.copy())
 
         position_bucket = collections.defaultdict(int)
@@ -171,7 +171,7 @@ class TestUniverseNoiser(unittest.TestCase):
             # #####    #####3#
             #  0  . #  .  .#1#
             ################## """)
-        universe = create_CTFUniverse(test_layout, 4)
+        universe = CTFUniverse.create(test_layout, 4)
         noiser = AStarNoiser(universe.copy())
 
         expected_0 = [(1, 2), (7, 3), (1, 3), (3, 3), (6, 3),
@@ -202,7 +202,7 @@ class TestUniverseNoiser(unittest.TestCase):
             # #####    #####3#
             #   0  . # .  .#1#
             ################## """)
-        universe = create_CTFUniverse(test_layout, 4)
+        universe = CTFUniverse.create(test_layout, 4)
         noiser = ManhattanNoiser(universe.copy())
 
         expected_0 = [ (1, 1), (1, 2), (1, 3), (2, 3), (3, 3),
@@ -238,7 +238,7 @@ class TestUniverseNoiser(unittest.TestCase):
             # #####    #####3#
             #  0  . #  .  .#1#
             ################## """)
-        universe = create_CTFUniverse(test_layout, 4)
+        universe = CTFUniverse.create(test_layout, 4)
         noiser = AStarNoiser(universe.copy())
 
         expected_0 = [(1, 2), (7, 3), (1, 3), (3, 3), (6, 3),
@@ -270,7 +270,7 @@ class TestUniverseNoiser(unittest.TestCase):
             # #####    #####3#
             #  0  . #  .  .#1#
             ################## """)
-        universe = create_CTFUniverse(test_layout, 4)
+        universe = CTFUniverse.create(test_layout, 4)
         noiser = ManhattanNoiser(universe.copy())
 
         expected_0 = [ (1, 1), (3, 1), (4, 1), (5, 1), (6, 1),
@@ -304,7 +304,7 @@ class TestUniverseNoiser(unittest.TestCase):
             #  0# . #  .  . 1#
             ################## """)
         # noiser should not find a connection
-        universe = create_CTFUniverse(test_layout, 4)
+        universe = CTFUniverse.create(test_layout, 4)
 
         positions = [b.current_pos for b in universe.bots]
 
@@ -325,7 +325,7 @@ class TestUniverseNoiser(unittest.TestCase):
             ###0###### .  . 1#
             ################## """)
         # noiser should not find a connection
-        universe = create_CTFUniverse(test_layout, 4)
+        universe = CTFUniverse.create(test_layout, 4)
 
         positions = [b.current_pos for b in universe.bots]
 
@@ -371,7 +371,7 @@ class TestGame(unittest.TestCase):
 
         def create_TestUniverse(layout, black_score=0, white_score=0):
             initial_pos = [(1, 1), (4, 2)]
-            universe = create_CTFUniverse(layout, number_bots)
+            universe = CTFUniverse.create(layout, number_bots)
             universe.teams[0].score = black_score
             universe.teams[1].score = white_score
             for i, pos in enumerate(initial_pos):

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import unittest
-from pelita.datamodel import create_CTFUniverse, Free, north, south, west, east, stop
+from pelita.datamodel import CTFUniverse, Free, north, south, west, east, stop
 from pelita.graph import new_pos, diff_pos, manhattan_dist, AdjacencyList, NoPathException, iter_adjacencies
 
 
@@ -83,7 +83,7 @@ class TestAdjacencyList(unittest.TestCase):
             #2#####    #####1#
             #     . #  .  .#3#
             ################## """)
-        universe = create_CTFUniverse(test_layout, 4)
+        universe = CTFUniverse.create(test_layout, 4)
         al = AdjacencyList(universe.free_positions())
         free = set(universe.maze.pos_of(Free))
 
@@ -107,7 +107,7 @@ class TestAdjacencyList(unittest.TestCase):
         """ ######
             #    #
             ###### """)
-        universe = create_CTFUniverse(test_layout, 0)
+        universe = CTFUniverse.create(test_layout, 0)
         al = AdjacencyList(universe.free_positions())
         target = { (4, 1): [(4, 1), (3, 1)],
                    (1, 1): [(2, 1), (1, 1)],
@@ -122,7 +122,7 @@ class TestAdjacencyList(unittest.TestCase):
             # #####    ##### #
             #     . #  .  .#1#
             ################## """)
-        universe = create_CTFUniverse(test_layout, 2)
+        universe = CTFUniverse.create(test_layout, 2)
         al = AdjacencyList(universe.free_positions())
 
         adjacency_target = {(7, 3): [(7, 2), (7, 3), (6, 3)],
@@ -166,7 +166,7 @@ class TestAdjacencyList(unittest.TestCase):
         """ ############
             #0.     #.1#
             ############ """)
-        universe = create_CTFUniverse(test_layout, 2)
+        universe = CTFUniverse.create(test_layout, 2)
         al = AdjacencyList(universe.free_positions())
         self.assertEqual([], al.bfs((1,1), [(1, 1), (2, 1)]))
 
@@ -177,7 +177,7 @@ class TestAdjacencyList(unittest.TestCase):
             #2#####    #####1#
             #     . #  .  .#3#
             ################## """)
-        universe = create_CTFUniverse(test_layout, 4)
+        universe = CTFUniverse.create(test_layout, 4)
         al = AdjacencyList(universe.free_positions())
         # just a simple smoke test
         self.assertEqual(14, len(al.a_star((1, 1), (3, 1))))
@@ -187,7 +187,7 @@ class TestAdjacencyList(unittest.TestCase):
         """ ############
             #0.     #.1#
             ############ """)
-        universe = create_CTFUniverse(test_layout, 2)
+        universe = CTFUniverse.create(test_layout, 2)
         al = AdjacencyList(universe.free_positions())
         self.assertRaises(NoPathException, al.bfs, (1, 1), [(10, 1)])
         self.assertRaises(NoPathException, al.bfs, (1, 1), [(10, 1), (9, 1)])
@@ -199,7 +199,7 @@ class TestAdjacencyList(unittest.TestCase):
         """ ############
             #0.     #.1#
             ############ """)
-        universe = create_CTFUniverse(test_layout, 2)
+        universe = CTFUniverse.create(test_layout, 2)
         al = AdjacencyList(universe.free_positions())
         self.assertRaises(NoPathException, al.a_star, (1, 1), (10, 1))
         self.assertRaises(NoPathException, al.a_star, (0, 1), (10, 1))

--- a/test/test_player.py
+++ b/test/test_player.py
@@ -2,7 +2,7 @@ import unittest
 import time
 import random
 from pelita.player import *
-from pelita.datamodel import create_CTFUniverse, north, stop, east, west
+from pelita.datamodel import CTFUniverse, north, stop, east, west
 from pelita.game_master import GameMaster
 from pelita.viewer import AsciiViewer
 
@@ -584,7 +584,7 @@ class TestSimpleTeam(unittest.TestCase):
                 #01#
                 #### """
         )
-        dummy_universe = create_CTFUniverse(layout, 2)
+        dummy_universe = CTFUniverse.create(layout, 2)
         team1 = SimpleTeam(TestPlayer('^'), TestPlayer('>'))
 
         dummy_universe.teams[0].bots = [1, 5, 10]


### PR DESCRIPTION
Is there a reason we did not do it this way in the first place? It makes a bit more sense to me but on the other hand, it is quite a messy method and CTFUniverse could me much nicer without it.

Of course ‘create’ being a classmethod means we could more easily modularise over different universe classes at some point (we’d need much more cleanup though).
