### PR TITLE
Fix CI engine and move call_pelitagame to libpelita

### DIFF
--- a/contrib/ci_engine.py
+++ b/contrib/ci_engine.py
@@ -51,9 +51,10 @@ import logging
 import os
 import random
 import sqlite3
-import subprocess
 import sys
 import unittest
+
+from pelita import libpelita
 
 
 parser = argparse.ArgumentParser()
@@ -129,89 +130,27 @@ class CI_Engine:
             the indices of the players
 
         """
-        import zmq
-
-        ctx = zmq.Context()
-        reply_addr = "ipc://tournament-reply#{pid}".format(pid=os.getpid())
-        reply_sock = ctx.socket(zmq.PAIR)
-        reply_sock.bind(reply_addr)
-
-
         left, right = [self.players[i]['path'] for i in (p1, p2)]
-        proc_args = [self.pelita_exe, left, right]
-        proc_args.extend(self.default_args)
-        proc_args.extend(['--reply-to', reply_addr])
+        args = [left, right] + self.default_args
 
-        proc = subprocess.Popen(proc_args,
-                                stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE,
-                                universal_newlines=True, env=dict(os.environ, PYTHONUNBUFFERED='x'))
-
-
-        import io, json
-        poll = zmq.Poller()
-        poll.register(reply_sock, zmq.POLLIN)
-        poll.register(proc.stdout.fileno(), zmq.POLLIN)
-        poll.register(proc.stderr.fileno(), zmq.POLLIN)
-
-        with io.StringIO() as stdout_buf, io.StringIO() as stderr_buf:
-            final_game_state = None
-
-            while True:
-                evts = dict(poll.poll(1000))
-
-                if not evts and proc.poll() is not None:
-                    # no more events and proc has finished.
-                    # we give up
-                    break
-
-                stdout_ready = (not proc.stdout.closed) and evts.get(proc.stdout.fileno(), False)
-                if stdout_ready:
-                    line = proc.stdout.readline()
-                    if line:
-                        print(line, end='', file=stdout_buf)
-                    else:
-                        poll.unregister(proc.stdout.fileno())
-                        proc.stdout.close()
-                stderr_ready = (not proc.stderr.closed) and evts.get(proc.stderr.fileno(), False)
-                if stderr_ready:
-                    line = proc.stderr.readline()
-                    if line:
-                        print(line, end='', file=stderr_buf)
-                    else:
-                        poll.unregister(proc.stderr.fileno())
-                        proc.stderr.close()
-                socket_ready = evts.get(reply_sock, False)
-                if socket_ready:
-                    try:
-                        pelita_status = json.loads(reply_sock.recv_string())
-                        game_state = pelita_status['__data__']['game_state']
-                        finished = game_state.get("finished", None)
-                        team_wins = game_state.get("team_wins", None)
-                        game_draw = game_state.get("game_draw", None)
-                        if finished:
-                            final_game_state = game_state
-                            break
-                    except json.JSONDecodeError:
-                        pass
-                    except KeyError:
-                        pass
-
-            # return (final_game_state, stdout_buf.getvalue(), stderr_buf.getvalue())
-            std_out = stdout_buf.getvalue()
-            std_err = stderr_buf.getvalue()
+        (final_game_state, stdout, stderr) = libpelita.call_pelitagame(args)
 
         try:
-            result = -1 if game_draw else team_wins
+            if final_game_state.get('game_draw', None):
+                result = -1
+            else:
+                result = final_game_state.get('team_wins', None)
+            if result is None:
+                raise ValueError("Neither game_draw nor team_wins in game_state.")
         except ValueError:
             logger.error("Couldn't parse the outcome of the game:")
-            logger.error("STDERR: \n%s" % std_err)
-            logger.error("STDOUT: \n%s" % std_out)
+            logger.error("STDERR: \n%s" % stderr)
+            logger.error("STDOUT: \n%s" % stdout)
             logger.error("Ignoring the result.")
             return
         p1_name, p2_name = self.players[p1]['name'], self.players[p2]['name']
 
-        self.dbwrapper.add_gameresult(p1_name, p2_name, result, std_out, std_err)
+        self.dbwrapper.add_gameresult(p1_name, p2_name, result, stdout, stderr)
 
 
     def start(self, n):

--- a/pelita/libpelita.py
+++ b/pelita/libpelita.py
@@ -116,10 +116,10 @@ class BinRunner(ModuleRunner):
         return subprocess.Popen(external_call)
 
 @contextlib.contextmanager
-def _call_standalone_pelitagame(module_spec, address):
+def _call_pelita_player(module_spec, address):
     proc = None
     try:
-        proc = call_standalone_pelitagame(module_spec, address)
+        proc = call_pelita_player(module_spec, address)
         yield proc
     finally:
         if proc is None:
@@ -128,7 +128,7 @@ def _call_standalone_pelitagame(module_spec, address):
             _logger.debug("Terminating proc %r", proc)
             proc.terminate()
 
-def call_standalone_pelitagame(module_spec, address):
+def call_pelita_player(module_spec, address):
     """ Starts another process with the same Python executable,
     the same start script (pelitagame) and runs `team_spec`
     as a standalone client on URL `addr`.
