### PR TITLE
Layout passed to setup_test_game should always be a string

### DIFF
--- a/pelita/utils/__init__.py
+++ b/pelita/utils/__init__.py
@@ -3,7 +3,8 @@ import random
 from ..player.team import create_layout, Game, bots_from_layout
 from ..graph import Graph
 
-def setup_test_game(*, layout, game=None, is_blue=True, round=None, score=None, seed=None):
+def setup_test_game(*, layout, game=None, is_blue=True, round=None, score=None, seed=None,
+                    food=None, bots=None, enemy=None):
     """Return a game object given a layout.
 
     The returned Game instance can be passed to a move function to test its return value.
@@ -11,11 +12,7 @@ def setup_test_game(*, layout, game=None, is_blue=True, round=None, score=None, 
     if game is not None:
         raise RuntimeError("Re-using an old game is not implemented yet.")
 
-    if isinstance(layout, str):
-        layout = create_layout(layout)
-
-#    elif not isinstance(layout, Layout):
-#        raise TypeError("layout needs to be of type Layout or str.")
+    layout = create_layout(layout, food=food, bots=bots, enemy=enemy)
 
     rng = [random.Random(seed) for _ in range(4)]
     if score is None:

--- a/test/test_team.py
+++ b/test/test_team.py
@@ -78,7 +78,7 @@ class TestLayout:
         layout = create_layout(layout_str)
         assert layout.bots == [(1, 1), (1, 1)]
         assert layout.enemy ==  [(1, 1), (1, 1)]
-        setup_test_game(layout=layout)
+        setup_test_game(layout=layout_str)
 
     def test_define_after(self):
         layout = create_layout(self.layout, food=[(1, 1)], bots=[None, None], enemy=None)


### PR DESCRIPTION
To avoid confusion there should be only one way to pass the layout to `setup_test_game`. It's easiest to pass this always as a string and add the `food`, `bots`, `enemy` parameter as arguments to `setup_test_game`.