### PR TITLE
DOC: Remove the __docformat__ specification.

### DIFF
--- a/check_boilerplate.sh
+++ b/check_boilerplate.sh
@@ -1,21 +1,11 @@
 #!/bin/zsh
 
-
-
-check_docformat(){
-    if ! grep -q '__docformat__' $1 ; then
-        echo "warning: file '$1' does not contain a '__docformat__' declaration!"
-    fi
-}
-
 check_coding(){
     if ! grep -q -e 'coding: utf-8' $1 ; then
         echo "warning: file '$1' does not contain a coding declaration!"
     fi
 }
 
-
 for f in $( ls pelita/**/*.py ) ; do
-    check_docformat $f
     check_coding $f
 done

--- a/pelita/__init__.py
+++ b/pelita/__init__.py
@@ -10,6 +10,4 @@ from . import (containers,
                utils,
                __version_from_git)
 
-__docformat__ = "restructuredtext"
-
 version = __version_from_git.version()

--- a/pelita/__version_from_git.py
+++ b/pelita/__version_from_git.py
@@ -3,9 +3,6 @@
 import os
 import subprocess
 
-__docformat__ = "restructuredtext"
-
-
 def __get_command_output(command, cwd=None):
     """ Execute arbitrary commands.
 

--- a/pelita/containers.py
+++ b/pelita/containers.py
@@ -8,9 +8,6 @@ from collections import Mapping, MutableSequence
 
 from .messaging.json_convert import serializable
 
-__docformat__ = "restructuredtext"
-
-
 @serializable
 class Mesh(Mapping):
     """ A mapping from a two-dimensional coordinate system into object space.

--- a/pelita/datamodel.py
+++ b/pelita/datamodel.py
@@ -11,9 +11,6 @@ from .layout import Layout
 from .containers import Mesh
 from .messaging.json_convert import serializable
 
-
-__docformat__ = "restructuredtext"
-
 north = (0, -1)
 south = (0, 1)
 west  = (-1, 0)

--- a/pelita/game_master.py
+++ b/pelita/game_master.py
@@ -11,8 +11,6 @@ from .graph import NoPathException, AdjacencyList, manhattan_dist
 from .datamodel import CTFUniverse, Bot, Free
 import six
 
-__docformat__ = "restructuredtext"
-
 class GameFinished(Exception):
     pass
 

--- a/pelita/graph.py
+++ b/pelita/graph.py
@@ -5,8 +5,6 @@
 from collections import deque
 import heapq
 
-__docformat__ = "restructuredtext"
-
 class NoPathException(Exception):
     pass
 

--- a/pelita/layout.py
+++ b/pelita/layout.py
@@ -16,9 +16,6 @@ except SyntaxError as err:
     print("Invalid syntax in __layouts module. Pelita will not be able to use built-in layouts.")
     print(err)
 
-__docformat__ = "restructuredtext"
-
-
 class LayoutEncodingException(Exception):
     """ Signifies a problem with the encoding of a layout. """
     pass

--- a/pelita/messaging/json_convert.py
+++ b/pelita/messaging/json_convert.py
@@ -5,9 +5,6 @@
 import inspect
 import json
 
-__docformat__ = "restructuredtext"
-
-
 class JsonConverter(object):
     """ The `JsonConverter` registers all necessary methods to transform
     an object into a Json understandable format and back again.

--- a/pelita/player.py
+++ b/pelita/player.py
@@ -12,8 +12,6 @@ import pdb
 from . import datamodel
 import six
 
-__docformat__ = "restructuredtext"
-
 class SimpleTeam(object):
     """ Simple class used to register an arbitrary number of (Abstract-)Players.
 

--- a/pelita/simplesetup.py
+++ b/pelita/simplesetup.py
@@ -46,8 +46,6 @@ from .viewer import AbstractViewer
 
 _logger = logging.getLogger("pelita.simplesetup")
 
-__docformat__ = "restructuredtext"
-
 class DeadConnection(Exception):
     """ Raised when the connection has been lost. """
 

--- a/pelita/utils/__init__.py
+++ b/pelita/utils/__init__.py
@@ -5,8 +5,6 @@ import contextlib as _contextlib
 from .threading_helpers import *
 from .debug import *
 
-__docformat__ = "restructuredtext"
-
 @_contextlib.contextmanager
 def with_sys_path(dirname):
     sys.path.insert(0, dirname)

--- a/pelita/utils/debug.py
+++ b/pelita/utils/debug.py
@@ -9,9 +9,6 @@ from . import SuspendableThread
 _logger = logging.getLogger("pelita.utils")
 _logger.setLevel(logging.DEBUG)
 
-__docformat__ = "restructuredtext"
-
-
 class ThreadInfoLogger(SuspendableThread):
     def __init__(self, interval, show_threads=True):
         super(ThreadInfoLogger, self).__init__()

--- a/pelita/utils/threading_helpers.py
+++ b/pelita/utils/threading_helpers.py
@@ -7,9 +7,6 @@ import logging
 _logger = logging.getLogger("pelita.threading")
 #_logger.setLevel(logging.DEBUG)
 
-__docformat__ = "restructuredtext"
-
-
 class CloseThread(Exception):
     """May be raised from inside the _run method to close the thread."""
 

--- a/pelita/viewer.py
+++ b/pelita/viewer.py
@@ -8,8 +8,6 @@ import six
 
 from .messaging.json_convert import json_converter
 
-__docformat__ = "restructuredtext"
-
 @six.add_metaclass(abc.ABCMeta)
 class AbstractViewer(object):
     def set_initial(self, universe):


### PR DESCRIPTION
I have no idea if this is actually useful. Let’s get rid of it.