### PR TITLE
Make a complete game of pelita executable from libpelita

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ language: python
 sudo: false
 matrix:
   include:
-    - python: "3.3"
-      env: PYZMQ="pyzmq"
-    - python: "3.4"
-      env: PYZMQ="pyzmq"
     - python: "3.5"
       env: PYZMQ="pyzmq"
     - python: "3.6"

--- a/pelita/libpelita.py
+++ b/pelita/libpelita.py
@@ -93,19 +93,19 @@ class BinRunner(ModuleRunner):
         return subprocess.Popen(external_call)
 
 @contextlib.contextmanager
-def _call_standalone_pelitagame(module_spec, address):
+def _call_pelita_player(module_spec, address):
     proc = None
     try:
-        proc = call_standalone_pelitagame(module_spec, address)
+        proc = call_pelita_player(module_spec, address)
         yield proc
     finally:
         if proc is None:
-            print("Problem running pelitagame")
+            print("Problem running pelita player.")
         else:
             _logger.debug("Terminating proc %r", proc)
             proc.terminate()
 
-def call_standalone_pelitagame(module_spec, address):
+def call_pelita_player(module_spec, address):
     """ Starts another process with the same Python executable,
     the same start script (pelitagame) and runs `team_spec`
     as a standalone client on URL `addr`.
@@ -140,7 +140,7 @@ def check_team(team_spec):
     team_player = RemoteTeamPlayer(socket)
 
     if team_spec.module:
-        with _call_standalone_pelitagame(team_spec.module, team_spec.address):
+        with _call_pelita_player(team_spec.module, team_spec.address):
             name = team_player.team_name()
     else:
         name = team_player.team_name()
@@ -194,7 +194,7 @@ def run_game(team_specs, game_config, viewers=None, controller=None):
             print("Waiting for external team %d to connect to %s." % (idx, team.address))
 
     external_players = [
-        call_standalone_pelitagame(team.module, team.address)
+        call_pelita_player(team.module, team.address)
         for team in teams
         if team.module
     ]

--- a/pelita/libpelita.py
+++ b/pelita/libpelita.py
@@ -191,6 +191,9 @@ def call_pelita(team_specs, *, rounds, filter, viewer, dump, seed):
     =======
     tuple of (game_state, stdout, stderr)
     """
+    if _mswindows:
+        raise RuntimeError("call_pelita is currently unavailable on Windows")
+
     team1, team2 = team_specs
 
     ctx = zmq.Context()

--- a/pelita/libpelita.py
+++ b/pelita/libpelita.py
@@ -148,7 +148,7 @@ def call_pelita(team_specs, *, rounds, filter, viewer, dump, seed):
         reply_port = reply_sock.bind_to_random_port(addr)
         reply_addr = 'tcp://127.0.0.1' + ':' + str(reply_port)
 
-    rounds = ['--rounds', rounds] if rounds else []
+    rounds = ['--rounds', str(rounds)] if rounds else []
     filter = ['--filter', filter] if filter else []
     viewer = ['--' + viewer] if viewer else []
     dump = ['--dump', dump] if dump else []

--- a/pelita/scripts/pelita_main.py
+++ b/pelita/scripts/pelita_main.py
@@ -394,7 +394,6 @@ def main():
             else:
                 libpelita.run_game(team_specs=team_specs, game_config=game_config, viewers=viewers)
 
-
 if __name__ == '__main__':
     main()
 

--- a/pelita/scripts/pelita_player.py
+++ b/pelita/scripts/pelita_player.py
@@ -6,6 +6,7 @@ import keyword
 import logging
 import os
 import random
+import signal
 import string
 import subprocess
 import sys
@@ -130,6 +131,13 @@ def with_zmq_router(team, address):
     dealer_pair_mapping = {}
     pair_dealer_mapping = {}
     proc_dealer_mapping = {}
+
+    def cleanup(signum, frame):
+        for proc in proc_dealer_mapping:
+            proc.terminate()
+        sys.exit()
+
+    signal.signal(signal.SIGTERM, cleanup)
 
     import zmq
     ctx = zmq.Context()

--- a/pelita/simplesetup.py
+++ b/pelita/simplesetup.py
@@ -513,6 +513,7 @@ class SimpleClient:
         """ Waits for incoming requests and tries to get a proper
         answer from the player.
         """
+
         json_message = self.socket.recv_unicode()
         py_obj = json.loads(json_message)
         uuid_ = py_obj["__uuid__"]

--- a/pelita/tournament/tournament.py
+++ b/pelita/tournament/tournament.py
@@ -250,90 +250,20 @@ def set_name(team):
 def run_match(config, teams):
     team1, team2 = teams
 