@@ -165,7 +165,7 @@ def check_team(team_spec):
     team_player = RemoteTeamPlayer(socket)
 
     if team_spec.module:
-        with _call_standalone_pelitagame(team_spec.module, team_spec.address):
+        with _call_pelita_player(team_spec.module, team_spec.address):
             name = team_player.team_name()
     else:
         name = team_player.team_name()
@@ -219,7 +219,7 @@ def run_game(team_specs, game_config, viewers=None, controller=None):
             print("Waiting for external team %d to connect to %s." % (idx, team.address))
 
     external_players = [
-        call_standalone_pelitagame(team.module, team.address)
+        call_pelita_player(team.module, team.address)
         for team in teams
         if team.module
     ]

--- a/tournament/test/test_tournament.py
+++ b/tournament/test/test_tournament.py
@@ -126,7 +126,7 @@ class TestRoundRobin:
 # There must be exactly one game_state with finished=True
 
 class TestSingleMatch:
-    def test_run_match(self):
+    def test_play_game_with_config(self):
         config = MagicMock()
         config.rounds = 200
         config.team_spec = lambda x: x
@@ -135,7 +135,7 @@ class TestSingleMatch:
         config.tournament_log_folder = None
 
         teams = ["StoppingPlayer", "StoppingPlayer"]
-        (state, stdout, stderr) = tournament.run_match(config, teams)
+        (state, stdout, stderr) = tournament.play_game_with_config(config, teams)
         assert state['team_wins'] == None
         assert state['game_draw'] == True
 
@@ -143,7 +143,7 @@ class TestSingleMatch:
         config.team_spec = lambda x: x
         config.viewer = 'ascii'
         teams = ["SmartEatingPlayer", "StoppingPlayer"]
-        (state, stdout, stderr) = tournament.run_match(config, teams)
+        (state, stdout, stderr) = tournament.play_game_with_config(config, teams)
         print(state)
         assert state['team_wins'] == 0
         assert state['game_draw'] == None
@@ -152,7 +152,7 @@ class TestSingleMatch:
         config.team_spec = lambda x: x
         config.viewer = 'ascii'
         teams = ["StoppingPlayer", "SmartEatingPlayer"]
-        (state, stdout, stderr) = tournament.run_match(config, teams)
+        (state, stdout, stderr) = tournament.play_game_with_config(config, teams)
         assert state['team_wins'] == 1
         assert state['game_draw'] == None
 

--- a/tournament/tournament/tournament.py
+++ b/tournament/tournament/tournament.py
@@ -3,7 +3,6 @@
 
 import builtins
 import io
-import json
 import os
 import random
 import re
@@ -14,7 +13,6 @@ import tempfile
 import time
 
 import yaml
-import zmq
 
 from pelita import libpelita
 from . import roundrobin
@@ -254,11 +252,6 @@ def set_name(team):
 def run_match(config, teams):
     team1, team2 = teams
 
-    ctx = zmq.Context()
-    reply_addr = "ipc://tournament-reply#{pid}".format(pid=os.getpid())
-    reply_sock = ctx.socket(zmq.PAIR)
-    reply_sock.bind(reply_addr)
-
     rounds = ['--rounds', str(config.rounds)] if config.rounds else []
     filter = ['--filter', config.filter] if config.filter else []
     viewer = ['--' + config.viewer] if config.viewer else []
@@ -268,77 +261,15 @@ def run_match(config, teams):
     else:
         dump = []
 
