### PR TITLE
ENH: Make state explicit in move

### DIFF
--- a/pelita/player/team.py
+++ b/pelita/player/team.py
@@ -58,7 +58,7 @@ class Team(AbstractTeam):
 
         #: Storage for the team state
         self._team_state = None
-        self._team_game = Game([None, None])
+        self._team_game = [None, None]
 
         #: Storage for the random generator
         self._bot_random = [None] * len(universe.bots)
@@ -137,8 +137,8 @@ class Team(AbstractTeam):
             mybot._track = self._bot_track[idx]
             mybot._eaten = self._bot_eaten[idx]
 
-        self._team_game.team[:] = team
-        move, state = self._team_move(turn, self._team_game, self._team_state)
+        self._team_game = team
+        move, state = self._team_move(self._team_game[turn], self._team_state)
 
         self._bot_eaten[turn] = False
         # restore the team state
@@ -153,69 +153,6 @@ class Team(AbstractTeam):
         return "Team(%r, %s)" % (self.team_name, repr(self._team_move))
 
 
-# @dataclass
-class Game:
-    def __init__(self, team):
-        self.team = team
-
-    def _repr_html_(self):
-        bot = self.team[0]
-        width = max(bot.walls)[0] + 1
-        height = max(bot.walls)[1] + 1
-
-        with StringIO() as out:
-            out.write("<table>")
-            for y in range(height):
-                out.write("<tr>")
-                for x in range(width):
-                    if (x, y) in bot.walls:
-                        bg = 'style="background-color: {}"'.format(
-                            "rgb(94, 158, 217)" if x < width // 2 else
-                            "rgb(235, 90, 90)")
-                    else:
-                        bg = ""
-                    out.write("<td %s>" % bg)
-                    if (x, y) in bot.walls: out.write("#")
-                    if (x, y) in bot.food: out.write('<span style="color: rgb(247, 150, 213)">●</span>')
-                    if (x, y) in bot.enemy[0].food: out.write('<span style="color: rgb(247, 150, 213)">●</span>')
-                    for idx in range(4):
-                        if bot._bots[idx].position == (x, y): out.write(str(idx))
-                    out.write("</td>")
-                out.write("</tr>")
-            out.write("</table>")
-            return out.getvalue()
-
-    def __str__(self):
-        bot = self.team[0]
-        width = max(bot.walls)[0] + 1
-        height = max(bot.walls)[1] + 1
-
-        header = ("{blue}{you_blue} vs {red}{you_red}.\n" +
-            "Playing on {col} side. Round: {round}, score: {blue_score}:{red_score}. " +
-            "timeouts: {blue_timeouts}:{red_timeouts}").format(
-            blue=bot._bots[0].team_name,
-            red=bot._bots[1].team_name,
-            round=bot.round,
-            blue_score=bot._bots[0].score,
-            red_score=bot._bots[1].score,
-            col="blue" if bot.is_blue else "red",
-            you_blue=" (you)" if bot.is_blue else "",
-            you_red=" (you)" if not bot.is_blue else "",
-            blue_timeouts=bot._bots[0].timeout_count,
-            red_timeouts=bot._bots[1].timeout_count,
-        )
-
-        with StringIO() as out:
-            out.write(header)
-
-            layout = Layout(walls=bot.walls[:],
-                            food=bot.food + bot.enemy[0].food,
-                            bots=[b.position for b in self.team],
-                            enemy=[e.position for e in bot.enemy])
-
-            out.write(str(layout))
-            return out.getvalue()
-
 def create_homezones(width, height):
     return [
         [(x, y) for x in range(0, width // 2)
@@ -223,7 +160,6 @@ def create_homezones(width, height):
         [(x, y) for x in range(width // 2, width)
                 for y in range(0, height)]
     ]
-
 
 class Bot:
     def __init__(self, *, bot_index,
@@ -283,6 +219,16 @@ class Bot:
            return [self._bots[1], self._bots[3]]
 
     @property
+    def turn(self):
+        """ The turn of our bot. """
+        return self.bot_index // 2
+
+    @property
+    def other(self):
+        """ The other bot in our team. """
+        return self._team[1 - self.turn]
+
+    @property
     def enemy(self):
         """ The list of enemy bots
         """
@@ -330,6 +276,71 @@ class Bot:
     def track(self):
         """ The previous positions of this bot including the current one. """
         return self._track
+
+    def _repr_html_(self):
+        """ Jupyter-friendly representation. """
+        bot = self
+        width = max(bot.walls)[0] + 1
+        height = max(bot.walls)[1] + 1
+
+        with StringIO() as out:
+            out.write("<table>")
+            for y in range(height):
+                out.write("<tr>")
+                for x in range(width):
+                    if (x, y) in bot.walls:
+                        bg = 'style="background-color: {}"'.format(
+                            "rgb(94, 158, 217)" if x < width // 2 else
+                            "rgb(235, 90, 90)")
+                    else:
+                        bg = ""
+                    out.write("<td %s>" % bg)
+                    if (x, y) in bot.walls: out.write("#")
+                    if (x, y) in bot.food: out.write('<span style="color: rgb(247, 150, 213)">●</span>')
+                    if (x, y) in bot.enemy[0].food: out.write('<span style="color: rgb(247, 150, 213)">●</span>')
+                    for idx in range(4):
+                        if bot._bots[idx].position == (x, y):
+                            if idx == self.bot_index:
+                                out.write('<b>' + str(idx) + '</b>')
+                            else:
+                                out.write(str(idx))
+                    out.write("</td>")
+                out.write("</tr>")
+            out.write("</table>")
+            return out.getvalue()
+
+    def __str__(self):
+        bot = self
+        width = max(bot.walls)[0] + 1
+        height = max(bot.walls)[1] + 1
+
+        header = ("{blue}{you_blue} vs {red}{you_red}.\n" +
+            "Playing on {col} side. Current turn: {turn}. Round: {round}, score: {blue_score}:{red_score}. " +
+            "timeouts: {blue_timeouts}:{red_timeouts}").format(
+            blue=bot._bots[0].team_name,
+            red=bot._bots[1].team_name,
+            turn=bot.turn,
+            round=bot.round,
+            blue_score=bot._bots[0].score,
+            red_score=bot._bots[1].score,
+            col="blue" if bot.is_blue else "red",
+            you_blue=" (you)" if bot.is_blue else "",
+            you_red=" (you)" if not bot.is_blue else "",
+            blue_timeouts=bot._bots[0].timeout_count,
+            red_timeouts=bot._bots[1].timeout_count,
+        )
+
+        with StringIO() as out:
+            out.write(header)
+
+            layout = Layout(walls=bot.walls[:],
+                            food=bot.food + bot.enemy[0].food,
+                            bots=[b.position for b in bot._team],
+                            enemy=[e.position for e in bot.enemy])
+
+            out.write(str(layout))
+            return out.getvalue()
+
 
 def _rebuild_universe(bots):
     """ Rebuilds a universe from the list of bots.

--- a/pelita/player/team.py
+++ b/pelita/player/team.py
@@ -58,7 +58,7 @@ class Team(AbstractTeam):
 
         #: Storage for the team state
         self._team_state = None
-        self._team_game = Game([None, None], self._team_state)
+        self._team_game = Game([None, None])
 
         #: Storage for the random generator
         self._bot_random = [None] * len(universe.bots)
@@ -138,11 +138,11 @@ class Team(AbstractTeam):
             mybot._eaten = self._bot_eaten[idx]
 
         self._team_game.team[:] = team
-        move = self._team_move(turn, self._team_game)
+        move, state = self._team_move(turn, self._team_game, self._team_state)
 
         self._bot_eaten[turn] = False
         # restore the team state
-        self._team_state = self._team_game.state
+        self._team_state = state
 
         return {
             "move": move,
@@ -155,9 +155,8 @@ class Team(AbstractTeam):
 
 # @dataclass
 class Game:
-    def __init__(self, team, state):
+    def __init__(self, team):
         self.team = team
-        self.state = state
 
     def _repr_html_(self):
         bot = self.team[0]

--- a/pelita/utils/__init__.py
+++ b/pelita/utils/__init__.py
@@ -1,13 +1,13 @@
 import random
 
-from ..player.team import create_layout, Game, bots_from_layout
+from ..player.team import create_layout, bots_from_layout
 from ..graph import Graph
 
 def setup_test_game(*, layout, game=None, is_blue=True, round=None, score=None, seed=None,
                     food=None, bots=None, enemy=None):
-    """Return a game object given a layout.
+    """Returns the first bot object given a layout.
 
-    The returned Game instance can be passed to a move function to test its return value.
+    The returned Bot instance can be passed to a move function to test its return value.
     The layout is a string that can be passed to create_layout."""
     if game is not None:
         raise RuntimeError("Re-using an old game is not implemented yet.")
@@ -24,5 +24,4 @@ def setup_test_game(*, layout, game=None, is_blue=True, round=None, score=None, 
     else:
         team = [bots[1], bots[3]]
 
-    game = Game(team)
-    return game
+    return team[0]

--- a/pelita/utils/__init__.py
+++ b/pelita/utils/__init__.py
@@ -24,6 +24,5 @@ def setup_test_game(*, layout, game=None, is_blue=True, round=None, score=None, 
     else:
         team = [bots[1], bots[3]]
 
-    state = None
-    game = Game(team, state)
+    game = Game(team)
     return game

--- a/test/test_team.py
+++ b/test/test_team.py
@@ -4,11 +4,10 @@ from pelita.game_master import GameMaster
 from pelita.player.team import Team, split_layout_str, create_layout, _rebuild_universe, bots_from_universe
 from pelita.utils import setup_test_game
 
-def stopping(turn, game, state):
+def stopping(bot, state):
     return (0, 0), state
 
-def randomBot(turn, game, state):
-    bot = game.team[turn]
+def randomBot(bot, state):
     legal = bot.legal_moves[:]
     return bot.random.choice(legal), state
 
@@ -179,12 +178,12 @@ class TestStoppingTeam:
     @staticmethod
     def round_counting():
         storage_copy = {}
-        def inner(turn, game, state):
+        def inner(bot, state):
             print(state)
             if state is None:
                 state = {}
-            state[turn] = state.get(turn, 0) + 1
-            storage_copy['rounds'] = state[turn]
+            state[bot.turn] = state.get(bot.turn, 0) + 1
+            storage_copy['rounds'] = state[bot.turn]
             print(state)
             return (0, 0), state
         inner._storage = storage_copy
@@ -243,20 +242,20 @@ class TestRebuild:
         #0#.   .# 1#
         ############
         """
-        game = setup_test_game(layout=layout, is_blue=True)
-        assert game.team[0].position == (1, 1)
-        assert game.team[1].position == (10, 1)
-        assert game.team[0].enemy[0].position is None
-        assert game.team[0].enemy[1].position is None
+        bot = setup_test_game(layout=layout, is_blue=True)
+        assert bot._team[0].position == (1, 1)
+        assert bot._team[1].position == (10, 1)
+        assert bot._team[0].enemy[0].position is None
+        assert bot._team[0].enemy[1].position is None
 
-        uni, state = _rebuild_universe(game.team[0]._bots)
+        uni, state = _rebuild_universe(bot._bots)
         assert uni.bots[0].current_pos == (1, 1)
         assert uni.bots[2].current_pos == (10, 1)
         assert uni.bots[1].current_pos == (9, 1)
         assert uni.bots[3].current_pos == (10, 1)
 
         with pytest.raises(ValueError):
-            uni, state = _rebuild_universe(game.team[0]._bots[0:2])
+            uni, state = _rebuild_universe(bot._bots[0:2])
 
         bots = bots_from_universe(uni, [None] * 4, round=0,
                                                    team_name=state['team_name'],
@@ -267,9 +266,9 @@ class TestRebuild:
 
 class TestTrack:
     def test_track(self):
-        def trackingBot(turn, game, state):
-            bot = game.team[turn]
-            other = game.team[1-turn]
+        def trackingBot(bot, state):
+            turn = bot.turn
+            other = bot.other
             if bot.round == 0 and turn == 0:
                 assert bot.track[0] == bot.position
                 state = {}
@@ -288,7 +287,7 @@ class TestTrack:
             assert bot.track[0] == bot._initial_position
             assert bot.track == state[turn]['track'] # bot.round * 2 + 1 + turn
             assert bot.track[-1] == bot.position
-            return randomBot(turn, game, state)
+            return randomBot(bot, state)
 
         layout = """
         ############


### PR DESCRIPTION
state is now an extra argument to the move function. In order to
properly update state, the move function now must return both the
move tuple and an updated state.:

    move(bot, state) -> (move, state)

Additionally, `move` receives a `Bot` instance of the current bot which is equivalent to the previous `game.team[turn]`.

Concept branch for #520 which requires additions (and discussions?) in https://github.com/ASPP/pelita_template before we should merge it. (Should we manually update the 2018 players so that they still run for tests or provide a compatibility mode?)