### PR TITLE
Add --long-help

### DIFF
--- a/pelita/game_master.py
+++ b/pelita/game_master.py
@@ -60,7 +60,7 @@ class GameMaster:
 
     """
     def __init__(self, layout, teams, number_bots, game_time, noise=True, noiser=None,
-                 initial_delay=0.0, max_timeouts=5, timeout_length=3, layout_name=None,
+                 max_timeouts=5, timeout_length=3, layout_name=None,
                  seed=None):
         self.universe = datamodel.CTFUniverse.create(layout, number_bots)
         self.number_bots = number_bots
@@ -74,7 +74,6 @@ class GameMaster:
         self.noiser = noiser(self.universe, seed=seed) if noise else None
 
         self.viewers = []
-        self.initial_delay = initial_delay
 
         # We seed the internal random number generator.
         # This instance should be used for all important random decisions
@@ -231,8 +230,6 @@ class GameMaster:
         """ Play game until finished. """
         # notify all PlayerTeams
         self.set_initial()
-
-        time.sleep(self.initial_delay)
 
         while not self.game_state.get("finished"):
             self.play_round()

--- a/pelita/libpelita.py
+++ b/pelita/libpelita.py
@@ -76,10 +76,10 @@ def firstNN(*args):
 
 
 def start_logging(filename):
-    if filename:
-        hdlr = logging.FileHandler(filename, mode='w')
-    else:
+    if not filename or filename == '-':
         hdlr = logging.StreamHandler()
+    else:
+        hdlr = logging.FileHandler(filename, mode='w')
     logger = logging.getLogger('pelita')
     FORMAT = '[%(relativeCreated)06d %(name)s:%(levelname).1s][%(funcName)s] %(message)s'
     formatter = logging.Formatter(FORMAT)

--- a/pelita/libpelita.py
+++ b/pelita/libpelita.py
@@ -355,7 +355,6 @@ def run_game(team_specs, game_config, viewers=None, controller=None):
     server = SimpleServer(layout_string=game_config["layout_string"],
                           rounds=game_config["rounds"],
                           bind_addrs=[team.address for team in teams],
-                          initial_delay=game_config["initial_delay"],
                           max_timeouts=game_config["max_timeouts"],
                           timeout_length=game_config["timeout_length"],
                           layout_name=game_config["layout_name"],

--- a/pelita/scripts/pelita_main.py
+++ b/pelita/scripts/pelita_main.py
@@ -184,7 +184,7 @@ viewer_opt.add_argument('--progress', action='store_const', const='progress',
 viewer_opt.add_argument('--tk', action='store_const', const='tk',
                         dest='viewer', help='Use the tk viewer (default).')
 viewer_opt.add_argument('--tk-no-sync', action='store_const', const='tk-no-sync',
-                        dest='viewer', help=argparse.SUPPRESS)
+                        dest='viewer', help=long_help('Uses the tk viewer in an unsynchronized mode.'))
 parser.set_defaults(viewer='tk')
 
 advanced_settings = parser.add_argument_group('Advanced settings')
@@ -307,15 +307,8 @@ def main():
         if len(team_specs) > num_teams:
             raise RuntimeError("Too many teams given. Must be < {}.".format(num_teams))
 
-        if args.viewer == 'tk-no-sync':
-            # only use delay when not synced.
-            initial_delay = 0.5
-        else:
-            initial_delay = 0.0
-
         game_config = {
             "rounds": args.rounds,
-            "initial_delay": initial_delay,
             "max_timeouts": args.max_timeouts,
             "timeout_length": args.timeout_length,
             "layout_name": layout_name,

--- a/pelita/scripts/pelita_main.py
+++ b/pelita/scripts/pelita_main.py
@@ -137,8 +137,6 @@ parser.add_argument('--dump', help=long_help('Print game dumps to file (will be 
                     metavar='DUMPFILE', const='pelita.dump', nargs='?')
 parser.add_argument('--replay', help=long_help('Replay a dumped game'),
                     metavar='DUMPFILE', dest='replayfile', const='pelita.dump', nargs='?')
-parser.add_argument('--dry-run', action='store_true',
-                    help=long_help('Load players but do not actually play the game.'))
 parser.add_argument('--list-layouts', action='store_true',
                     help='List all available layouts.')
 parser.add_argument('--check-team', action="store_true",
@@ -308,9 +306,6 @@ def main():
             raise RuntimeError("Not enough teams given. Must be {}".format(num_teams))
         if len(team_specs) > num_teams:
             raise RuntimeError("Too many teams given. Must be < {}.".format(num_teams))
-
-        if args.dry_run:
-            sys.exit(0)
 
         if args.viewer == 'tk-no-sync':
             # only use delay when not synced.

--- a/pelita/simplesetup.py
+++ b/pelita/simplesetup.py
@@ -336,8 +336,6 @@ class SimpleServer:
     bind_addrs : list of strings, optional
         The address(es) which this server uses for its connections.
         Defaults to ["tcp://*"] * teams, if not given.
-    initial_delay : float
-        Delays the start of the game by `initial_delay` seconds.
     layout_name : string, optional
         The name of the given layout string.
     seed : int, optional
@@ -352,7 +350,7 @@ class SimpleServer:
 
     """
     def __init__(self, layout_string, teams=2, players=4, rounds=300, bind_addrs=None,
-                 initial_delay=0.0, max_timeouts=5, timeout_length=3, layout_name=None,
+                 max_timeouts=5, timeout_length=3, layout_name=None,
                  seed=None):
 
         self.players = players
@@ -413,7 +411,6 @@ class SimpleServer:
 
         self.game_master = GameMaster(layout_string, self.team_players,
                                       self.players, self.rounds,
-                                      initial_delay=initial_delay,
                                       max_timeouts=max_timeouts,
                                       timeout_length=timeout_length,
                                       layout_name=layout_name,


### PR DESCRIPTION
Adds a `--long-help` flag to `pelita`.

The implementation is a slight hack because the feature does not exist in argparse. It uses a helper function `long_help` that will be `argparse.SUPPRESS` when `--long-help` is not set so that it will usually hide the advanced features from normal users.

Additionally, this commit does some cleaning up and gets rid of the `initial_delay` variable.