### PR TITLE
Flexible tournament

### DIFF
--- a/pelita/libpelita.py
+++ b/pelita/libpelita.py
@@ -10,7 +10,6 @@ import sys
 
 import zmq
 
-from . import layout
 from .simplesetup import RemoteTeamPlayer, SimpleController, SimplePublisher, SimpleServer
 
 _logger = logging.getLogger("pelita.libpelita")
@@ -150,24 +149,20 @@ def prepare_team(team_spec):
         address = "tcp://127.0.0.1"
     return TeamSpec(module, address)
 
-def run_game(team_specs, game_config):
-    if game_config["layout"] or game_config["layoutfile"]:
-        layout_name, layout_string = layout.load_layout(layout_name=game_config["layout"], layout_file=game_config["layoutfile"])
-    else:
-        layout_name, layout_string = layout.get_random_layout(game_config["filter"])
-
-    print("Using layout '%s'" % layout_name)
+def run_game(team_specs, game_config, viewers=None, controller=None):
+    if viewers is None:
+        viewers = []
 
     teams = [prepare_team(team_spec) for team_spec in team_specs]
 
-    server = SimpleServer(layout_string=layout_string,
-                                             rounds=game_config["rounds"],
-                                             bind_addrs=[team.address for team in teams],
-                                             initial_delay=game_config["initial_delay"],
-                                             max_timeouts=game_config["max_timeouts"],
-                                             timeout_length=game_config["timeout_length"],
-                                             layout_name=layout_name,
-                                             seed=game_config["seed"])
+    server = SimpleServer(layout_string=game_config["layout_string"],
+                          rounds=game_config["rounds"],
+                          bind_addrs=[team.address for team in teams],
+                          initial_delay=game_config["initial_delay"],
+                          max_timeouts=game_config["max_timeouts"],
+                          timeout_length=game_config["timeout_length"],
+                          layout_name=game_config["layout_name"],
+                          seed=game_config["seed"])
 
     # Update our teams with the bound addresses
     teams = [
@@ -185,17 +180,64 @@ def run_game(team_specs, game_config):
         if team.module
     ]
 
-    publisher = SimplePublisher(game_config["publish_to"])
-#    config["publish-addr"] = publisher.socket_addr
-    print("Publishing to %s" % publisher.socket_addr)
-    server.game_master.register_viewer(publisher)
+    for viewer in viewers:
+        server.game_master.register_viewer(viewer)
 
-    if game_config.get("controller"):
-        controller = SimpleController(server.game_master, game_config["controller"])
-        controller.run()
-        server.exit_teams()
-    else:
+    if game_config.get("publisher"):
+        server.game_master.register_viewer(game_config["publisher"])
 
-        server.run()
-    return server.game_master.game_state
+    with autoclose_subprocesses(external_players):
+        if controller is not None:
+            if controller.game_master is None:
+                controller.game_master = server.game_master
+            controller.run()
+            server.exit_teams()
+        else:
+            server.run()
+        return server.game_master.game_state
 
+@contextlib.contextmanager
+def tk_viewer(geometry=None, delay=None):
+    publisher = SimplePublisher("tcp://127.0.0.1:*")
+    controller = SimpleController(None, "tcp://127.0.0.1:*")
+
+    viewer = run_external_viewer(publisher.socket_addr, controller.socket_addr,
+                                 geometry=geometry, delay=delay)
+    yield { "publisher": publisher, "controller": controller }
+
+def run_external_viewer(subscribe_sock, controller, geometry, delay):
+    # Something on OS X prevents Tk from running in a forked process.
+    # Therefore we cannot use multiprocessing here. subprocess works, though.
+    viewer_args = [ str(subscribe_sock) ]
+    if controller:
+        viewer_args += ["--controller-address", str(controller)]
+    if geometry:
+        viewer_args += ["--geometry", "{0}x{1}".format(*geometry)]
+    if delay:
+        viewer_args += ["--delay", str(delay)]
+
+    tkviewer = os.path.join(os.path.dirname(sys.argv[0]), "tkviewer.py")
+    external_call = [get_python_process(), tkviewer] + viewer_args
+    _logger.debug("Executing: %r", external_call)
+    return subprocess.Popen(external_call)
+
+@contextlib.contextmanager
+def autoclose_subprocesses(subprocesses):
+    """
+    Automatically close subprocesses when the context ends.
+    This needs to be done to shut down misbehaving bots
+    when the main program finishes.
+    """
+    try:
+        yield
+    except KeyboardInterrupt:
+        pass
+    finally:
+        # kill all client processes. NOW!
+        # (is ths too early?)
+        for sp in subprocesses:
+            _logger.debug("Attempting to terminate %r.", sp)
+            sp.terminate()
+        for sp in subprocesses:
+            sp.wait()
+            _logger.debug("%r terminated.", sp)

--- a/pelita/libpelita.py
+++ b/pelita/libpelita.py
@@ -42,18 +42,19 @@ class DefaultRunner(ModuleRunner):
 
 class Py2Runner(ModuleRunner):
     def run(self, addr):
-        player_path = os.path.dirname(sys.argv[0])
+        player_path = os.environ.get("PELITA_PATH") or os.path.dirname(sys.argv[0])
         player = os.path.join(player_path, "module_player.py")
         external_call = ["python2",
                          player,
                          self.team_spec,
                          addr]
+        print(external_call)
         _logger.debug("Executing: %r", external_call)
         return subprocess.Popen(external_call)
 
 class Py3Runner(ModuleRunner):
     def run(self, addr):
