### PR TITLE
[RULE CHANGE] End the game immediately once all food for a team has been eaten.

### DIFF
--- a/pelita/game_master.py
+++ b/pelita/game_master.py
@@ -395,14 +395,15 @@ class GameMaster:
             self.game_state["finished"] = True
             return True
 
-        # If the round has finished, we may check, if we can end the game
+        # If the round has finished, we can check, if we can end the game
         if self.game_state["bot_id"] is None:
             if self.game_state["round_index"] >= self.game_time:
                 self.game_state["finished"] = True
-            else:
-                for to_eat, eaten in zip(self.game_state["food_to_eat"], self.game_state["food_count"]):
-                    if to_eat == eaten:
-                        self.game_state["finished"] = True
+
+        # If one of the teams has eaten all the food, we finish immediately
+        for to_eat, eaten in zip(self.game_state["food_to_eat"], self.game_state["food_count"]):
+            if to_eat == eaten:
+                self.game_state["finished"] = True
 
         if self.game_state["finished"]:
             if self.universe.teams[0].score > self.universe.teams[1].score:

--- a/test/test_game_master.py
+++ b/test/test_game_master.py
@@ -331,11 +331,13 @@ class TestGame:
         test_sixth_round = (
             """ ######
                 #  0 #
-                #1   #
+                #.1  #
                 ###### """)
         print(gm.universe.pretty)
+        # The game will have finished after bot 0 has eaten the pellet
         assert create_TestUniverse(test_sixth_round,
             black_score=gm.universe.KILLPOINTS, white_score=gm.universe.KILLPOINTS) == gm.universe
+        assert gm.game_state['finished'] is True
 
         teams = [SimpleTeam(SteppingPlayer('>-v>>>')), SimpleTeam(SteppingPlayer('<<-<<<'))]
         # now play the full game
@@ -344,7 +346,7 @@ class TestGame:
         test_sixth_round = (
             """ ######
                 #  0 #
-                #1   #
+                #.1  #
                 ###### """)
         assert create_TestUniverse(test_sixth_round,
             black_score=gm.universe.KILLPOINTS, white_score=gm.universe.KILLPOINTS) == gm.universe
@@ -786,36 +788,36 @@ class TestGame:
         gm.play_round()
         # second call works
         assert gm.universe.bots[0].current_pos == (6,1)
-        assert gm.universe.bots[1].current_pos == (1,2)
+        assert gm.universe.bots[1].current_pos == (2,2)
         assert gm.game_state["round_index"] == 3
-        assert gm.game_state["bot_id"] is None
+        assert gm.game_state["bot_id"] == 0
         assert gm.game_state["finished"] == True
-        assert gm.game_state["team_wins"] == None
-        assert gm.game_state["game_draw"] == True
+        assert gm.game_state["team_wins"] == 0
+        assert gm.game_state["game_draw"] == None
 
-        # Game finished because all food was eaten
-        # team 0 finished first but the round was played regularly to the end
-        # (hence round_index == 3 and bot_id is None)
-
-        # nothing happens anymore
-        gm.play_round()
-        assert gm.universe.bots[0].current_pos == (6,1)
-        assert gm.universe.bots[1].current_pos == (1,2)
-        assert gm.game_state["round_index"] == 3
-        assert gm.game_state["bot_id"] is None
-        assert gm.game_state["finished"] == True
-        assert gm.game_state["team_wins"] == None
-        assert gm.game_state["game_draw"] == True
+        # Game finished immediately once all food for one group was eaten
+        # team 0 finished first and the round was NOT played regularly to the end
+        # (hence round_index == 3 and bot_id == 0)
 
         # nothing happens anymore
         gm.play_round()
         assert gm.universe.bots[0].current_pos == (6,1)
-        assert gm.universe.bots[1].current_pos == (1,2)
+        assert gm.universe.bots[1].current_pos == (2,2)
         assert gm.game_state["round_index"] == 3
-        assert gm.game_state["bot_id"] is None
+        assert gm.game_state["bot_id"] == 0
         assert gm.game_state["finished"] == True
-        assert gm.game_state["team_wins"] == None
-        assert gm.game_state["game_draw"] == True
+        assert gm.game_state["team_wins"] == 0
+        assert gm.game_state["game_draw"] == None
+
+        # nothing happens anymore
+        gm.play_round()
+        assert gm.universe.bots[0].current_pos == (6,1)
+        assert gm.universe.bots[1].current_pos == (2,2)
+        assert gm.game_state["round_index"] == 3
+        assert gm.game_state["bot_id"] == 0
+        assert gm.game_state["finished"] == True
+        assert gm.game_state["team_wins"] == 0
+        assert gm.game_state["game_draw"] == None
 
     def test_kill_count(self):
         test_start = (


### PR DESCRIPTION
It has been told (wrongly) in the presentation for ages but since it is easier to change code than to update a line in the presentation, we’ll now make it right.

Previously, the game would still finish the current round, even though all food had been eaten by one of the players (or both players).
The new rule will arguably be an even bigger advantage for the starting team but on the other hand it will also simplify the code for all parties since now the assertion

    assert len(food) > 0

is always true (for food ∈  {team_food, enemy_food}).
