### PR TITLE
BF: Aborting with better error message when set_initial was not called before get_move.

### DIFF
--- a/pelita/game_master.py
+++ b/pelita/game_master.py
@@ -210,6 +210,8 @@ class GameMaster:
                 self.game_state["team_name"][team_id] = team_name
             except PlayerTimeout:
                 pass
+            except PlayerDisconnected:
+                self.game_state["teams_disqualified"][team_id] = "disconnected"
 
     # TODO the game winning detection should be refactored
     def play(self):

--- a/pelita/player.py
+++ b/pelita/player.py
@@ -154,7 +154,11 @@ class SimpleTeam(AbstractTeam):
         -------
         move : dict
         """
-        return self._bot_players[bot_id]._get_move(universe, game_state)
+        try:
+            bot_player = self._bot_players[bot_id]
+        except KeyError:
+            raise RuntimeError("Trying to call ‘get_move’ on undefined player. ‘set_initial’ may have not been called. Aborting.")
+        return bot_player._get_move(universe, game_state)
 
     @property
     def remote_game(self):

--- a/pelita/simplesetup.py
+++ b/pelita/simplesetup.py
@@ -247,6 +247,7 @@ class RemoteTeamPlayer:
             raise PlayerTimeout()
         except DeadConnection:
             _logger.info("Detected a DeadConnection.")
+            raise PlayerDisconnected()
 
     def get_move(self, bot_id, universe, game_state):
         try:

--- a/test/test_player.py
+++ b/test/test_player.py
@@ -483,6 +483,23 @@ class TestSimpleTeam:
         with pytest.raises(ValueError):
             team1.set_initial(0, dummy_universe, {})
 
+    def test_init_order(self):
+        layout = (
+            """ ######
+                #0  1#
+                ###### """
+        )
+        dummy_universe = CTFUniverse.create(layout, 2)
+
+        team = SimpleTeam(TestPlayer(">"))
+        team.set_initial(0, universe=dummy_universe, game_state={"seed": 0})
+        assert team.get_move(0, universe=dummy_universe, game_state={})['move'] == (1, 0)
+
+        team = SimpleTeam(TestPlayer(">"))
+        with pytest.raises(RuntimeError):
+            assert team.get_move(0, universe=dummy_universe, game_state={})['move'] == (1, 0)
+
+
 class TestAbstracts:
     class BrokenPlayer(AbstractPlayer):
         pass


### PR DESCRIPTION
Problem: A client connects while the game is already running and therefore never receives a set_initial request. Then get_move is called and the team is in an undefined state.

A better solution would be for the server to disallow a late connection in the first place.

Gives a better error message to #269.