-        player_path = os.path.dirname(sys.argv[0])
+        player_path = os.environ.get("PELITA_PATH") or os.path.dirname(sys.argv[0])
         player = os.path.join(player_path, "module_player.py")
         external_call = ["python3",
                          player,

--- a/pelita/libpelita.py
+++ b/pelita/libpelita.py
@@ -31,7 +31,7 @@ class ModuleRunner(object):
 
 class DefaultRunner(ModuleRunner):
     def run(self, addr):
-        player_path = os.path.dirname(sys.argv[0])
+        player_path = os.environ.get("PELITA_PATH") or os.path.dirname(sys.argv[0])
         player = os.path.join(player_path, "module_player.py")
         external_call = [get_python_process(),
                          player,

--- a/pelita/libpelita.py
+++ b/pelita/libpelita.py
@@ -198,8 +198,10 @@ def run_game(team_specs, game_config, viewers=None, controller=None):
         return server.game_master.game_state
 
 @contextlib.contextmanager
-def tk_viewer(geometry=None, delay=None):
-    publisher = SimplePublisher("tcp://127.0.0.1:*")
+def tk_viewer(publish_to=None, geometry=None, delay=None):
+    if publish_to is None:
+        publish_to = "tcp://127.0.0.1:*"
+    publisher = SimplePublisher(publish_to)
     controller = SimpleController(None, "tcp://127.0.0.1:*")
 
     viewer = run_external_viewer(publisher.socket_addr, controller.socket_addr,

--- a/pelita/simplesetup.py
+++ b/pelita/simplesetup.py
@@ -174,7 +174,7 @@ class ZMQConnection(object):
         py_obj = json.loads(json_message)
         #print repr(json_msg)
         msg_uuid = py_obj["__uuid__"]
-        msg_action = py_obj.get("__action__")
+        msg_action = py_obj.get("__action__") or py_obj.get("__return__")
 
         _logger.debug("<--- %r [%s]", msg_action, msg_uuid)
 

--- a/pelitagame
+++ b/pelitagame
@@ -14,7 +14,7 @@ import sys
 import time
 
 import pelita
-from pelita.libpelita import check_team, prepare_team, call_standalone_pelitagame, get_python_process
+from pelita import libpelita
 
 # silence stupid warnings from logging module
 logging.root.manager.emittedNoHandlerWarning = 1
@@ -114,7 +114,7 @@ def run_external_viewer(subscribe_sock, controller, geometry, delay):
         viewer_args += ["--delay", str(delay)]
 
     tkviewer = os.path.join(os.path.dirname(sys.argv[0]), "tkviewer.py")
-    external_call = [get_python_process(), tkviewer] + viewer_args
+    external_call = [libpelita.get_python_process(), tkviewer] + viewer_args
     _logger.debug("Executing: %r", external_call)
     return subprocess.Popen(external_call)
 
@@ -143,23 +143,6 @@ def geometry_string(s):
         msg = "%s is not a valid geometry specification" %s
         raise argparse.ArgumentTypeError(msg)
     return geometry
-
-@contextlib.contextmanager
-def autoclose_externals(external_viewers, external_players):
-    try:
-        yield
-    except KeyboardInterrupt:
-        for external_viewer in external_viewers:
-            external_viewer.kill()
-    finally:
-        # kill all client processes. NOW!
-        # (is this too early?)
-        for external_player in external_players:
-            _logger.debug("Attempting to terminate %r.", external_player)
-            external_player.terminate()
-        for external_player in external_players:
-            external_player.wait()
-            _logger.debug("%r terminated.", external_player)
 
 parser = argparse.ArgumentParser(description='Run a single pelita game',
                                  add_help=False,
@@ -351,7 +334,7 @@ def run_game():
         if not args.team_specs:
             raise ValueError("No teams specified.")
         for team_spec in args.team_specs:
-            team_name = check_team(prepare_team(team_spec))
+            team_name = libpelita.check_team(libpelita.prepare_team(team_spec))
             print("NAME:", team_name)
         sys.exit(0)
 
@@ -365,9 +348,6 @@ def run_game():
         replayfile = args.replay or 'pelita.dump'
     except AttributeError:
         replayfile = None
-
-    external_players = []
-    external_viewers = []
 
     if replayfile:
         replay_publisher = ReplayPublisher(args.publish_to, replayfile)
@@ -391,11 +371,6 @@ def run_game():
         if len(team_specs) > num_teams:
             raise RuntimeError("Too many teams given. Must be < {}.".format(num_teams))
 
-        teams = [prepare_team(team_spec) for team_spec in team_specs]
-
-
-        print(teams)
-
         if args.dry_run:
             sys.exit(0)
 
@@ -405,82 +380,39 @@ def run_game():
         else:
             initial_delay = 0.0
 
-        server = pelita.simplesetup.SimpleServer(layout_string=layout_string,
-                                                 rounds=args.rounds,
-                                                 bind_addrs=[team.address for team in teams],
-                                                 initial_delay=initial_delay,
-                                                 max_timeouts=args.max_timeouts,
-                                                 timeout_length=args.timeout_length,
-                                                 layout_name=layout_name,
-                                                 seed=args.seed)
+        game_config = {
+            "rounds": args.rounds,
+            "initial_delay": initial_delay,
+            "max_timeouts": args.max_timeouts,
+            "timeout_length": args.timeout_length,
+            "layout_name": layout_name,
+            "layout_string": layout_string,
+            "seed": args.seed,
+        }
 
-        # Update our teams with the bound addresses
-        teams = [
-            team._replace(address=address)
-            for team, address in zip(teams, server.bind_addresses)
-        ]
-
-        for idx, team in enumerate(teams):
-            if team.module is None:
-                print("Waiting for external team %d to connect to %s." % (idx, team.address))
-
-        external_players = [
-            call_standalone_pelitagame(team.module, team.address)
-            for team in teams
-            if team.module
-        ]
-
-       # print([sub.returncode for sub in subs])
-        #[s.wait() for s in subs]
-
-        # register the viewers
-        if args.publish_to:
-            publisher = pelita.simplesetup.SimplePublisher(args.publish_to)
-            config["publish-addr"] = publisher.socket_addr
-            print("Publishing to %s" % publisher.socket_addr)
-            server.game_master.register_viewer(publisher)
-
+        viewers = []
         if dump:
-            server.game_master.register_viewer(pelita.viewer.DumpingViewer(open(dump, "w")))
+            viewers.append(pelita.viewer.DumpingViewer(open(dump, "w")))
         if args.viewer == 'ascii':
-            server.game_master.register_viewer(pelita.viewer.AsciiViewer())
+            viewers.append(pelita.viewer.AsciiViewer())
         if args.viewer == 'progress':
-            server.game_master.register_viewer(pelita.viewer.ProgressViewer())
+            viewers.append(pelita.viewer.ProgressViewer())
         if args.viewer == 'null':
             pass
 
         # Adding the result printer to the viewers.
-        server.game_master.register_viewer(ResultPrinter(args.parseable_output))
+        viewers.append(ResultPrinter(args.parseable_output))
 
-        if args.viewer == 'tk' or args.external_controller:
-            controller = pelita.simplesetup.SimpleController(server.game_master, args.controller)
-            print("Controller listening on %s" % controller.socket_addr)
-            config["controller-addr"] = controller.socket_addr
-            def runner():
-                controller.run()
-                server.exit_teams()
+        if args.viewer.startswith('tk'):
+            geometry = args.geometry
+            delay = int(1000./args.fps)
+            with libpelita.tk_viewer(geometry=geometry, delay=delay) as external_viewer:
+                controller = external_viewer["controller"]
+                publisher = external_viewer["publisher"]
+                game_config["publisher"] = publisher
+                libpelita.run_game(team_specs=team_specs, game_config=game_config, viewers=viewers, controller=controller)
         else:
-            def runner():
-                server.run()
-
-    if args.viewer.startswith('tk'):
-        # Something on OS X prevents Tk from running in a forked process.
-        # Therefore we cannot use multiprocessing here. subprocess works, though.
-        delay = int(1000./args.fps)
-        if args.viewer == 'tk':
-            sync_address_tk = config["controller-addr"].replace('*', 'localhost')
-        else:
-            sync_address_tk = None
-
-        subscribe_sock = config["publish-addr"].replace('*', 'localhost')
-        tkprocess = run_external_viewer(subscribe_sock, sync_address_tk, args.geometry, delay)
-        external_viewers.append(tkprocess)
-
-        if not sync_address_tk:
-            time.sleep(0.5)
-
-    with autoclose_externals(external_viewers, external_players):
-        runner()
+            libpelita.run_game(team_specs=team_specs, game_config=game_config, viewers=viewers)
 
 
 if __name__ == '__main__':

--- a/pelitagame
+++ b/pelitagame
@@ -195,7 +195,7 @@ publisher_opt.add_argument('--publish', type=str, metavar='URL',
                            dest='publish_to', help='publish to this zmq socket')
 publisher_opt.add_argument('--no-publish', const=False, action='store_const',
                            dest='publish_to', help='do not publish')
-parser.set_defaults(publish_to="tcp://*:*")
+parser.set_defaults(publish_to="tcp://127.0.0.1:*")
 
 controller_opt = parser.add_argument_group("Controller")
 controller_opt.add_argument('--controller', type=str, metavar='URL', default="tcp://127.0.0.1:*",
@@ -406,7 +406,7 @@ def run_game():
         if args.viewer.startswith('tk'):
             geometry = args.geometry
             delay = int(1000./args.fps)
-            with libpelita.tk_viewer(geometry=geometry, delay=delay) as external_viewer:
+            with libpelita.tk_viewer(publish_to=args.publish_to, geometry=geometry, delay=delay) as external_viewer:
                 controller = external_viewer["controller"]
                 publisher = external_viewer["publisher"]
                 game_config["publisher"] = publisher

--- a/tournament/komode.py
+++ b/tournament/komode.py
@@ -55,7 +55,7 @@ class Match(namedtuple("Match", ["t1", "t2"]), MatrixElem):
 
     def to_s(self, size=None):
         prefix = "├─"
-        name = self.winner if self.winner else "unknown"
+        name = self.winner if self.winner else "???"
         return self.box(name, prefix=prefix, padLeft=" ", padRight=" ", size=size)
 
 class FinalMatch(namedtuple("FinalMatch", ["t1", "t2"]), MatrixElem):
@@ -65,7 +65,7 @@ class FinalMatch(namedtuple("FinalMatch", ["t1", "t2"]), MatrixElem):
         prefix = "├──┨"
         postfix = "┃"
         fillElem = " "
-        name = self.winner if self.winner else "unknown"
+        name = self.winner if self.winner else "???"
         return self.box(name, prefix=prefix, postfix=postfix, padLeft=" ", padRight=" ", fillElem=fillElem, size=size)
 
 class Element(namedtuple("Element", ["char"]), MatrixElem):

--- a/tournament/komode.py
+++ b/tournament/komode.py
@@ -94,10 +94,11 @@ class BorderBottom(namedtuple("BorderBottom", ["team", "tight"]), MatrixElem):
         fillElem = "━"
         return self.box("", prefix=prefix, postfix=postfix, padLeft=padLeft, padRight=padRight, fillElem=fillElem, size=size)
 
-def knockout_matrix(*teams):
+def knockout_matrix(tree):
     """
     For now teams is a list (cols) of list (rows) of teams
     """
+    teams = tree_enumerate(tree)
 
     initial_teams = teams[0]
     N = len(initial_teams)
@@ -136,8 +137,8 @@ def knockout_matrix(*teams):
 
     return matrix, last_match
 
-def print_knockout(*teams, bonusmatch=False):
-    matrix, final_match = knockout_matrix(*teams)
+def print_knockout(tree):
+    matrix, final_match = knockout_matrix(tree)
 
     winner_row = final_match[0]
     winning_team = matrix[final_match].winner
@@ -188,10 +189,6 @@ def prepare_matches(teams, bonusmatch=False):
     else:
         final_match = makepairs([Team(t) for t in teams])
     return final_match
-
-def print_tree(tree):
-    return print_knockout(*tree_enumerate(tree))
-
 
 def is_balanced(tree):
     if isinstance(tree, Match):

--- a/tournament/komode.py
+++ b/tournament/komode.py
@@ -1,0 +1,267 @@
+#!/usr/bin/python3
+# -*- coding:utf-8 -*-
+
+import itertools
+import math
+import queue
+from collections import defaultdict, namedtuple
+
+import numpy as np
+
+def sort_ranks(teams):
+    l = len(teams)
+    if l % 2 != 0:
+        bonus = [teams[-1]]
+    else:
+        bonus = []
+    good_teams = teams[:l//2]
+    bad_teams = reversed(teams[l//2:2*(l//2)])
+    return [team for pair in zip(good_teams, bad_teams) for team in pair] + bonus
+
+
+class MatrixElem:
+    def size(self):
+        return len(self.to_s())
+
+    def show(self, team, *, prefix=None, postfix=None, size=None, padLeft="", padRight="", fillElem="─"):
+        if prefix is None:
+            prefix = ""
+        if postfix is None:
+            postfix = ""
+
+        if size is None:
+            size = 0
+        else:
+            size = size - len(prefix) - len(postfix)
+        padded = "{padLeft}{team}{padRight}".format(team=team, padLeft=padLeft, padRight=padRight)
+        return "{prefix}{team:{fillElem}<{size}}{postfix}".format(team=padded, prefix=prefix, postfix=postfix, size=size, fillElem=fillElem)
+
+class Team(namedtuple("Team", ["name"]), MatrixElem):
+    def to_s(self, size=None):
+        return self.show(self.name, size=size, prefix="", padLeft=" ", padRight=" ")
+
+class Bye(namedtuple("Bye", ["team"]), MatrixElem):
+    def to_s(self, size=None):
+        prefix = "──"
+        # return show_team("…", prefix=prefix, padLeft=" ", padRight=" ", size=size)
+        return self.show("", size=size)
+
+class Match(namedtuple("Match", ["t1", "t2"]), MatrixElem):
+    def __init__(self, *args, **kwargs):
+        self.winner = None
+
+    def __repr__(self):
+        return "Match(t1={}, t2={}, winner={})".format(self.t1, self.t2, self.winner)
+
+    def to_s(self, size=None):
+        prefix = "├─"
+        name = self.winner if self.winner else "unknown"
+        return self.show(name, prefix=prefix, padLeft=" ", padRight=" ", size=size)
+
+class FinalMatch(namedtuple("FinalMatch", ["t1", "t2"]), MatrixElem):
+    def __init__(self, *args, **kwargs):
+        self.winner = None
+    def to_s(self, size=None):
+        prefix = "├──┨"
+        postfix = "┃"
+        fillElem = " "
+        name = self.winner if self.winner else "unknown"
+        return self.show(name, prefix=prefix, postfix=postfix, padLeft=" ", padRight=" ", fillElem=fillElem, size=size)
+
+class Element(namedtuple("Element", ["char"]), MatrixElem):
+    def to_s(self, size=None):
+        return self.show(self.char, size=size, fillElem=" ")
+
+class Empty(namedtuple("Empty", []), MatrixElem):
+    def to_s(self, size=None):
+        return self.show(" ", size=size, fillElem=" ")
+
+class BorderTop(namedtuple("BorderTop", ["team", "tight"]), MatrixElem):
+    def to_s(self, size=None):
+        prefix = "│  " if not self.tight else "┐  "
+        padRight = ""
+        padLeft = "┏"
+        postfix = "┓"
+        fillElem = "━"
+        return self.show("", prefix=prefix, postfix=postfix, padLeft=padLeft, padRight=padRight, fillElem=fillElem, size=size)
+
+class BorderBottom(namedtuple("BorderBottom", ["team", "tight"]), MatrixElem):
+    def to_s(self, size=None):
+        prefix = "│  " if not self.tight else "┘  "
+        padRight = ""
+        padLeft = "┗"
+        postfix = "┛"
+        fillElem = "━"
+        return self.show("", prefix=prefix, postfix=postfix, padLeft=padLeft, padRight=padRight, fillElem=fillElem, size=size)
+
+def knockout_matrix(*teams):
+    """
+    For now teams is a list (cols) of list (rows) of teams
+    """
+
+    initial_teams = teams[0]
+    N = len(initial_teams)
+    height = N * 2 - 1
+    width = math.ceil(math.log(N, 2)) + 1
+    matrix = np.empty([height, width], dtype=np.object_)
+
+    matrix.fill(Empty())
+
+    matrix[::2, 0] = [Team(t) for t in initial_teams]
+
+    for col in range(1, width):
+        start = None
+        end = None
+        last_match = None
+        rowIdx = 0
+        for row in range(height):
+            left_elem = matrix[row, col - 1]
+            if isinstance(left_elem, Team) or isinstance(left_elem, Match) or isinstance(left_elem, Bye):
+                # left of us is a team
+                if start is None:
+                    start = row
+                else:
+                    end = row
+                    middle = math.floor(start + (end - start) / 2)
+                    t1 = matrix[start, col - 1]
+                    t2 = matrix[end, col - 1]
+                    match = Match(t1=t1, t2=t2)
+                    match.winner=teams[col][rowIdx]
+                    rowIdx += 1
+                    matrix[start:end, col].fill(Element('│'))
+                    matrix[start, col] = Element('┐')
+                    matrix[end, col] = Element('┘')
+                    matrix[middle, col] = match
+                    last_match = (middle, col)
+                    start = end = None
+        else:
+            if start is not None:
+                team = matrix[start, col - 1]
+                matrix[start, col] = Bye(team=team)
+                last_match = (start, col)
+
+    # Decorate the winner column
+    isMatch = np.vectorize(lambda elem: not isinstance(elem, Empty))
+
+    return matrix, last_match
+
+def print_knockout(*teams, bonusmatch=False):
+    if bonusmatch:
+        bonus_team = teams[0][-1]
+        bonus_final = teams[-1][0]
+
+        teams = [t[:] for t in teams]
+        del teams[0][-1]
+        del teams[-1]
+        matrix, final_match = knockout_matrix(*teams)
+        winner_row = final_match[0]
+
+        enlarged_height = matrix.shape[0] + 2
+        enlarged_width = matrix.shape[1] + 1
+        enlarged_matrix = np.empty([enlarged_height, enlarged_width], dtype=np.object_)
+        enlarged_matrix.fill(Empty())
+        for row in range(matrix.shape[0]):
+            for col in range(0, matrix.shape[1]):
+                enlarged_matrix[row, col] = matrix[row, col]
+        matrix = enlarged_matrix
+
+        matrix[-1, 0] = Team(bonus_team)
+        matrix[-1, 1:-1].fill(Bye(team=matrix[-1, 0]))
+
+        col = -1
+        start = winner_row
+        end = matrix.shape[0] - 1
+        middle = math.floor(start + (end - start) / 2)
+
+        matrix[start:end, col].fill(Element('│'))
+        matrix[start, col] = Element('┐')
+        matrix[end, col] = Element('┘')
+        matrix[middle, col] = Match(".", ".")
+        matrix[middle, col].winner = teams[col][0]
+
+        final_match = (middle, col)
+    else:
+        matrix, final_match = knockout_matrix(*teams)
+
+    winner_row = final_match[0]
+    winner = matrix[final_match] = FinalMatch(* matrix[final_match])
+
+    def is_tight(elem):
+        return not isinstance(elem, Empty) and not isinstance(elem, Element)
+
+    matrix[winner_row - 1, -1] = BorderTop(winner, is_tight(matrix[winner_row - 1, -2]))
+    matrix[winner_row + 1, -1] = BorderBottom(winner, is_tight(matrix[winner_row + 1, -2]))
+
+    colwidths = np.amax(np.vectorize(lambda self: self.size())(matrix), axis=0)
+
+    for row in range(matrix.shape[0]):
+        for col in range(0, matrix.shape[1]):
+            try:
+                print(matrix[row, col].to_s(colwidths[col]), end="")
+            except AttributeError:
+                print("Here:", end="")
+                print(row, col, matrix[row, col])
+                raise
+        print()
+
+def makepairs(matches):
+    if len(matches) == 0:
+        raise ValueError("Cannot prepare matches (no teams given).")
+    while not len(matches) == 1:
+        m = []
+        pairs = itertools.zip_longest(matches[::2], matches[1::2])
+        for p1, p2 in pairs:
+            if p2 is not None:
+                m.append(Match(p1, p2)) #  winner=None))
+            else:
+                m.append(Bye(p1))
+        matches = m
+    return matches[0]
+
+def prepare_matches(teams, bonusmatch=False):
+    final_match = makepairs([Team(t) for t in teams])
+    return final_match
+
+def print_tree(tree, bonusmatch=False):
+    return print_knockout(*tree_enumerate(tree), bonusmatch=bonusmatch)
+
+
+def is_balanced(tree):
+    if isinstance(tree, Match):
+        return is_balanced(tree.t1) and is_balanced(tree.t2) and tree_depth(tree.t1) == tree_depth(tree.t2)
+    if isinstance(tree, Bye):
+        return True
+    if isinstance(tree, Team):
+        return True
+
+def tree_depth(tree):
+    if isinstance(tree, Match):
+        return 1 + max(tree_depth(tree.t1), tree_depth(tree.t2))
+    if isinstance(tree, Bye):
+        return 1 + tree_depth(tree.team)
+    if isinstance(tree, Team):
+        return 1
+
+def tree_enumerate(tree):
+    enumerated = defaultdict(list)
+
+    nodes = queue.Queue()
+    nodes.put((tree, 0))
+    while not nodes.empty():
+        node, generation = nodes.get()
+        if isinstance(node, Match):
+            nodes.put((node.t1, generation + 1))
+            nodes.put((node.t2, generation + 1))
+        if isinstance(node, Bye):
+            nodes.put((node.team, generation + 1))
+        if isinstance(node, Team):
+            pass
+        enumerated[generation].append(node)
+
+    generations = []
+    for idx in sorted(enumerated.keys()):
+        generations.append(enumerated[idx])
+    generations.reverse()
+    return generations
+
+

--- a/tournament/komode.py
+++ b/tournament/komode.py
@@ -184,7 +184,9 @@ def print_knockout(*teams, bonusmatch=False):
         matrix, final_match = knockout_matrix(*teams)
 
     winner_row = final_match[0]
+    winning_team = matrix[final_match].winner
     winner = matrix[final_match] = FinalMatch(* matrix[final_match])
+    winner.winner = winning_team
 
     def is_tight(elem):
         return not isinstance(elem, Empty) and not isinstance(elem, Element)
@@ -223,7 +225,22 @@ def prepare_matches(teams, bonusmatch=False):
     return final_match
 
 def print_tree(tree, bonusmatch=False):
-    return print_knockout(*tree_enumerate(tree), bonusmatch=bonusmatch)
+    enumerated = tree_enumerate(tree)
+    def show(elem):
+        if isinstance(elem, Match):
+            if elem.winner is not None:
+                return elem.winner
+            else:
+                return "???"
+        if isinstance(elem, Team):
+            return elem.name
+        if isinstance(elem, Bye):
+            return show(elem.team)
+    enumerated = [
+        [show(elem) for elem in elems] for elems in enumerated
+    ]
+
+    return print_knockout(*enumerated, bonusmatch=bonusmatch)
 
 
 def is_balanced(tree):

--- a/tournament/komode.py
+++ b/tournament/komode.py
@@ -23,7 +23,7 @@ class MatrixElem:
     def size(self):
         return len(self.to_s())
 
-    def show(self, team, *, prefix=None, postfix=None, size=None, padLeft="", padRight="", fillElem="─"):
+    def box(self, team, *, prefix=None, postfix=None, size=None, padLeft="", padRight="", fillElem="─"):
         if prefix is None:
             prefix = ""
         if postfix is None:
@@ -38,13 +38,13 @@ class MatrixElem:
 
 class Team(namedtuple("Team", ["name"]), MatrixElem):
     def to_s(self, size=None):
-        return self.show(self.name, size=size, prefix="", padLeft=" ", padRight=" ")
+        return self.box(self.name, size=size, prefix="", padLeft=" ", padRight=" ")
 
 class Bye(namedtuple("Bye", ["team"]), MatrixElem):
     def to_s(self, size=None):
         prefix = "──"
         # return show_team("…", prefix=prefix, padLeft=" ", padRight=" ", size=size)
-        return self.show("", size=size)
+        return self.box("", size=size)
 
 class Match(namedtuple("Match", ["t1", "t2"]), MatrixElem):
     def __init__(self, *args, **kwargs):
@@ -56,7 +56,7 @@ class Match(namedtuple("Match", ["t1", "t2"]), MatrixElem):
     def to_s(self, size=None):
         prefix = "├─"
         name = self.winner if self.winner else "unknown"
-        return self.show(name, prefix=prefix, padLeft=" ", padRight=" ", size=size)
+        return self.box(name, prefix=prefix, padLeft=" ", padRight=" ", size=size)
 
 class FinalMatch(namedtuple("FinalMatch", ["t1", "t2"]), MatrixElem):
     def __init__(self, *args, **kwargs):
@@ -66,15 +66,15 @@ class FinalMatch(namedtuple("FinalMatch", ["t1", "t2"]), MatrixElem):
         postfix = "┃"
         fillElem = " "
         name = self.winner if self.winner else "unknown"
-        return self.show(name, prefix=prefix, postfix=postfix, padLeft=" ", padRight=" ", fillElem=fillElem, size=size)
+        return self.box(name, prefix=prefix, postfix=postfix, padLeft=" ", padRight=" ", fillElem=fillElem, size=size)
 
 class Element(namedtuple("Element", ["char"]), MatrixElem):
     def to_s(self, size=None):
-        return self.show(self.char, size=size, fillElem=" ")
+        return self.box(self.char, size=size, fillElem=" ")
 
 class Empty(namedtuple("Empty", []), MatrixElem):
     def to_s(self, size=None):
-        return self.show(" ", size=size, fillElem=" ")
+        return self.box(" ", size=size, fillElem=" ")
 
 class BorderTop(namedtuple("BorderTop", ["team", "tight"]), MatrixElem):
     def to_s(self, size=None):
@@ -83,7 +83,7 @@ class BorderTop(namedtuple("BorderTop", ["team", "tight"]), MatrixElem):
         padLeft = "┏"
         postfix = "┓"
         fillElem = "━"
-        return self.show("", prefix=prefix, postfix=postfix, padLeft=padLeft, padRight=padRight, fillElem=fillElem, size=size)
+        return self.box("", prefix=prefix, postfix=postfix, padLeft=padLeft, padRight=padRight, fillElem=fillElem, size=size)
 
 class BorderBottom(namedtuple("BorderBottom", ["team", "tight"]), MatrixElem):
     def to_s(self, size=None):
@@ -92,7 +92,7 @@ class BorderBottom(namedtuple("BorderBottom", ["team", "tight"]), MatrixElem):
         padLeft = "┗"
         postfix = "┛"
         fillElem = "━"
-        return self.show("", prefix=prefix, postfix=postfix, padLeft=padLeft, padRight=padRight, fillElem=fillElem, size=size)
+        return self.box("", prefix=prefix, postfix=postfix, padLeft=padLeft, padRight=padRight, fillElem=fillElem, size=size)
 
 def knockout_matrix(*teams):
     """

--- a/tournament/roundrobin.py
+++ b/tournament/roundrobin.py
@@ -1,0 +1,20 @@
+#!/usr/bin/python3
+# -*- coding:utf-8 -*-
+
+import itertools
+import random
+
+def initial_state(teams):
+    rr = []
+    for pair in itertools.combinations(teams, 2):
+        match = list(pair)
+        random.shuffle(match)
+        rr.append(match)
+    # shuffle the matches for more fun
+    random.shuffle(rr)
+    return rr
+
+# def round_robin(state, teams):
+#    if not state:
+#        state = initial_state
+

--- a/tournament/test_tournament.py
+++ b/tournament/test_tournament.py
@@ -1,0 +1,26 @@
+#!/usr/bin/python3
+# -*- coding:utf-8 -*-
+
+import unittest
+
+import komode
+
+class TestKoMode(unittest.TestCase):
+    def test_sort_ranks(self):
+        sort_ranks = komode.sort_ranks
+        self.assertListEqual(sort_ranks(range(7)), [0, 5, 1, 4, 2, 3, 6])
+        self.assertListEqual(sort_ranks(range(4)), [0, 3, 1, 2])
+        self.assertListEqual(sort_ranks(range(2)), [0, 1])
+        self.assertListEqual(sort_ranks(range(1)), [0])
+        self.assertListEqual(sort_ranks([]), [])
+
+    def test_prepared_matches(self):
+        print(komode.prepare_matches([1]))
+        print()
+        print(komode.prepare_matches([1,2]))
+        print()
+        print(komode.prepare_matches([1,2,3]))
+        print()
+        print(komode.prepare_matches([1,2,3,4,5,6]))
+        print()
+        print(komode.prepare_matches([1,2,3,4,5]))

--- a/tournament/tournament.py
+++ b/tournament/tournament.py
@@ -311,7 +311,7 @@ def recur_matches(do_deathmatch, match):
         match.winner = winner
         return winner
     elif isinstance(match, komode.Bye):
-        return match.team.name
+        return recur_matches(do_deathmatch, match.team)
     elif isinstance(match, komode.Team):
         return match.name
     return None

--- a/tournament/tournament.py
+++ b/tournament/tournament.py
@@ -266,42 +266,6 @@ def round1(config, rr_unplayed, rr_played):
     return [team_id for team_id, p in round1_ranking(config, rr_played)]
 
 
-def pp_round2_results(teams, w1, w2, w3, w4):
-    """Pretty print the results for the K.O. round.
-
-    teams is the list [group0, group1, ...] not the names of the agens, sorted
-    by the result of the first round.
-    """
-    names = dict(RNAMES)
-    names['???'] = '???'
-    feed = max(len(item) for item in list(RNAMES.values()))+2
-    lengths={}
-    for name in names:
-        lengths[name] = feed - len(names[name])
-
-    semifinal_top_up = names[teams[0]]+' '+"─"*lengths[teams[0]]+'┐'
-    final_top = " "*feed+' ├─ '+names[w1]+' '+'─'*lengths[w1]+'┐'
-    semifinal_top_down = names[teams[3]]+' '+"─"*lengths[teams[3]]+'┘'
-    preliminary_winner = (" "*(2*feed+5)+'├─ '+names[w3]+' '+
-                          '─'*lengths[w3]+'┐ ')
-    semifinal_bottom_up = names[teams[1]]+' '+"─"*lengths[teams[1]]+'┐'
-    final_bottom = " "*feed+' ├─ '+names[w2]+' '+'─'*lengths[w2]+'┘'
-    semifinal_bottom_down = names[teams[2]]+' '+"─"*lengths[teams[2]]+'┘'
-    looser = names[teams[4]]+' '+"─"*lengths[teams[4]]+'─'*(2*feed+8)+'┘'
-    winner = " "*(3*feed+9)+'├─ '+names[w4]
-    print()
-    print(semifinal_top_up, speak=False)
-    print(final_top, speak=False)
-    print(semifinal_top_down+' '*(feed+3)+'│', speak=False)
-    print(preliminary_winner, speak=False)
-    print(semifinal_bottom_up+' '*(feed+3)+'│'+' '*(feed+3)+'│', speak=False)
-    print(final_bottom+' '*(feed+3)+'└ '+names[w4], speak=False)
-    print(semifinal_bottom_down+' '*(feed+3)+' '+' '*(feed+3)+
-          '┌ '+'═'*len(names[w4]), speak=False)
-    print(" "*(3*feed+9)+'│')
-    print(looser, speak=False)
-    print()
-
 def recur_matches(do_deathmatch, match):
     if isinstance(match, komode.Match) and match.winner is None:
         t1 = recur_matches(do_deathmatch, match[0])

--- a/tournament/tournament.py
+++ b/tournament/tournament.py
@@ -325,8 +325,7 @@ def round2(config, teams):
     wait_for_keypress()
 
 
-    last_match = komode.prepare_matches(teams)
-    komode.print_knockout(*komode.tree_enumerate(last_match), bonusmatch=config.bonusmatch)
+    last_match = komode.prepare_matches(teams, bonusmatch=config.bonusmatch)
 
     def do_deathmatch(config):
         def inner(t1, t2):

--- a/tournament/tournament.py
+++ b/tournament/tournament.py
@@ -298,7 +298,6 @@ def pp_round2_results(teams, w1, w2, w3, w4):
     print()
 
 def recur_matches(do_deathmatch, match):
-    print("Trying match", match)
     if isinstance(match, komode.Match) and match.winner is None:
         t1 = recur_matches(do_deathmatch, match[0])
         t2 = recur_matches(do_deathmatch, match[1])
@@ -329,8 +328,6 @@ def round2(config, teams):
     last_match = komode.prepare_matches(teams)
     komode.print_knockout(*komode.tree_enumerate(last_match), bonusmatch=config.bonusmatch)
 
-    print(type(last_match))
-
     def do_deathmatch(config):
         def inner(t1, t2):
             komode.print_tree(last_match)
@@ -339,6 +336,8 @@ def round2(config, teams):
         return inner
 
     recur_matches(do_deathmatch(config), last_match)
+
+    komode.print_tree(last_match)
 
     wait_for_keypress()
 

--- a/tournament/tournament.py
+++ b/tournament/tournament.py
@@ -259,9 +259,14 @@ def round1_ranking(config, rr_played):
     team_points = [(team_id, points[team_id]) for team_id in config.team_ids]
     return sorted(team_points, key=lambda elem: elem[1], reverse=True)
 
-def pp_round1_results(config, rr_played):
+def pp_round1_results(config, rr_played, rr_unplayed):
     """Pretty print the current result of the matches."""
-    print('Current Ranking:')
+    n_played = len(rr_played)
+    es = "es" if n_played != 1 else ""
+    n_togo = len(rr_unplayed)
+
+    print()
+    print('Ranking after {n_played} match{es} ({n_togo} to go):'.format(n_played=n_played, es=es, n_togo=n_togo))
     for team_id, p in round1_ranking(config, rr_played):
         print("  %25s %d" % (config.team_name(team_id), p))
     print()
@@ -291,7 +296,7 @@ def round1(config, state):
         else:
             rr_played.append({ "match": match, "winner": match[winner-1] })
 
-        pp_round1_results(config, rr_played)
+        pp_round1_results(config, rr_played, rr_unplayed)
 
         state.save(ARGS.state)
 

--- a/tournament/tournament.py
+++ b/tournament/tournament.py
@@ -290,7 +290,6 @@ def round2(config, teams):
     print()
     wait_for_keypress()
 
-
     last_match = komode.prepare_matches(teams, bonusmatch=config.bonusmatch)
     tournament = komode.tree_enumerate(last_match)
 

--- a/tournament/tournament.py
+++ b/tournament/tournament.py
@@ -74,7 +74,19 @@ class Config:
         return self.teams[team]["spec"]
 
 class State:
-    pass
+    def __init__(self):
+        self.round1 = {
+            "played": [],
+            "unplayed": roundrobin.initial_state(config.team_ids)
+        }
+        self.round2 = {}
+
+    def save(self, filename):
+        pass
+
+    @staticmethod
+    def load(self, filename):
+        pass
 
 def _print(*args, **kwargs):
     builtins.print(*args, **kwargs)
@@ -136,7 +148,6 @@ def present_teams(config):
 
 def set_name(team):
     """Get name of team."""
-
     try:
         team = libpelita.prepare_team(team)
         return libpelita.check_team(team)
@@ -376,16 +387,6 @@ if __name__ == '__main__':
     random.seed(config.seed)
 
     present_teams(config)
-
-    state = {
-        "round1": {
-            "played": [],
-            "unplayed": roundrobin.initial_state(config.team_ids)
-        },
-        "round2": {
-
-        }
-    }
 
     rr_ranking = round1(config, state["round1"]["unplayed"], state["round1"]["played"])
     if config.bonusmatch:

--- a/tournament/tournament.py
+++ b/tournament/tournament.py
@@ -298,14 +298,14 @@ def round2(config, teams):
 
     def do_deathmatch(config):
         def inner(t1, t2):
-            komode.print_tree(last_match)
+            komode.print_knockout(last_match)
             winner = start_deathmatch(config, t1, t2)
             return winner
         return inner
 
     recur_matches(do_deathmatch(config), last_match)
 
-    komode.print_tree(last_match)
+    komode.print_knockout(last_match)
 
     wait_for_keypress()
 

--- a/tournament/tournament.py
+++ b/tournament/tournament.py
@@ -2,6 +2,7 @@
 # -*- coding:utf-8 -*-
 
 import argparse
+import builtins
 import io
 import itertools
 import json
@@ -44,10 +45,10 @@ SPEAK = False
 LOGFILE = None
 
 def _print(*args, **kwargs):
-    __builtins__.print(*args, **kwargs)
+    builtins.print(*args, **kwargs)
     if LOGFILE:
         kwargs['file'] = LOGFILE
-        __builtins__.print(*args, **kwargs)
+        builtins.print(*args, **kwargs)
 
 def print(*args, **kwargs):
     """Speak while you print. To disable set speak=False.

--- a/tournament/tournament.py
+++ b/tournament/tournament.py
@@ -322,6 +322,8 @@ if __name__ == '__main__':
                         metavar="TEAMFILE.json", default="teams.json")
     parser.add_argument('--interactive', help='ask before proceeding',
                         action='store_true')
+    parser.add_argument('--no-log', help='do not store the log data',
+                        action='store_true')
 
     parser.epilog = """
 TEAMFILE.json must be of the form:
@@ -351,13 +353,14 @@ TEAMFILE.json must be of the form:
     # Check speaking support
     SPEAK = ARGS.speak and os.path.exists(FLITE)
 
-    # create a directory for the dumps
-    DUMPSTORE = create_directory('./dumpstore')
+    if not ARGS.no_log:
+        # create a directory for the dumps
+        DUMPSTORE = create_directory('./dumpstore')
 
-    # open the log file (fail if it exists)
-    logfile = os.path.join(DUMPSTORE, 'log')
-    fd = os.open(logfile, os.O_CREAT|os.O_EXCL|os.O_WRONLY, 0o0666)
-    LOGFILE = os.fdopen(fd, 'w')
+        # open the log file (fail if it exists)
+        logfile = os.path.join(DUMPSTORE, 'log')
+        fd = os.open(logfile, os.O_CREAT|os.O_EXCL|os.O_WRONLY, 0o0666)
+        LOGFILE = os.fdopen(fd, 'w')
 
     teams = list(RNAMES.keys())
 

--- a/tournament/tournament.py
+++ b/tournament/tournament.py
@@ -297,12 +297,12 @@ def round2(config, teams):
     for round in tournament:
         for match in round:
             if isinstance(match, komode.Match):
-                komode.print_knockout(last_match)
+                komode.print_knockout(last_match, config.team_name)
                 match.winner = start_deathmatch(config,
                                                 recur_match_winner(match.t1),
                                                 recur_match_winner(match.t2))
 
-    komode.print_knockout(last_match)
+    komode.print_knockout(last_match, config.team_name)
 
     wait_for_keypress()
 

--- a/tournament/tournament.py
+++ b/tournament/tournament.py
@@ -161,6 +161,11 @@ def start_match(config, team1, team2):
         dumpfile = os.path.join(DUMPSTORE, time.strftime('%Y%m%d-%H%M%S'))
         cmd += ['--dump', dumpfile]
 
+    if ARGS.dry_run:
+        print("Would run: {cmd}".format(cmd=cmd))
+        print("Choosing winner at random.")
+        return random.choice([0, 1, 2])
+
     stdout, stderr = Popen(cmd, stdout=PIPE, stderr=PIPE,
                            universal_newlines=True).communicate()
     tmp = reversed(stdout.splitlines())

--- a/tournament/tournament.py
+++ b/tournament/tournament.py
@@ -432,7 +432,7 @@ if __name__ == '__main__':
 
     winner = round2(config, sorted_ranking)
 
-    print('The winner of the %s Pelita tournament is...' % config.location, wait=2)
-    print('{team_name}. Congratulations'.format(config.team_name(winner)), wait=2)
+    print('The winner of the %s Pelita tournament is...' % config.location, wait=2, end=" ")
+    print('{team_name}. Congratulations'.format(team_name=config.team_name(winner)), wait=2)
     print('Good evening master. It was a pleasure to serve you.')
 

--- a/tournament/tournament.yaml
+++ b/tournament/tournament.yaml
@@ -1,0 +1,28 @@
+---
+location: Munich
+date: 2015
+team_prefix: group
+seed: null
+bonusmatch: True
+teams:
+  - spec: StoppingPlayer
+    members:
+      - "Stopper"
+  - spec: SpeakingPlayer
+    members:
+      - "Speaker"
+  - spec: FoodEatingPlayer
+    members:
+      - "Food Eater"
+  - spec: RandomExplorerPlayer
+    members:
+      - "Random Explorer"
+  - spec: RandomPlayer
+    members:
+      - "Random Player"
+  - spec: NQRandomPlayer
+    members:
+      - "Not quite Random Player"
+  - spec: SmartRandomPlayer
+    members:
+      - "Smarter Random Player"


### PR DESCRIPTION
New, more flexible tournament mode. To be rebased when #304 is merged.

Configuration is done in a yaml file.

    location: Munich
    date: 2015
    team_prefix: group
    seed: 42
    bonusmatch: True
    teams:
      - spec: FoodEatingPlayer
        members:
          - "Player One"
          - "Player Two"
      - spec: StoppingPlayer
        members:
          - "b"
      - spec: random
        members:
          - noone

`spec` is the same module specifier that the pelitagame command line uses. So, things like `py3@/home/user/pelita_player:dumb_factory` are also possible. The name of the team will be queried during initialisation of the tournament (which also serves as a short sanity check).

Still TODO:
  - [x] Demo mode
  - [ ] More tests
  - [ ] Test integration
  - [x] KO mode handling (bonus matches)
  - [ ] Automatic state savings in case of crashes.