### PR TITLE
BF: Decouples the Tk process from its calling process.

### DIFF
--- a/pelita/libpelita.py
+++ b/pelita/libpelita.py
@@ -417,7 +417,11 @@ def run_external_viewer(subscribe_sock, controller, geometry, delay):
     _logger.debug("Executing: %r", external_call)
     # os.setsid will keep the viewer from closing when the main process exits
     # a better solution might be to decouple the viewer from the main process
-    return subprocess.Popen(external_call, preexec_fn=os.setsid)
+    if _mswindows:
+        p = subprocess.Popen(external_call, creationflags=subprocess.CREATE_NEW_PROCESS_GROUP)
+    else:
+        p = subprocess.Popen(external_call, preexec_fn=os.setsid)
+    return p
 
 @contextlib.contextmanager
 def autoclose_subprocesses(subprocesses):

--- a/pelita/libpelita.py
+++ b/pelita/libpelita.py
@@ -415,7 +415,9 @@ def run_external_viewer(subscribe_sock, controller, geometry, delay):
                      '-m',
                      tkviewer] + viewer_args
     _logger.debug("Executing: %r", external_call)
-    return subprocess.Popen(external_call)
+    # os.setsid will keep the viewer from closing when the main process exits
+    # a better solution might be to decouple the viewer from the main process
+    return subprocess.Popen(external_call, preexec_fn=os.setsid)
 
 @contextlib.contextmanager
 def autoclose_subprocesses(subprocesses):


### PR DESCRIPTION
This means Tk will not be automatically closed when the main process exits.

Lacks proper testing on Windows, so do not merge yet. The PR is mostly for reference and as a quick fix for #451 (mostly to allow for playing proper tournaments again. see: #456).

A better solution would explicitly have the supervising process take control of Tk (for example by running the viewer manually before starting the game). For the tournament this could also become an improvement: Having one Tk window for all the games that never closes.
