### PR TITLE
Rework the import logic in pelita_player

### DIFF
--- a/pelita/scripts/pelita_player.py
+++ b/pelita/scripts/pelita_player.py
@@ -107,9 +107,7 @@ def load_factory(filespec):
     return getattr(module, factory_name)
 
 def import_builtin_player(name):
-    with pelita.utils.with_sys_path("./"):
-        players_module = __import__('pelita.player', fromlist='players')
-        sane_players = {p.__name__: p for p in players_module.SANE_PLAYERS}
+    sane_players = {p.__name__: p for p in pelita.player.SANE_PLAYERS}
 
     if name == 'random':
         player = random.choice(list(sane_players.values()))

--- a/pelita/scripts/pelita_player.py
+++ b/pelita/scripts/pelita_player.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import importlib
 import inspect
 import keyword
 import logging
@@ -102,7 +103,7 @@ def load_factory(filespec):
 
     factory_name = factory_name or DEFAULT_FACTORY
     with pelita.utils.with_sys_path(dirname):
-        module = __import__(modname, fromlist=[factory_name])
+        module = importlib.import_module(modname)
     return getattr(module, factory_name)
 
 def import_builtin_player(name):

--- a/test/test_pelita_player.py
+++ b/test/test_pelita_player.py
@@ -72,7 +72,7 @@ def test_import_of_pyc():
         with initfile.open(mode='w') as f:
             f.write(SIMPLE_MODULE)
         pycfile = initfile.parent / "teampycpyc.pyc"
-        py_compile.compile(initfile, cfile=pycfile)
+        py_compile.compile(str(initfile), cfile=str(pycfile))
         initfile.unlink()
 
         spec = str(pycfile)

--- a/test/test_pelita_player.py
+++ b/test/test_pelita_player.py
@@ -120,4 +120,3 @@ class TestLoadTeam:
         for spec, exception in specs:
             with pytest.raises(exception):
                 load_team(spec)
-

--- a/test/test_pelita_player.py
+++ b/test/test_pelita_player.py
@@ -104,19 +104,22 @@ class TestLoadTeam:
                 spec = str(module)
                 load_team(spec)
 
-    def test_builtin_import(self):
-        specs = [
-            "StoppingPlayer",
-            "StoppingPlayer,StoppingPlayer",
-        ]
-        for spec in specs:
-            load_team(spec)
+    load_team_cases = [
+        ("StoppingPlayer", None),
+        ("StoppingPlayer,StoppingPlayer", None),
+        ("NonExistingPlayer", ImportError),
+        ("StoppingPlayer,StoppingPlayer,FoodEatingPlayer", ValueError),
+        ('doc/source/groupN:team', None),
+        ('doc/source/groupN/__init__.py', ImportError),
+        ('doc/source/groupN', ValueError), # Has already been imported
+    ]
 
-    def test_builtin_import_fails(self):
-        specs = [
-            ("NonExistingPlayer", ImportError),
-            ("StoppingPlayer,StoppingPlayer,FoodEatingPlayer", ValueError)
-        ]
-        for spec, exception in specs:
-            with pytest.raises(exception):
-                load_team(spec)
+    def test_load_team(self):
+        for path, result in self.load_team_cases:
+            print(path, result)
+            if result is not None:
+                with pytest.raises(result):
+                    load_team(path)
+            else:
+                load_team(path)
+ 

--- a/test/test_pelita_player.py
+++ b/test/test_pelita_player.py
@@ -1,0 +1,63 @@
+import pytest
+
+from pathlib import Path
+import sys
+import tempfile
+
+import pelita
+from pelita import libpelita
+from pelita.scripts.pelita_player import load_factory
+
+SIMPLE_MODULE = """
+def team():
+    return None
+"""
+
+SIMPLE_FAILING_MODULE = """
+def noteam():
+    return None
+"""
+
+def test_simple_module_import():
+    modules_before = list(sys.modules.keys())
+    with tempfile.TemporaryDirectory() as d:
+        module = Path(d) / "teamx"
+        module.mkdir()
+        initfile = module / "__init__.py"
+        with initfile.open(mode='w') as f:
+            f.write(SIMPLE_MODULE)
+
+        spec = str(module)
+        load_factory(spec)
+#        del sys.modules[module.stem]
+#    assert list(sys.modules.keys()) == modules_before
+
+def test_simple_file_import():
+    modules_before = list(sys.modules.keys())
+    with tempfile.TemporaryDirectory() as d:
+        module = Path(d) / "teamy"
+        module.mkdir()
+        initfile = module / "team.py"
+        with initfile.open(mode='w') as f:
+            f.write(SIMPLE_MODULE)
+
+        spec = str(initfile)
+        load_factory(spec)
+#        del sys.modules[module.stem]
+#    assert list(sys.modules.keys()) == modules_before
+
+def test_failing_import():
+    modules_before = list(sys.modules.keys())
+    with tempfile.TemporaryDirectory() as d:
+        module = Path(d) / "teamz"
+        module.mkdir()
+        initfile = module / "__init__.py"
+        with initfile.open(mode='w') as f:
+            f.write(SIMPLE_FAILING_MODULE)
+
+        spec = str(module)
+        with pytest.raises(AttributeError):
+            load_factory(spec)
+#        del sys.modules[module.stem]
+#    assert list(sys.modules.keys()) == modules_before
+

