### PR TITLE
Proof of concept for network players.

### DIFF
--- a/pelita/scripts/pelita_main.py
+++ b/pelita/scripts/pelita_main.py
@@ -96,19 +96,6 @@ def default_players():
     from ..player import SANE_PLAYERS
     return sorted(SANE_PLAYERS, key=lambda m: m.__name__)
 
-def start_logging(filename):
-    if filename:
-        hdlr = logging.FileHandler(filename, mode='w')
-    else:
-        hdlr = logging.StreamHandler()
-    logger = logging.getLogger('pelita')
-    FORMAT = \
-    '[%(relativeCreated)06d %(name)s:%(levelname).1s][%(funcName)s] %(message)s'
-    formatter = logging.Formatter(FORMAT)
-    hdlr.setFormatter(formatter)
-    logger.addHandler(hdlr)
-    logger.setLevel(logging.DEBUG)
-
 def geometry_string(s):
     """Get a X-style geometry definition and return a tuple.
 
@@ -316,7 +303,7 @@ def main():
         raise ValueError("Options --tk (or --tk-no-sync) and --no-publish are mutually exclusive.")
 
     try:
-        start_logging(args.log)
+        pelita.utils.start_logging(args.log)
     except AttributeError:
         pass
 

--- a/pelita/scripts/pelita_player.py
+++ b/pelita/scripts/pelita_player.py
@@ -126,19 +126,64 @@ def import_builtin_player(name):
     else:
         raise ImportError("%r is not a valid player." % player)
 
-def with_zmq_router(address):
+def with_zmq_router(team, address):
+    dealer_pair_mapping = {}
+    pair_dealer_mapping = {}
+
     import zmq
     ctx = zmq.Context()
     sock = ctx.socket(zmq.ROUTER)
     sock.bind(address)
+
+    poll = zmq.Poller()
+    poll.register(sock, zmq.POLLIN)
+
     while True:
-        _ = sock.recv()
-        msg = sock.recv_json()
-        if "REQUEST" in msg:
-            yield msg["REQUEST"]
+        evts = dict(poll.poll(1000))
+        if sock in evts:
+            id_ = sock.recv()
+            msg = sock.recv_json()
+            if "REQUEST" in msg:
+                pair_sock = ctx.socket(zmq.PAIR)
+                port = pair_sock.bind_to_random_port('tcp://127.0.0.1')
+                pair_addr = 'tcp://127.0.0.1:{}'.format(port)
+
+                poll.register(pair_sock, zmq.POLLIN)
+
+                dealer_pair_mapping[id_] = pair_sock
+                pair_dealer_mapping[pair_sock] = id_
+
+                assert len(dealer_pair_mapping) == len(pair_dealer_mapping)
+
+                sub = play_remote(team, pair_addr)
+            elif id_ in dealer_pair_mapping:
+                dealer_pair_mapping[id_].send_json(msg)
+            else:
+                _logger.info("Unknown incoming DEALER and not a request.")
+
+        elif len(evts):
+            for pair_sock, id_ in pair_dealer_mapping.items():
+                if pair_sock in evts:
+                    msg = pair_sock.recv()
+                    sock.send_multipart([id_, msg])
+
+def play_remote(team, pair_addr):
+    player_path = os.environ.get("PELITA_PATH") or os.path.dirname(sys.argv[0])
+    player = 'pelita.scripts.pelita_player'
+    external_call = [pelita.libpelita.get_python_process(),
+                    '-m',
+                    player,
+                    team,
+                    pair_addr]
+    _logger.debug("Executing: %r", external_call)
+    sub = subprocess.Popen(external_call)
+    return sub
+
 
 def main():
     parser = argparse.ArgumentParser(description="Runs a Python pelita module.")
+    parser.add_argument('--log', help='print debugging log information to LOGFILE (default \'stderr\')',
+                        metavar='LOGFILE', default=argparse.SUPPRESS, nargs='?')
     parser.add_argument('--remote', help='bind to a zmq.ROUTER socket at the given address which forks subprocesses on demand',
                         action='store_const', const=True)
     parser.add_argument('team')
@@ -146,23 +191,17 @@ def main():
 
     args = parser.parse_args()
 
+    try:
+        pelita.utils.start_logging(args.log)
+    except AttributeError:
+        pass
+
     if args.remote:
-        for match_addr in with_zmq_router(args.address):
-            player_path = os.environ.get("PELITA_PATH") or os.path.dirname(sys.argv[0])
-            player = 'pelita.scripts.pelita_player'
-            external_call = [pelita.libpelita.get_python_process(),
-                            '-m',
-                            player,
-                            args.team,
-                            match_addr]
-            _logger.debug("Executing: %r", external_call)
-            subprocess.Popen(external_call)
-
+        with_zmq_router(args.team, args.address)
+    else:
         client = make_client(args.team, args.address)
-        print("YEAH")
+        ret = client.run()
 
-    client = make_client(args.team, args.address)
-    ret = client.run()
     sys.exit(ret)
 
 if __name__ == '__main__':

--- a/pelita/utils/__init__.py
+++ b/pelita/utils/__init__.py
@@ -1,5 +1,7 @@
-import sys
+
 import contextlib as _contextlib
+import logging
+import sys
 
 @_contextlib.contextmanager
 def with_sys_path(dirname):
@@ -9,3 +11,15 @@ def with_sys_path(dirname):
     finally:
         sys.path.remove(dirname)
 
+
+def start_logging(filename):
+    if filename:
+        hdlr = logging.FileHandler(filename, mode='w')
+    else:
+        hdlr = logging.StreamHandler()
+    logger = logging.getLogger('pelita')
+    FORMAT = '[%(relativeCreated)06d %(name)s:%(levelname).1s][%(funcName)s] %(message)s'
+    formatter = logging.Formatter(FORMAT)
+    hdlr.setFormatter(formatter)
+    logger.addHandler(hdlr)
+    logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
(On top of the setup.py changes, sorry.)

A call to

    remote# pelita_player --remote players/SmartRandomPlayer.py tcp://0.0.0.0:12345

binds the given zmq socket and waits for incoming match requests. For each request it opens a subshell which connects to the local game master and plays the game.

Local players can then play against the networked player with

    local# pelita my_player remote:tcp://server:12345

Current problems:

  * local does not know its IP address, therefore remote does not know how to connect to the local game master. This may either be given by the local user (straight forward to implement but won’t work with firewalls then) or the whole setup has to be restructured to use zmq addresses (this means we will have to reuse the sockets, I think).

Do not merge yet but it is better than nothing.