-    ctx = zmq.Context()
-    reply_addr = "ipc://tournament-reply#{pid}".format(pid=os.getpid())
-    reply_sock = ctx.socket(zmq.PAIR)
-    reply_sock.bind(reply_addr)
-
-    rounds = ['--rounds', str(config.rounds)] if config.rounds else []
-    filter = ['--filter', config.filter] if config.filter else []
-    viewer = ['--' + config.viewer] if config.viewer else []
     if config.tournament_log_folder:
         dumpfile = os.path.join(config.tournament_log_folder, "dump-{time}".format(time=time.strftime('%Y%m%d-%H%M%S')))
-        dump = ['--dump', dumpfile]
+        dump = dumpfile
     else:
-        dump = []
+        dump = None
 
-    cmd = [libpelita.get_python_process(), '-m', 'pelita.scripts.pelita_main'] + [config.team_spec(team1), config.team_spec(team2),
-                              '--reply-to', reply_addr,
-                              '--seed', str(random.randint(0, sys.maxsize)),
-                              *dump,
-                              *filter,
-                              *rounds,
-                              *viewer]
+    seed = str(random.randint(0, sys.maxsize))
 
-    _logger.debug("Executing: {}".format(libpelita.shlex_unsplit(cmd)))
-
-    # We use the environment variable PYTHONUNBUFFERED here to retrieve stdout without buffering
-    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                            universal_newlines=True, env=dict(os.environ, PYTHONUNBUFFERED='x'))
-
-
-    #if ARGS.dry_run:
-    #    print("Would run: {cmd}".format(cmd=cmd))
-    #    print("Choosing winner at random.")
-    #    return random.choice([0, 1, 2])
-
-
-    poll = zmq.Poller()
-    poll.register(reply_sock, zmq.POLLIN)
-    poll.register(proc.stdout.fileno(), zmq.POLLIN)
-    poll.register(proc.stderr.fileno(), zmq.POLLIN)
-
-    with io.StringIO() as stdout_buf, io.StringIO() as stderr_buf:
-        final_game_state = None
-
-        while True:
-            evts = dict(poll.poll(1000))
-
-            if not evts and proc.poll() is not None:
-                # no more events and proc has finished.
-                # we give up
-                break
-
-            stdout_ready = (not proc.stdout.closed) and evts.get(proc.stdout.fileno(), False)
-            if stdout_ready:
-                line = proc.stdout.readline()
-                if line:
-                    print(line, end='', file=stdout_buf)
-                else:
-                    poll.unregister(proc.stdout.fileno())
-                    proc.stdout.close()
-            stderr_ready = (not proc.stderr.closed) and evts.get(proc.stderr.fileno(), False)
-            if stderr_ready:
-                line = proc.stderr.readline()
-                if line:
-                    print(line, end='', file=stderr_buf)
-                else:
-                    poll.unregister(proc.stderr.fileno())
-                    proc.stderr.close()
-            socket_ready = evts.get(reply_sock, False)
-            if socket_ready:
-                try:
-                    pelita_status = json.loads(reply_sock.recv_string())
-                    game_state = pelita_status['__data__']['game_state']
-                    finished = game_state.get("finished", None)
-                    team_wins = game_state.get("team_wins", None)
-                    game_draw = game_state.get("game_draw", None)
-                    if finished:
-                        final_game_state = game_state
-                        break
-                except json.JSONDecodeError:
-                    pass
-                except KeyError:
-                    pass
-
-        return (final_game_state, stdout_buf.getvalue(), stderr_buf.getvalue())
+    return libpelita.call_pelita([config.team_spec(team1), config.team_spec(team2)],
+                                  rounds=config.rounds,
+                                  filter=config.filter,
+                                  viewer=config.viewer,
+                                  dump=dump,
+                                  seed=seed)
 
 
 def start_match(config, teams, shuffle=False):

--- a/pelita/tournament/tournament.py
+++ b/pelita/tournament/tournament.py
@@ -247,7 +247,7 @@ def set_name(team):
         raise
 
 
-def run_match(config, teams):
+def play_game_with_config(config, teams):
     team1, team2 = teams
 
     if config.tournament_log_folder:
@@ -284,7 +284,7 @@ def start_match(config, teams, shuffle=False):
     config.print()
     config.wait_for_keypress()
 
-    (final_state, stdout, stderr) = run_match(config, teams)
+    (final_state, stdout, stderr) = play_game_with_config(config, teams)
     try:
         game_draw = final_state['game_draw']
         team_wins = final_state['team_wins']

--- a/test/test_libpelita.py
+++ b/test/test_libpelita.py
@@ -1,3 +1,7 @@
+import pytest
+
+import sys
+
 from pelita import libpelita
 
 class TestLibpelitaUtils:
