### PR TITLE
BLD: Speedup travis runs by not needing sudo rights.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+sudo: false
 python:
   - "2.7"
   - "3.3"


### PR DESCRIPTION
This makes travis use a container instead of a fuller VM.