### PR TITLE
Make Graph a subclass of Userdict

### DIFF
--- a/pelita/graph.py
+++ b/pelita/graph.py
@@ -1,7 +1,7 @@
 """ Basic graph module """
 
 import heapq
-from collections import deque
+from collections import deque, UserDict
 
 
 class NoPathException(Exception):
@@ -96,7 +96,7 @@ def iter_adjacencies(initial, adjacencies_for_pos):
         reached.add(pos)
         yield (pos, legal_moves)
 
-class Graph(dict):
+class Graph(UserDict):
     """ Adjacency list [1] representation of a Maze.
 
     The `Graph` is mostly a wrapper for a `dict`. Given a position,
@@ -106,6 +106,7 @@ class Graph(dict):
 
     """
     def __init__(self, *args):
+        super().__init__()
         if len(args) == 1:
             adjacencies = args[0]
             self.update(adjacencies)
@@ -124,6 +125,10 @@ class Graph(dict):
 
         self.update(it for it in iter_adjacencies([initial], lambda pos: legal_neighbors(maze, pos)))
 
+    def __copy__(self):
+        # needed to override the default __copy__ dict implementation and to
+        # return a Graph instance
+        return self.__class__(self.data)
 
     def pos_within(self, position, distance):
         """ Positions within a certain distance.


### PR DESCRIPTION
Given that moving Graph to be its own class (right thing to do) requires
some work at the moment, we make it a subclass of UserDict, so that at
least we can properly implement `__copy__` This is needed because
the default `dict.copy()` behaviour is shortcutting `__copy__`.
Anyway, this mess needs to be cleaned up and Graph should be its own
thing.