@@ -9,7 +13,7 @@ class TestLibpelitaUtils:
         assert libpelita.firstNN(None, None, None) == None
         assert libpelita.firstNN() == None
 
-
+@pytest.mark.skipif(sys.platform == 'win32', reason="does not run on windows")
 class TestCallPelita:
     def test_call_pelita(self):
         rounds = 200

--- a/test/test_libpelita.py
+++ b/test/test_libpelita.py
@@ -9,3 +9,25 @@ class TestLibpelitaUtils:
         assert libpelita.firstNN(None, None, None) == None
         assert libpelita.firstNN() == None
 
+
+class TestCallPelita:
+    def test_call_pelita(self):
+        rounds = 200
+        viewer = 'ascii'
+        filter = 'small'
+
+        teams = ["StoppingPlayer", "StoppingPlayer"]
+        (state, stdout, stderr) = libpelita.call_pelita(teams, rounds=rounds, viewer=viewer, filter=filter, dump=None, seed=None)
+        assert state['team_wins'] is None
+        assert state['game_draw'] is True
+
+        teams = ["SmartEatingPlayer", "StoppingPlayer"]
+        (state, stdout, stderr) = libpelita.call_pelita(teams, rounds=rounds, viewer=viewer, filter=filter, dump=None, seed=None)
+        assert state['team_wins'] == 0
+        assert state['game_draw'] is None
+
+        teams = ["StoppingPlayer", "SmartEatingPlayer"]
+        (state, stdout, stderr) = libpelita.call_pelita(teams, rounds=rounds, viewer=viewer, filter=filter, dump=None, seed=None)
+        assert state['team_wins'] == 1
+        assert state['game_draw'] is None
+

--- a/test/test_pelitagame.py
+++ b/test/test_pelitagame.py
@@ -44,10 +44,17 @@ def test_default_players():
 
 import atexit
 
+def terminate_and_wait(proc):
+    proc.terminate()
+    try:
+        proc.wait(3)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+
 def Popen_autokill(args):
     # we need to autokill in case of errors
     p = subprocess.Popen(args)
-    atexit.register(p.kill)
+    atexit.register((lambda p: lambda: terminate_and_wait(p))(p))
     return p
 
 def test_remote_game():

--- a/test/test_tournament.py
+++ b/test/test_tournament.py
@@ -133,7 +133,7 @@ class TestRoundRobin:
 # There must be exactly one game_state with finished=True
 
 class TestSingleMatch:
-    def test_run_match(self):
+    def test_play_game_with_config(self):
         config = MagicMock()
         config.rounds = 200
         config.team_spec = lambda x: x
@@ -142,7 +142,7 @@ class TestSingleMatch:
         config.tournament_log_folder = None
 
         teams = ["StoppingPlayer", "StoppingPlayer"]
-        (state, stdout, stderr) = tournament.run_match(config, teams)
+        (state, stdout, stderr) = tournament.play_game_with_config(config, teams)
         assert state['team_wins'] == None
         assert state['game_draw'] == True
 
@@ -150,7 +150,7 @@ class TestSingleMatch:
         config.team_spec = lambda x: x
         config.viewer = 'ascii'
         teams = ["SmartEatingPlayer", "StoppingPlayer"]
-        (state, stdout, stderr) = tournament.run_match(config, teams)
+        (state, stdout, stderr) = tournament.play_game_with_config(config, teams)
         print(state)
         assert state['team_wins'] == 0
         assert state['game_draw'] == None
@@ -159,7 +159,7 @@ class TestSingleMatch:
         config.team_spec = lambda x: x
         config.viewer = 'ascii'
         teams = ["StoppingPlayer", "SmartEatingPlayer"]
-        (state, stdout, stderr) = tournament.run_match(config, teams)
+        (state, stdout, stderr) = tournament.play_game_with_config(config, teams)
         assert state['team_wins'] == 1
         assert state['game_draw'] == None
 

--- a/test/test_tournament.py
+++ b/test/test_tournament.py
@@ -2,7 +2,7 @@ import pytest
 from unittest.mock import MagicMock
 
 import sys
-pytestmark = pytest.mark.skipif(sys.version_info < (3,5), reason="requires python3.5")
+pytestmark = pytest.mark.skipif(sys.platform == 'win32', reason="tournament does not run on windows")
 
 import re
 from textwrap import dedent


### PR DESCRIPTION
Replaces #386.

This moves the run_match logic from the tournament to libpelita. Currently this spawns a new subprocess with the given command line arguments and captures the final state as well as stdout, stderr. This might make it thread-safe, although there are no tests for this yet.

The disadvantage is the slightly awkward work-arounds that go with running an external process and having basically no feed-back while the function is running.