-    pelitagame = os.path.join(os.environ.get("PELITA_PATH") or os.path.dirname(sys.argv[0]), './pelitagame')
-    cmd = [libpelita.get_python_process()] + [pelitagame] + [config.team_spec(team1), config.team_spec(team2),
-                              '--reply-to', reply_addr,
-                              '--seed', str(random.randint(0, sys.maxsize)),
-                              *dump,
-                              *filter,
-                              *rounds,
-                              *viewer]
+    args = [config.team_spec(team1), config.team_spec(team2),
+            '--seed', str(random.randint(0, sys.maxsize)),
+            *dump,
+            *filter,
+            *rounds,
+            *viewer]
 
-    _logger.debug("Executing: {}".format(libpelita.shlex_unsplit(cmd)))
-
-    # We use the environment variable PYTHONUNBUFFERED here to retrieve stdout without buffering
-    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                            universal_newlines=True, env=dict(os.environ, PYTHONUNBUFFERED='x'))
-
-
-    #if ARGS.dry_run:
-    #    print("Would run: {cmd}".format(cmd=cmd))
-    #    print("Choosing winner at random.")
-    #    return random.choice([0, 1, 2])
-
-
-    poll = zmq.Poller()
-    poll.register(reply_sock, zmq.POLLIN)
-    poll.register(proc.stdout.fileno(), zmq.POLLIN)
-    poll.register(proc.stderr.fileno(), zmq.POLLIN)
-
-    with io.StringIO() as stdout_buf, io.StringIO() as stderr_buf:
-        final_game_state = None
-
-        while True:
-            evts = dict(poll.poll(1000))
-
-            if not evts and proc.poll() is not None:
-                # no more events and proc has finished.
-                # we give up
-                break
-
-            stdout_ready = (not proc.stdout.closed) and evts.get(proc.stdout.fileno(), False)
-            if stdout_ready:
-                line = proc.stdout.readline()
-                if line:
-                    print(line, end='', file=stdout_buf)
-                else:
-                    poll.unregister(proc.stdout.fileno())
-                    proc.stdout.close()
-            stderr_ready = (not proc.stderr.closed) and evts.get(proc.stderr.fileno(), False)
-            if stderr_ready:
-                line = proc.stderr.readline()
-                if line:
-                    print(line, end='', file=stderr_buf)
-                else:
-                    poll.unregister(proc.stderr.fileno())
-                    proc.stderr.close()
-            socket_ready = evts.get(reply_sock, False)
-            if socket_ready:
-                try:
-                    pelita_status = json.loads(reply_sock.recv_string())
-                    game_state = pelita_status['__data__']['game_state']
-                    finished = game_state.get("finished", None)
-                    team_wins = game_state.get("team_wins", None)
-                    game_draw = game_state.get("game_draw", None)
-                    if finished:
-                        final_game_state = game_state
-                        break
-                except json.JSONDecodeError:
-                    pass
-                except KeyError:
-                    pass
-
-        return (final_game_state, stdout_buf.getvalue(), stderr_buf.getvalue())
+    (final_game_state, stdout, stderr) = libpelita.call_pelitagame(args)
+    return final_game_state, stdout, stderr
 
 
 def start_match(config, teams, shuffle=False):

--- a/tournament/tournament/tournament.py
+++ b/tournament/tournament/tournament.py
@@ -249,7 +249,21 @@ def set_name(team):
         raise
 
 
-def run_match(config, teams):
+def play_game_with_config(config, teams):
+    """ Plays a game between two teams with a given configuration and returns the result.
+
+    Parameters
+    ----------
+    config : Config
+        The configuration
+    teams : list of two team_ids
+        The teams which play this game
+
+    Returns
+    -------
+    (final_game_state, stdout, stderr)
+    """
+
     team1, team2 = teams
 
     rounds = ['--rounds', str(config.rounds)] if config.rounds else []
@@ -290,7 +304,7 @@ def start_match(config, teams, shuffle=False):
     config.print()
     config.wait_for_keypress()
 
-    (final_state, stdout, stderr) = run_match(config, teams)
+    (final_state, stdout, stderr) = play_game_with_config(config, teams)
     try:
         game_draw = final_state['game_draw']
         team_wins = final_state['team_wins']


### PR DESCRIPTION
Slight problem: call_pelitagame is POSIX only and Python 3.5+ so it might not be the best fit for libpelita which is supposed to be more generic. (CI and tournament can be POSIX and 3.5 only.)

Also: recursion: pelitagame imports libpelita and then finds a function that executes pelitagame … should we move it somewhere else?

Future work:
- The cli could be better defined and exposed as function args
- Add a flag that prints directly to stdout instead of capturing it
- The zmq socket could be passed as an environment variable to avoid ambiguity in the popen call
