### PR TITLE
DOC/ENH: Correct sentence in Maze description

### DIFF
--- a/doc/source/writing_player.rst
+++ b/doc/source/writing_player.rst
@@ -136,7 +136,7 @@ The Maze Coordinate System
 ==========================
 
 The coordinate system is the standard coordinate system used in computer games.
-``x`` increases to the left, and ``y`` increases downwards, and a position is
+``x`` increases to the right, and ``y`` increases downwards, and a position is
 encoded as the tuple ``(x, y)``. There are no negative coordinates. The
 following example illustrates this for a few positions:
 


### PR DESCRIPTION
If I don't make mistake in my understanding of the Maze (and English), the `x` coordinate increases to the _right_ and not to the _left_ as said in the documentation.
