### PR TITLE
Give warning if creating layout without food (fixes #418)

### DIFF
--- a/pelita/game_master.py
+++ b/pelita/game_master.py
@@ -4,6 +4,7 @@ import abc
 import random
 import sys
 import time
+from warnings import warn
 
 from . import datamodel
 from .datamodel import Bot, CTFUniverse
@@ -17,6 +18,10 @@ class PlayerTimeout(Exception):
     pass
 
 class PlayerDisconnected(Exception):
+    pass
+
+class NoFoodWarning(Warning):
+    """ Warning about a layout with no food. """
     pass
 
 class GameMaster:
@@ -157,6 +162,12 @@ class GameMaster:
             #: sight distance of the noise
             "noise_sight_distance": self.noiser and self.noiser.sight_distance
         }
+
+        # Check that both teams have food, and raise a warning otherwise
+        for (team_id, food_count) in enumerate(self.game_state["food_to_eat"]):
+            if food_count == 0:
+                warn("Layout contains no food for team {}.".format(team_id),
+                     NoFoodWarning)
 
     @property
     def game_time(self):

--- a/test/test_game_master.py
+++ b/test/test_game_master.py
@@ -4,7 +4,7 @@ import unittest
 import collections
 
 from pelita.datamodel import CTFUniverse
-from pelita.game_master import GameMaster, ManhattanNoiser, PlayerTimeout
+from pelita.game_master import GameMaster, ManhattanNoiser, PlayerTimeout, NoFoodWarning
 from pelita.player import AbstractPlayer, SimpleTeam, StoppingPlayer, SteppingPlayer
 from pelita.viewer import AbstractViewer
 
@@ -83,6 +83,26 @@ class TestGameMaster:
         with pytest.raises(ValueError):
             GameMaster(test_layout_4, [team_1, team_2, team_3], 4, 200)
 
+    def test_no_food(self):
+        team_1 = SimpleTeam(SteppingPlayer([]), SteppingPlayer([]))
+        team_2 = SimpleTeam(SteppingPlayer([]), SteppingPlayer([]))
+
+        both_starving_layout = (
+            """ ######
+                #0   #
+                #   1#
+                ###### """)
+        with pytest.warns(NoFoodWarning):
+            GameMaster(both_starving_layout, [team_1, team_2], 2, 1)
+
+        one_side_starving_layout = (
+            """ ######
+                #0  .#
+                #   1#
+                ###### """)
+        with pytest.warns(NoFoodWarning):
+            GameMaster(one_side_starving_layout, [team_1, team_2], 2, 1)
+
 class TestUniverseNoiser:
     def test_uniform_noise_manhattan(self):
         test_layout = (
@@ -106,7 +126,7 @@ class TestUniverseNoiser:
                      (4, 3), (5, 3), (6, 3), (7, 3), (7, 2),
                      (6, 1), (5, 1), (4, 1), (3, 1) ]
         unittest.TestCase().assertCountEqual(position_bucket, expected, position_bucket)
-    
+
 
     def test_uniform_noise_4_bots_manhattan(self):
         test_layout = (


### PR DESCRIPTION
Fixes #418. I know that we were burnt by this, so I thought I would address it...

This just checks that a layout includes food and, if not, gives a warning. I've put the warning in the factory method that creates the layout rather than in the GameMaster - I don't know what you'd prefer. Since there are several tests with no food, I've also added a pytest.ini to suppress the warnings from them and keep the output cleaner (I couldn't see any other customisation for py.test already in the repository).

Edit: Just saw the format for marking commits, sorry!
Edit2: Failing on 3.3 seems strange, although I see that configuration uses a different pytest version (2.9.2 vs 3.x in later ones). I don't see anything about how warnings are handled in the changelog, though.