--- a/test/test_pelita_player.py
+++ b/test/test_pelita_player.py
@@ -1,6 +1,7 @@
 import pytest
 
 from pathlib import Path
+import py_compile
 import sys
 import tempfile
 
@@ -37,7 +38,7 @@ def test_simple_file_import():
     with tempfile.TemporaryDirectory() as d:
         module = Path(d) / "teamy"
         module.mkdir()
-        initfile = module / "team.py"
+        initfile = module / "teamyy.py"
         with initfile.open(mode='w') as f:
             f.write(SIMPLE_MODULE)
 
@@ -61,3 +62,20 @@ def test_failing_import():
 #        del sys.modules[module.stem]
 #    assert list(sys.modules.keys()) == modules_before
 
+
+def test_import_of_pyc():
+    modules_before = list(sys.modules.keys())
+    with tempfile.TemporaryDirectory() as d:
+        module = Path(d) / "teampyc"
+        module.mkdir()
+        initfile = module / "teampycpyc.py"
+        with initfile.open(mode='w') as f:
+            f.write(SIMPLE_MODULE)
+        pycfile = initfile.parent / "teampycpyc.pyc"
+        py_compile.compile(initfile, cfile=pycfile)
+        initfile.unlink()
+
+        spec = str(pycfile)
+        load_factory(spec)
+#        del sys.modules[module.stem]
+#    assert list(sys.modules.keys()) == modules_before

--- a/test/test_pelitagame.py
+++ b/test/test_pelitagame.py
@@ -6,29 +6,6 @@ import pelita
 from pelita import libpelita
 from pelita.simplesetup import SimpleServer
 
-print(dir(pelita))
-with pelita.utils.with_sys_path('test'):
-    from pelita.scripts.pelita_player import check_module
-
-check_module_cases = [
-    ('test/test_pelitagame.py', None),
-    ('test/__init__.py', ValueError),
-    ('test/', ValueError),
-    ('test', ValueError),
-    ('doc/source/groupN', None),
-    ('doc/source/groupN/__init__.py', ValueError),
-    ('doc/source/time', ValueError),
-    ]
-
-class TestCheckModule:
-    def test_check_module(self):
-        for path,result in check_module_cases:
-            print(path, result)
-            if result is not None:
-                with pytest.raises(result):
-                    check_module(path)
-            else:
-                check_module(path)
 
 def test_default_players():
     from pelita.scripts.pelita_main import default_players


### PR DESCRIPTION
Previously, our check_module function would take a guess at what a proper module would look like and fail if it looked differently.  We now relax some of the constraints and just try to import the module (with importlib). If it works, good, if it doesn’t, then we can still fail.

As a side-effect, this change allows to specify a module without path delimiters (unless it would collide with a built-in player) and modules containing only .pyc files.

Unfortunately, this still imports the modules into the global namespace, which means that in the tests, we have to use a new module name in each one (otherwise there will be collisions).

For reference, I also tried the following logic with `importlib` (where we could get more explicit feedback about which modules are imported – and potentially clear them afterwards) but since it does not add the parent to `sys.modules`, we cannot import anything with relative imports in it:


    def _load_factory(filespec: str):
        # strip off the factory_name after the first :
        filename, _, factory_name = filespec.partition(':')
        factory_name = factory_name or DEFAULT_FACTORY
        path = Path(filename)

        if path.is_dir():
            spec = importlib.util.spec_from_file_location(path.stem, path / '__init__.py')
        else:
            spec = importlib.util.spec_from_file_location(path.stem, path)

        module = importlib.util.module_from_spec(spec)
        spec.loader.exec_module(module)
        sys.modules[path.stem] = module
        return getattr(module, factory_name)

