### PR TITLE
BF: Flush the pelita.dump after writing.

### DIFF
--- a/pelita/viewer.py
+++ b/pelita/viewer.py
@@ -103,7 +103,11 @@ class DumpingViewer(AbstractViewer):
     def _send(self, message):
         as_json = json.dumps(message)
         self.stream.write(as_json)
-        self.stream.write("\x04")
+        # We use 0x04 (EOT) as a separator between the events.
+        # The additional newline is for improved readability
+        # and should be ignored by the Python json reader.
+        self.stream.write("\x04\n")
+        self.stream.flush()
 
     def set_initial(self, universe, game_state):
         message = {"__action__": "set_initial",


### PR DESCRIPTION
Fixes #518 .

When the tournament runs a game, it will bind a `zmq.PAIR` and then `Popen` a call to `pelita` with the URI of the socket. Once the game has finished, `pelita` will send the result on the socket and once the tournament has read the result, it will send a SIGTERM to `pelita`. This may result in files not being properly written.
The flush should fix the problem. (The result is only sent *after* the dump has been written.)

Two improvements are possible:
1. Make the `zmq.PAIR` bidirectional and tell `pelita` to properly shut down via this channel.
2. Write the dump file in the tournament and not in `pelita`. (The `zmq.PAIR` sends all dump data anyway.)