### PR TITLE
FIX: Changed A-star algorithm so that the history is taken into account

### DIFF
--- a/pelita/graph.py
+++ b/pelita/graph.py
@@ -276,7 +276,7 @@ class AdjacencyList(dict):
             else:
                 seen.append(current)
                 for pos in self[current]:
-                    heapq.heappush(to_visit, (manhattan_dist(target, pos), (pos)))
+                    heapq.heappush(to_visit, (man_dist + manhattan_dist(target, pos), (pos)))
 
         if not found:
             raise NoPathException("BFS: No path from %r to %r."


### PR DESCRIPTION
Hi!

I found a little bug in the A* algorithm, where it didn't take the path already travelled into account. This caused it to have some weird behaviour when starting in the upper right corner with walls in the way (see pull request for new test). 

Dori