### PR TITLE
NF: Allow for wildcard teams

### DIFF
--- a/contrib/ci.cfg
+++ b/contrib/ci.cfg
@@ -16,10 +16,5 @@ db_file = ci_engine.sqlite
 # This section contains the names and paths of the agents to test. Add as many
 # as you want.
 
-basti = ../../players/basti
-pietro = ../../players/pietro_2013
-bartosz = ../../players/bartosz
-rike = ../../players/rike
-emanuele = ../../players/emanuele
-niko = ../../players/niko
-nicola = ../../players/nicola 
+* = players/*
+

--- a/contrib/ci_engine.py
+++ b/contrib/ci_engine.py
@@ -80,7 +80,14 @@ class CI_Engine(object):
         config = configparser.ConfigParser()
         config.read(os.path.abspath(cfgfile))
         for name, path in  config.items('agents'):
-            if os.path.isdir(path):
+            if name == '*':
+                import glob
+                paths = glob.glob(path)
+                for p in paths:
+                    self.players.append({'name': os.path.basename(p),
+                                         'path': p
+                    })
+            elif os.path.isdir(path):
                 self.players.append({'name' : name,
                                      'path' : path
                                      })


### PR DESCRIPTION
We can now specify

    * = players/*

in the config and have all teams (which may be symlinks)
in the players folder automatically imported.