### PR TITLE
ENH: Clean up the logging a little.

### DIFF
--- a/pelita/libpelita.py
+++ b/pelita/libpelita.py
@@ -17,7 +17,7 @@ import zmq
 
 from .simplesetup import RemoteTeamPlayer, SimpleController, SimplePublisher, SimpleServer
 
-_logger = logging.getLogger("pelita.libpelita")
+_logger = logging.getLogger(__name__)
 _mswindows = (sys.platform == "win32")
 
 TeamSpec = namedtuple("TeamSpec", ["module", "address"])

--- a/pelita/scripts/pelita_main.py
+++ b/pelita/scripts/pelita_main.py
@@ -15,7 +15,7 @@ from pelita import libpelita
 
 # silence stupid warnings from logging module
 logging.root.manager.emittedNoHandlerWarning = 1
-_logger = logging.getLogger("pelitagame")
+_logger = logging.getLogger(__name__)
 
 class ReplayPublisher:
     def __init__(self, publish_sock, replayfile):

--- a/pelita/scripts/pelita_player.py
+++ b/pelita/scripts/pelita_player.py
@@ -19,7 +19,7 @@ import zmq
 import pelita
 from ..player.team import new_style_team
 
-_logger = logging.getLogger("pelita.scripts.pelita_player")
+_logger = logging.getLogger(__name__)
 
 class MalformedBuiltinTeam(ValueError):
     pass

--- a/pelita/scripts/pelita_tkviewer.py
+++ b/pelita/scripts/pelita_tkviewer.py
@@ -35,7 +35,7 @@ parser.add_argument('--version', help='show the version number and exit',
                     action='store_const', const=True)
 parser.add_argument('--log', help='print debugging log information to'
                                   ' LOGFILE (default \'stderr\')',
-                    metavar='LOGFILE', default=argparse.SUPPRESS, nargs='?')
+                    metavar='LOGFILE', const='-', nargs='?')
 
 def main():
     args = parser.parse_args()
@@ -47,10 +47,9 @@ def main():
 
         sys.exit(0)
 
-    try:
-        pelita.utils.start_logging(args.log)
-    except AttributeError:
-        pass
+
+    if args.log:
+        pelita.libpelita.start_logging(args.log)
 
     tkargs = {
         'address': args.subscribe_sock,

--- a/pelita/scripts/pelita_tournament.py
+++ b/pelita/scripts/pelita_tournament.py
@@ -19,19 +19,6 @@ from ..tournament import tournament
 from ..tournament.tournament import Config, State
 
 
-def start_logging(filename):
-    if filename:
-        hdlr = logging.FileHandler(filename, mode='w')
-    else:
-        hdlr = logging.StreamHandler()
-    logger = logging.getLogger('pelita-tournament')
-    FORMAT = '[%(relativeCreated)06d %(name)s:%(levelname).1s][%(funcName)s] %(message)s'
-    formatter = logging.Formatter(FORMAT)
-    hdlr.setFormatter(formatter)
-    logger.addHandler(hdlr)
-    logger.setLevel(logging.DEBUG)
-
-
 def create_directory(prefix):
     for suffix in itertools.count(0):
         name = '{}-{:02d}'.format(prefix, suffix)
@@ -229,7 +216,7 @@ def main():
         config.tournament_log_file = logfile #os.fdopen(fd, 'w')
 
         try:
-            start_logging(os.path.join(storage_folder, 'tournament.log'))
+            libpelita.start_logging(os.path.join(storage_folder, 'tournament.log'))
         except AttributeError:
             pass
 

--- a/pelita/simplesetup.py
+++ b/pelita/simplesetup.py
@@ -38,7 +38,7 @@ from .datamodel import CTFUniverse
 from .game_master import GameMaster, PlayerDisconnected, PlayerTimeout
 from .viewer import AbstractViewer
 
-_logger = logging.getLogger("pelita.simplesetup")
+_logger = logging.getLogger(__name__)
 
 class ZMQUnreachablePeer(Exception):
     """ Raised when ZMQ cannot send a message (connection may have been lost). """

--- a/pelita/tournament/tournament.py
+++ b/pelita/tournament/tournament.py
@@ -20,7 +20,7 @@ from pelita import libpelita
 from . import roundrobin
 from . import komode
 
-_logger = libpelita.logging.getLogger("pelita-tournament")
+_logger = libpelita.logging.getLogger(__name__)
 
 # Number of points a teams gets for matches in the first round
 # Probably not worth it to make it options.

--- a/pelita/ui/tk_canvas.py
+++ b/pelita/ui/tk_canvas.py
@@ -13,7 +13,7 @@ from .tk_sprites import BotSprite, Food, Wall, col
 from .tk_utils import wm_delete_window_handler
 from .tk_sprites import BotSprite, Food, Wall, RED, BLUE, YELLOW, GREY, BROWN
 
-_logger = logging.getLogger("pelita.tk")
+_logger = logging.getLogger(__name__)
 
 
 

--- a/pelita/ui/tk_utils.py
+++ b/pelita/ui/tk_utils.py
@@ -7,10 +7,7 @@ import platform
 import signal
 import sys
 
-# make a logger for these handlers that prints info messages to stderr
-_logger = logging.getLogger("signal_handlers")
-_logger.setLevel(logging.INFO)
-_logger.addHandler(logging.StreamHandler(sys.stderr))
+_logger = logging.getLogger(__name__)
 
 def exit_handler(*args):
     """ Simple handler to just quit using os._exit(-1).


### PR DESCRIPTION
Use `logging.getLogger(__name__)` everywhere.