### PR TITLE
Rearranged CLI --help

### DIFF
--- a/pelita/scripts/pelita_main.py
+++ b/pelita/scripts/pelita_main.py
@@ -131,6 +131,8 @@ parser.add_argument('--replay', help='replay a dumped game'
                     metavar='DUMPFILE', default=argparse.SUPPRESS, nargs='?')
 parser.add_argument('--dry-run', const=True, action='store_const',
                     help='load players but do not actually play the game')
+parser.add_argument('--list-layouts', action='store_const', const=True,
+                    help='List all available layouts.')
 parser.add_argument('--list-teams', action="store_const", const=True,
                     help='Print the names of the included default teams.')
 parser.add_argument('--check-team', action="store_const", const=True,
@@ -146,12 +148,9 @@ layout_opt = game_settings.add_mutually_exclusive_group()
 layout_opt.add_argument('--layoutfile', metavar='FILE',
                         help='load a maze layout from FILE')
 layout_opt.add_argument('--layout', metavar='NAME',
-                        help="load a maze layout by name. If NAME is"
-                        " 'list' return a list of available names")
-layout_opt.add_argument('--filter', metavar='STRING',
-                        default='normal_without_dead_ends',
-                        help='restrict the pool of random layouts to those whose'
-                        ' name contains STRING.'
+                        help='load a maze layout by name')
+layout_opt.add_argument('--filter', metavar='STRING', default='normal_without_dead_ends',
+                        help='restrict the pool of random layouts to those whose name contains STRING.'
                         ' Default: \'normal_without_dead_ends\'')
 
 game_settings.add_argument('--max-timeouts', type=int, default=5,
@@ -278,14 +277,15 @@ def main():
     if args.help:
         parser.print_help()
         sys.exit(0)
+
     if args.version:
         if pelita._git_version:
             print("Pelita {} (git: {})".format(pelita.__version__, pelita._git_version))
         else:
             print("Pelita {}".format(pelita.__version__))
-
         sys.exit(0)
-    if args.layout == 'list':
+
+    if args.list_layouts:
         layouts = pelita.layout.get_available_layouts()
         print('\n'.join(layouts))
         sys.exit(0)

--- a/pelita/scripts/pelita_main.py
+++ b/pelita/scripts/pelita_main.py
@@ -121,68 +121,28 @@ parser.add_argument('--help', '-h', help='show this help message and exit',
 parser.add_argument('--version', help='show the version number and exit',
                     action='store_const', const=True)
 parser.add_argument('--log', help='print debugging log information to'
-                                  ' LOGFILE (default \'stderr\')',
+                    ' LOGFILE (default \'stderr\')',
                     metavar='LOGFILE', default=argparse.SUPPRESS, nargs='?')
 parser.add_argument('--dump', help='print game dumps to file (will be overwritten)'
-                                  ' DUMPFILE (default \'pelita.dump\')',
+                    ' DUMPFILE (default \'pelita.dump\')',
                     metavar='DUMPFILE', default=argparse.SUPPRESS, nargs='?')
 parser.add_argument('--replay', help='replay a dumped game'
-                                  ' DUMPFILE (default \'pelita.dump\')',
+                    ' DUMPFILE (default \'pelita.dump\')',
                     metavar='DUMPFILE', default=argparse.SUPPRESS, nargs='?')
-parser.add_argument('--rounds', type=int, default=300,
-                    help='maximum number of rounds to play')
-parser.add_argument('--fps', type=float, default=40,
-                    help='(approximate) number of frames per second in a graphical viewer')
-parser.add_argument('--seed', type=int, metavar='SEED', default=None,
-                    help='fix random seed')
-parser.add_argument('--geometry', type=geometry_string, metavar='NxM',
-                    help='initial size of the game window')
 parser.add_argument('--dry-run', const=True, action='store_const',
                     help='load players but do not actually play the game')
-parser.add_argument('--max-timeouts', type=int, default=5,
-                    dest='max_timeouts', help='maximum number of timeouts allowed (default: 5)')
 parser.add_argument('--list-teams', action="store_const", const=True,
                     help='Print the names of the included default teams.')
 parser.add_argument('--check-team', action="store_const", const=True,
                     help='Check that the team is valid (on first sight) and print its name.')
 
-timeout_opt = parser.add_mutually_exclusive_group()
-timeout_opt.add_argument('--timeout', type=float, metavar="SEC",
-                         dest='timeout_length', help='time before timeout is triggered (default: 3 seconds)')
-timeout_opt.add_argument('--no-timeout', const=None, action='store_const',
-                         dest='timeout_length', help='run game with no timeouts')
-parser.set_defaults(timeout_length=3)
+game_settings = parser.add_argument_group('Game settings')
+game_settings.add_argument('--rounds', type=int, default=300,
+                           help='maximum number of rounds to play')
+game_settings.add_argument('--seed', type=int, metavar='SEED', default=None,
+                           help='fix random seed')
 
-parser.add_argument('--reply-to', type=str, metavar='URL',
-                    dest='reply_to', help='Reply channel')
-
-publisher_opt = parser.add_mutually_exclusive_group()
-publisher_opt.add_argument('--publish', type=str, metavar='URL',
-                           dest='publish_to', help='publish to this zmq socket')
-publisher_opt.add_argument('--no-publish', const=False, action='store_const',
-                           dest='publish_to', help='do not publish')
-parser.set_defaults(publish_to="tcp://127.0.0.1:*")
-
-controller_opt = parser.add_argument_group("Controller")
-controller_opt.add_argument('--controller', type=str, metavar='URL', default="tcp://127.0.0.1:*",
-                            help='open a controller on this zmq socket')
-controller_opt.add_argument('--external-controller', const=True, action='store_const',
-                            help='force control by an external controller')
-
-viewer_opt = parser.add_mutually_exclusive_group()
-viewer_opt.add_argument('--ascii', action='store_const', const='ascii',
-                        dest='viewer', help='use the ASCII viewer')
-viewer_opt.add_argument('--null', action='store_const', const='null',
-                        dest='viewer', help='use the /dev/null viewer')
-viewer_opt.add_argument('--progress', action='store_const', const='progress',
-                        dest='viewer', help='use the progress viewer')
-viewer_opt.add_argument('--tk', action='store_const', const='tk',
-                        dest='viewer', help='use the tk viewer (default)')
-viewer_opt.add_argument('--tk-no-sync', action='store_const', const='tk-no-sync',
-                        dest='viewer', help='use the unsynchronised tk viewer')
-parser.set_defaults(viewer='tk')
-
-layout_opt = parser.add_mutually_exclusive_group()
+layout_opt = game_settings.add_mutually_exclusive_group()
 layout_opt.add_argument('--layoutfile', metavar='FILE',
                         help='load a maze layout from FILE')
 layout_opt.add_argument('--layout', metavar='NAME',
@@ -193,6 +153,50 @@ layout_opt.add_argument('--filter', metavar='STRING',
                         help='retrict the pool of random layouts to those whose'
                         ' name contains STRING.'
                         ' Default: \'normal_without_dead_ends\'')
+
+game_settings.add_argument('--max-timeouts', type=int, default=5,
+                           dest='max_timeouts', help='maximum number of timeouts allowed (default: 5)')
+timeout_opt = game_settings.add_mutually_exclusive_group()
+timeout_opt.add_argument('--timeout', type=float, metavar="SEC",
+                         dest='timeout_length', help='time before timeout is triggered (default: 3 seconds)')
+timeout_opt.add_argument('--no-timeout', const=None, action='store_const',
+                         dest='timeout_length', help='run game with no timeouts')
+parser.set_defaults(timeout_length=3)
+
+viewer_settings = parser.add_argument_group('Viewer settings')
+viewer_settings.add_argument('--geometry', type=geometry_string, metavar='NxM',
+                    help='initial size of the game window')
+viewer_settings.add_argument('--fps', type=float, default=40,
+                    help='(approximate) number of frames per second in a graphical viewer')
+
+viewer_opt = viewer_settings.add_mutually_exclusive_group()
+viewer_opt.add_argument('--null', action='store_const', const='null',
+                        dest='viewer', help='use no viewer on stdout')
+viewer_opt.add_argument('--ascii', action='store_const', const='ascii',
+                        dest='viewer', help='use the ASCII viewer')
+viewer_opt.add_argument('--progress', action='store_const', const='progress',
+                        dest='viewer', help='use the progress viewer')
+viewer_opt.add_argument('--tk', action='store_const', const='tk',
+                        dest='viewer', help='use the tk viewer (default)')
+viewer_opt.add_argument('--tk-no-sync', action='store_const', const='tk-no-sync',
+                        dest='viewer', help='use the unsynchronised tk viewer')
+parser.set_defaults(viewer='tk')
+
+advanced_settings = parser.add_argument_group('Advanced settings')
+advanced_settings.add_argument('--reply-to', type=str, metavar='URL',
+                    dest='reply_to', help='Reply channel')
+
+publisher_opt = advanced_settings.add_mutually_exclusive_group()
+publisher_opt.add_argument('--publish', type=str, metavar='URL',
+                           dest='publish_to', help='publish to this zmq socket')
+publisher_opt.add_argument('--no-publish', const=False, action='store_const',
+                           dest='publish_to', help='do not publish')
+parser.set_defaults(publish_to="tcp://127.0.0.1:*")
+
+advanced_settings.add_argument('--controller', type=str, metavar='URL',
+                               default="tcp://127.0.0.1:*", help='open a controller on this zmq socket')
+advanced_settings.add_argument('--external-controller', const=True, action='store_const',
+                               help='force control by an external controller')
 
 parser.epilog = """\
 Team Specification:

--- a/pelita/scripts/pelita_main.py
+++ b/pelita/scripts/pelita_main.py
@@ -116,21 +116,21 @@ parser._positionals = parser.add_argument_group('Arguments')
 parser.add_argument('team_specs', help='teams (default: random)', nargs='*', default=None)
 
 parser._optionals = parser.add_argument_group('Options')
-parser.add_argument('--help', '-h', help='show this help message and exit',
+parser.add_argument('--help', '-h', help='Show this help message and exit.',
                     action='store_const', const=True)
-parser.add_argument('--version', help='show the version number and exit',
+parser.add_argument('--version', help='Show the version number and exit.',
                     action='store_const', const=True)
-parser.add_argument('--log', help='print debugging log information to'
-                    ' LOGFILE (default \'stderr\')',
+parser.add_argument('--log', help='Print debugging log information to'
+                    ' LOGFILE (default \'stderr\').',
                     metavar='LOGFILE', default=argparse.SUPPRESS, nargs='?')
-parser.add_argument('--dump', help='print game dumps to file (will be overwritten)'
-                    ' DUMPFILE (default \'pelita.dump\')',
+parser.add_argument('--dump', help='Print game dumps to file (will be overwritten)'
+                    ' DUMPFILE (default \'pelita.dump\').',
                     metavar='DUMPFILE', default=argparse.SUPPRESS, nargs='?')
-parser.add_argument('--replay', help='replay a dumped game'
-                    ' DUMPFILE (default \'pelita.dump\')',
+parser.add_argument('--replay', help='Replay a dumped game'
+                    ' DUMPFILE (default \'pelita.dump\').',
                     metavar='DUMPFILE', default=argparse.SUPPRESS, nargs='?')
 parser.add_argument('--dry-run', const=True, action='store_const',
-                    help='load players but do not actually play the game')
+                    help='Load players but do not actually play the game.')
 parser.add_argument('--list-layouts', action='store_const', const=True,
                     help='List all available layouts.')
 parser.add_argument('--list-teams', action="store_const", const=True,
@@ -140,62 +140,62 @@ parser.add_argument('--check-team', action="store_const", const=True,
 
 game_settings = parser.add_argument_group('Game settings')
 game_settings.add_argument('--rounds', type=int, default=300,
-                           help='maximum number of rounds to play')
+                           help='Maximum number of rounds to play.')
 game_settings.add_argument('--seed', type=int, metavar='SEED', default=None,
-                           help='fix random seed')
+                           help='Initialize the random number generator with SEED.')
 
 layout_opt = game_settings.add_mutually_exclusive_group()
 layout_opt.add_argument('--layoutfile', metavar='FILE',
-                        help='load a maze layout from FILE')
+                        help='Load a maze layout from FILE.')
 layout_opt.add_argument('--layout', metavar='NAME',
-                        help='load a maze layout by name')
+                        help='Load a maze layout by name.')
 layout_opt.add_argument('--filter', metavar='STRING', default='normal_without_dead_ends',
-                        help='restrict the pool of random layouts to those whose name contains STRING.'
+                        help='Restrict the pool of random layouts to those whose name contains STRING.'
                         ' Default: \'normal_without_dead_ends\'')
 
 game_settings.add_argument('--max-timeouts', type=int, default=5,
-                           dest='max_timeouts', help='maximum number of timeouts allowed (default: 5)')
+                           dest='max_timeouts', help='Maximum number of timeouts allowed (default: 5).')
 timeout_opt = game_settings.add_mutually_exclusive_group()
 timeout_opt.add_argument('--timeout', type=float, metavar="SEC",
-                         dest='timeout_length', help='time before timeout is triggered (default: 3 seconds)')
+                         dest='timeout_length', help='Time before timeout is triggered (default: 3 seconds).')
 timeout_opt.add_argument('--no-timeout', const=None, action='store_const',
-                         dest='timeout_length', help='run game with no timeouts')
+                         dest='timeout_length', help='Run game without timeouts.')
 parser.set_defaults(timeout_length=3)
 
 viewer_settings = parser.add_argument_group('Viewer settings')
 viewer_settings.add_argument('--geometry', type=geometry_string, metavar='NxM',
-                    help='initial size of the game window')
+                    help='Set initial size of the game window.')
 viewer_settings.add_argument('--fps', type=float, default=40,
-                    help='(approximate) number of frames per second in a graphical viewer')
+                    help='Set (approximate) number of frames per second in a graphical viewer.')
 
 viewer_opt = viewer_settings.add_mutually_exclusive_group()
 viewer_opt.add_argument('--null', action='store_const', const='null',
-                        dest='viewer', help='use no viewer on stdout')
+                        dest='viewer', help='Use no viewer on stdout.')
 viewer_opt.add_argument('--ascii', action='store_const', const='ascii',
-                        dest='viewer', help='use the ASCII viewer')
+                        dest='viewer', help='Use the ASCII viewer.')
 viewer_opt.add_argument('--progress', action='store_const', const='progress',
-                        dest='viewer', help='use the progress viewer')
+                        dest='viewer', help='Use the progress viewer.')
 viewer_opt.add_argument('--tk', action='store_const', const='tk',
-                        dest='viewer', help='use the tk viewer (default)')
+                        dest='viewer', help='Use the tk viewer (default).')
 viewer_opt.add_argument('--tk-no-sync', action='store_const', const='tk-no-sync',
-                        dest='viewer', help='use the unsynchronised tk viewer')
+                        dest='viewer', help='Use the unsynchronised tk viewer.')
 parser.set_defaults(viewer='tk')
 
 advanced_settings = parser.add_argument_group('Advanced settings')
 advanced_settings.add_argument('--reply-to', type=str, metavar='URL',
-                    dest='reply_to', help='Reply channel')
+                    dest='reply_to', help='Communicate the result of the game on this channel.')
 
 publisher_opt = advanced_settings.add_mutually_exclusive_group()
 publisher_opt.add_argument('--publish', type=str, metavar='URL',
-                           dest='publish_to', help='publish to this zmq socket')
+                           dest='publish_to', help='Publish the game to this zmq socket.')
 publisher_opt.add_argument('--no-publish', const=False, action='store_const',
-                           dest='publish_to', help='do not publish')
+                           dest='publish_to', help='Do not publish.')
 parser.set_defaults(publish_to="tcp://127.0.0.1:*")
 
 advanced_settings.add_argument('--controller', type=str, metavar='URL',
-                               default="tcp://127.0.0.1:*", help='open a controller on this zmq socket')
+                               default="tcp://127.0.0.1:*", help='Channel for controlling the game.')
 advanced_settings.add_argument('--external-controller', const=True, action='store_const',
-                               help='force control by an external controller')
+                               help='Force control by an external controller.')
 
 parser.epilog = """\
 Team Specification:

--- a/pelita/scripts/pelita_main.py
+++ b/pelita/scripts/pelita_main.py
@@ -150,7 +150,7 @@ layout_opt.add_argument('--layout', metavar='NAME',
                         " 'list' return a list of available names")
 layout_opt.add_argument('--filter', metavar='STRING',
                         default='normal_without_dead_ends',
-                        help='retrict the pool of random layouts to those whose'
+                        help='restrict the pool of random layouts to those whose'
                         ' name contains STRING.'
                         ' Default: \'normal_without_dead_ends\'')
 


### PR DESCRIPTION
Small improvement for the pelita cli help that should make it a little easier to ignore the advanced settings.

From this

    Options:
    --help, -h            show this help message and exit
    --version             show the version number and exit
    --log [LOGFILE]       print debugging log information to LOGFILE (default
                            'stderr')
    --dump [DUMPFILE]     print game dumps to file (will be overwritten)
                            DUMPFILE (default 'pelita.dump')
    --replay [DUMPFILE]   replay a dumped game DUMPFILE (default 'pelita.dump')
    --rounds ROUNDS       maximum number of rounds to play
    --fps FPS             (approximate) number of frames per second in a
                            graphical viewer
    --seed SEED           fix random seed
    --geometry NxM        initial size of the game window
    --dry-run             load players but do not actually play the game
    --max-timeouts MAX_TIMEOUTS
                            maximum number of timeouts allowed (default: 5)
    --list-teams          Print the names of the included default teams.
    --check-team          Check that the team is valid (on first sight) and
                            print its name.
    --timeout SEC         time before timeout is triggered (default: 3 seconds)
    --no-timeout          run game with no timeouts
    --reply-to URL        Reply channel
    --publish URL         publish to this zmq socket
    --no-publish          do not publish
    --ascii               use the ASCII viewer
    --null                use the /dev/null viewer
    --progress            use the progress viewer
    --tk                  use the tk viewer (default)
    --tk-no-sync          use the unsynchronised tk viewer
    --layoutfile FILE     load a maze layout from FILE
    --layout NAME         load a maze layout by name. If NAME is 'list' return a
                            list of available names
    --filter STRING       retrict the pool of random layouts to those whose name
                            contains STRING. Default: 'normal_without_dead_ends'

    Controller:
    --controller URL      open a controller on this zmq socket
    --external-controller
                            force control by an external controller


to

    Options:
    --help, -h            Show this help message and exit.
    --version             Show the version number and exit.
    --log [LOGFILE]       Print debugging log information to LOGFILE (default
                            'stderr').
    --dump [DUMPFILE]     Print game dumps to file (will be overwritten)
                            DUMPFILE (default 'pelita.dump').
    --replay [DUMPFILE]   Replay a dumped game DUMPFILE (default 'pelita.dump').
    --dry-run             Load players but do not actually play the game.
    --list-layouts        List all available layouts.
    --list-teams          Print the names of the included default teams.
    --check-team          Check that the team is valid (on first sight) and
                            print its name.

    Game settings:
    --rounds ROUNDS       Maximum number of rounds to play.
    --seed SEED           Initialize the random number generator with SEED.
    --layoutfile FILE     Load a maze layout from FILE.
    --layout NAME         Load a maze layout by name.
    --filter STRING       Restrict the pool of random layouts to those whose
                            name contains STRING. Default:
                            'normal_without_dead_ends'
    --max-timeouts MAX_TIMEOUTS
                            Maximum number of timeouts allowed (default: 5).
    --timeout SEC         Time before timeout is triggered (default: 3 seconds).
    --no-timeout          Run game without timeouts.

    Viewer settings:
    --geometry NxM        Set initial size of the game window.
    --fps FPS             Set (approximate) number of frames per second in a
                            graphical viewer.
    --null                Use no viewer on stdout.
    --ascii               Use the ASCII viewer.
    --progress            Use the progress viewer.
    --tk                  Use the tk viewer (default).
    --tk-no-sync          Use the unsynchronised tk viewer.

    Advanced settings:
    --reply-to URL        Communicate the result of the game on this channel.
    --publish URL         Publish the game to this zmq socket.
    --no-publish          Do not publish.
    --controller URL      Channel for controlling the game.
    --external-controller
                            Force control by an external controller.
