### PR TITLE
ENH: New approach for the simplified player API.

### DIFF
--- a/demo/demo_team.py
+++ b/demo/demo_team.py
@@ -1,0 +1,15 @@
+
+import random
+
+from pelita.player import Team
+from pelita.player.player_functions import legal_moves
+
+def move1(datadict, storage):
+    legal = legal_moves(datadict)
+    return random.choice(legal)
+
+def move2(datadict, storage):
+    return (0, 0)
+
+def team():
+    return Team("My Team", move1, move2)

--- a/pelita/player/__init__.py
+++ b/pelita/player/__init__.py
@@ -5,6 +5,8 @@ from .base import (StoppingPlayer, SteppingPlayer, SpeakingPlayer,
                    RoundBasedPlayer, MoveExceptionPlayer, InitialExceptionPlayer,
                    DebuggablePlayer)
 
+from .team import Team
+
 from .RandomPlayers import RandomPlayer, NQRandomPlayer
 from .FoodEatingPlayer import FoodEatingPlayer
 from .SmartEatingPlayer import SmartEatingPlayer

--- a/pelita/player/player_functions.py
+++ b/pelita/player/player_functions.py
@@ -1,0 +1,6 @@
+
+# Player API
+
+def legal_moves(datadict):
+    # TODO
+    return [(0, 0)]

--- a/pelita/player/team.py
+++ b/pelita/player/team.py
@@ -1,0 +1,130 @@
+
+from . import AbstractTeam
+
+
+class Team(AbstractTeam):
+    """ Simple class used to register an arbitrary number of (Abstract-)Players.
+
+    Each Player is used to control a Bot in the Universe.
+
+    SimpleTeam transforms the `set_initial` and `get_move` messages
+    from the GameMaster into calls to the user-supplied functions.
+
+    Parameters
+    ----------
+    team_name :
+        the name of the team (optional)
+    players : functions with signature (datadict, storage) -> move
+        the Players who shall join this SimpleTeam
+    """
+    def __init__(self, *args):
+        if not args:
+            raise ValueError("No teams given.")
+
+        if isinstance(args[0], str):
+            self.team_name = args[0]
+            players = args[1:]
+        else:
+            self.team_name = ""
+            players = args[:]
+
+        self._players = players
+        self._bot_players = {}
+
+        #: The storage dict that can be used to exchange data between the players
+        # and between rounds.
+        self.storage = {}
+
+    def set_initial(self, team_id, universe, game_state):
+        """ Sets the bot indices for the team and returns the team name.
+        Currently, we do not call _set_initial on the user side.
+
+        Parameters
+        ----------
+        team_id : int
+            The id of the team
+        universe : Universe
+            The initial universe
+        game_state : dict
+            The initial game state
+
+        Returns
+        -------
+        Team name : string
+            The name of the team
+
+        """
+
+        # only iterate about those player which are in bot_players
+        # we might have defined more players than we have received
+        # indexes for.
+        team_bots = universe.team_bots(team_id)
+
+        if len(team_bots) > len(self._players):
+            raise ValueError("Tried to set %d bot_ids with only %d Players." % (len(team_bots), len(self._players)))
+
+        for bot, player in zip(team_bots, self._players):
+            # tell the player its index
+            # TODO: This _index is obviously not visible from inside the functions,
+            # therefore this information will have to be added to the datadict in each
+            # call inside get_move.
+            # TODO: This will fail for bound methods.
+            player._index = bot.index
+
+            # TODO: Should we tell the player about the initial universe?
+            # We could call the function with a flag that tells the player
+            # that it is the initial call. But then the player will have to check
+            # for themselves in each round.
+            #player._set_initial(universe, game_state)
+
+            self._bot_players[bot.index] = player
+
+        return self.team_name
+
+    def get_move(self, bot_id, universe, game_state):
+        """ Requests a move from the Player who controls the Bot with id `bot_id`.
+
+        This method returns a dict with a key `move` and a value specifying the direction
+        in a tuple. Additionally, a key `say` can be added with a textual value.
+
+        Parameters
+        ----------
+        bot_id : int
+            The id of the bot who needs to play
+        universe : Universe
+            The initial universe
+        game_state : dict
+            The initial game state
+
+        Returns
+        -------
+        move : dict
+        """
+
+        # We prepare a dict-only representation of our universe and game state.
+        # This forces us to rewrite all functions for the user API and avoids having to
+        # look into the documentation for our nested datamodel APIself.
+        # Once we settle on a useable representation, we can then backport this to
+        # the datamodel as well.
+        datadict = {
+            'universe': universe._to_json_dict(),
+            'game_state': game_state
+        }
+
+        # TODO: Transform the datadict in a way that makes it more practical to use,
+        # reduces unnecessary redundancy but still avoids recalculations for simple things
+
+        # TODO: What to do with the random seed?
+
+        # TODO: How are we saying things? Should we have a reserved index in the storage dict
+        # that can be used for that? storage['__say'] = "Blah"
+
+
+        move = self._bot_players[bot_id](datadict, self.storage)
+        return {
+            "move": move,
+        #    "say": ???
+        }
+
+    def __repr__(self):
+        return "Team(%r, %s)" % (self.team_name, ", ".join(repr(p) for p in self._players))

