### PR TITLE
ENH: Store the tournament output next to the dumpfile.

### DIFF
--- a/pelita/scripts/pelita_main.py
+++ b/pelita/scripts/pelita_main.py
@@ -335,6 +335,7 @@ def main():
             "layout_name": layout_name,
             "layout_string": layout_string,
             "seed": args.seed,
+            "dump": dump,
         }
 
         viewers = []

--- a/pelita/tournament/tournament.py
+++ b/pelita/tournament/tournament.py
@@ -5,6 +5,7 @@ import builtins
 import io
 import json
 import os
+from pathlib import Path
 import random
 import re
 import shlex
@@ -258,12 +259,19 @@ def play_game_with_config(config, teams):
 
     seed = str(random.randint(0, sys.maxsize))
 
-    return libpelita.call_pelita([config.team_spec(team1), config.team_spec(team2)],
-                                  rounds=config.rounds,
-                                  filter=config.filter,
-                                  viewer=config.viewer,
-                                  dump=dump,
-                                  seed=seed)
+    res = libpelita.call_pelita([config.team_spec(team1), config.team_spec(team2)],
+                                rounds=config.rounds,
+                                filter=config.filter,
+                                viewer=config.viewer,
+                                dump=dump,
+                                seed=seed)
+
+    if dump:
+        (_final_state, stdout, stderr) = res
+        Path(dump + '.out').write_text(stdout)
+        Path(dump + '.err').write_text(stderr)
+
+    return res
 
 
 def start_match(config, teams, shuffle=False):


### PR DESCRIPTION
Quick fix for #519

Stdout and stderr are captured in `call_pelita` but are just written to a variable that is then returned by `call_pelita`. So far, the tournament script would only present the stdout and stderr to the user, if `call_pelita` itself did not return a meaningful result. In the case of a player crashing, this would just trigger a normal disconnect and the other team would simply win, so it was never considered to be a situation where the tournament host would need to investigate.

This adds a fix to the tournament that will store stdout and stderr of `call_pelita` directly in a file, *after* `call_pelita` has run.

We could additionally add the feature that `call_pelita` writes directly to a file (or log), if requested, but unless we need live updates (`tail -f`), this fix should suffice.