### PR TITLE
ENH: Do not print output for flite.

### DIFF
--- a/pelita/tournament/tournament.py
+++ b/pelita/tournament/tournament.py
@@ -139,7 +139,7 @@ class Config:
             cmd = shlex.split(self.speaker)
             full_cmd = [*cmd, tmp.name]
             try:
-                festival = subprocess.check_call(full_cmd)
+                festival = subprocess.check_call(full_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
             except FileNotFoundError:
                 # If we could not find the executable then there is not need to keep on trying.
                 # Disabling speak. (Although self.say() will still attempt to speak.)


### PR DESCRIPTION
Fixes #521 (crudely).