--- a/test/test_team.py
+++ b/test/test_team.py
@@ -1,0 +1,47 @@
+from pelita.game_master import GameMaster
+from pelita.player import Team
+
+
+class TestStoppingTeam:
+    @staticmethod
+    def stopping(datadict, storage):
+        return (0, 0)
+
+    @staticmethod
+    def round_counting():
+        storage_copy = {}
+        def inner(datadict, storage):
+            storage['rounds'] = storage.get('rounds', 0) + 1
+            storage_copy['rounds'] = storage['rounds']
+            return (0, 0)
+        inner._storage = storage_copy
+        return inner
+
+    def test_stopping(self):
+        test_layout = (
+        """ ############
+            #0#.   .# 1#
+            ############ """)
+
+        round_counting = self.round_counting()
+        team = [
+            Team(self.stopping),
+            Team(round_counting)
+        ]
+        gm = GameMaster(test_layout, team, 2, 1)
+        gm.play()
+        assert gm.universe.bots[0].current_pos == (1, 1)
+        assert gm.universe.bots[1].current_pos == (10, 1)
+        assert round_counting._storage['rounds'] == 1
+
+
+        round_counting = self.round_counting()
+        team = [
+            Team(self.stopping),
+            Team(round_counting)
+        ]
+        gm = GameMaster(test_layout, team, 2, 3)
+        gm.play()
+        assert gm.universe.bots[0].current_pos == (1, 1)
+        assert gm.universe.bots[1].current_pos == (10, 1)
+        assert round_counting._storage['rounds'] == 3


### PR DESCRIPTION
The general idea is that we give up on the object oriented interface and instead have the user supply a move function (or perhaps several for the individual bots) that receives a universe/state and a storage dict.

The universe/state object should contain all necessary information to evaluate a state. The representation will be kept as simple as possible (a simple print should show all available information to help with observability) and we will export all the previous helper methods on AbstractPlayer as functions.

Additionally, we initialise an empty storage dict which we pass to the move function. The storage dict can be used to share data between the individual players and rounds and is persistent for a whole game.


### Implementation strategy

The goal will be to get to an immutable universe/game_state representation for the user side that can be queried with external accessor functions. Users can write their own accessor functions and they will look exactly the same as our functions. (This is not possible with the OO interface, or at least not for non-OO people.)

The goal is not to change the datamodel API. This can follow eventually but it is not necessary just yet.

Our starting point for the representation will be created from the `_to_json_dict` transformation of `CTFUniverse` (which is the same format that we use for sending through zmq) and will consist of dicts, lists and simple types only.
Starting from this representation forces us to not look back and re-use the datamodel API.
Inside the `Team` class, we will have a function that performs a few ‘cosmetic adjustments’ (removing redundancy, improving the format). If deemed good, we may want to backport those changes to the zmq wire-format as well but again, this will be a second step.

Open questions and TODOs:

* Right now, the storage dict is stored in the `Team` class. We should decide whether we want to allow reusing a `Team` for more than one game and what happens with the storage dict in this case.

* In the OO version, it feels more natural to have people use `self.rng` for the seeded `random` module (and it will automatically be persistent between rounds). How should we solve this with a functional API?

* Do we want to have reserved keys in the storage dict? Those could be used for returning additional information (the move function itself only returns a direction). Most prominently, this could be used for having the bots talk (perhaps also for rng state?) but it could also be useful for some kind of UI overlay for debugging (we could have the players print additional information on the Tk interface in development mode).

* How do we pass the bot’s own index to the move function? In a separate argument or inside the datadict?

* Will we keep the `set_initial` phase?

### What is already done?

I added a new `Team` class to `pelita.player` which replaces the old `SimpleTeam` (the one that worked with `AbstractPlayer`s). This class can be used in parallel with players using `SimpleTeam`. A small (working but not yet useful) example of how it could look like eventually has been given in `demo/demo_team.py`.

The API for the player is to be added to `pelita/player/player_functions.py` (for now). There we should now implement all those methods from `AbstractPlayer` and datamodel that we still feel are useable. We might want to start with a more minimalistic set of methods though and not provide an accessor for everything.