### PR TITLE
Use the travis deploy mechanism to publish our docs to gh-pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,8 @@ after_success:
 # generate sphinx documentation in doc/build/html/
 before_deploy:
 - python -m pip install sphinx
+- git fetch --unshallow
+- git fetch --tags
 - . ./build-docs.sh
 
 # deploy docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,18 @@ script:
 after_success:
   - codecov
   - coveralls
-  - ./deploy-gh-pages.sh
+
+before_deploy:
+  - python -m pip install sphinx
+  - . ./build-docs.sh
+
+deploy:
+  provider: pages
+  local-dir: doc/build/html/
+  skip-cleanup: true
+  github-token: $GITHUB_TOKEN
+  keep-history: true
+  on:
+    branch: master
+    python: "3.7"
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ matrix:
     sudo: true
 env:
   global:
-  - secure: "fHTmXSkUyVFu7lJ4upcu4Xhv+5cTGq+SJ+GV9UUJ9guZYVWafxJw3CRmd/qqjucQzOTPg/2JA4/9XqDZDSWKKBwGTOgeiFjKaa4xPFO/bvpbECqR4y7TDh7k7zSjMCDD624b8k6LyWiaerh50ShU2CSi3cTjpyZWloolQWRotLM="
-  - REPO: "ASPP/pelita"
+    # our GITHUB_TOKEN
+    secure: acCojrLAQFpC5thBOVfOV77mxFATlWGVtuKB1e27jp/0kQx6RILu29OO9A0SzTMOxjGbI8G4pQy6tLDuNukoG5Rl6vBvHSEGS+naInBSgF7zc0zC9+YJK7gaJc5qZ6jnURsi84+bIEz//RP5WN5Yz3QsJ4t9QZ3zwbBESTdhA9M=
 
 # install dependencies and pelita
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,3 +55,4 @@ deploy:
   on:
     branch: master
     python: 3.7
+    repo: ASPP/pelita

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,38 +2,48 @@ language: python
 sudo: false
 matrix:
   include:
-    - python: "3.5"
-    - python: "3.6"
-    - python: "3.7"
-      dist: xenial
-      sudo: true
+  - python: 3.5
+  - python: 3.6
+  - python: 3.7
+    dist: xenial
+    sudo: true
 env:
   global:
-    - secure: "fHTmXSkUyVFu7lJ4upcu4Xhv+5cTGq+SJ+GV9UUJ9guZYVWafxJw3CRmd/qqjucQzOTPg/2JA4/9XqDZDSWKKBwGTOgeiFjKaa4xPFO/bvpbECqR4y7TDh7k7zSjMCDD624b8k6LyWiaerh50ShU2CSi3cTjpyZWloolQWRotLM="
-    - REPO: "ASPP/pelita"
-# command to install dependencies
+  - secure: "fHTmXSkUyVFu7lJ4upcu4Xhv+5cTGq+SJ+GV9UUJ9guZYVWafxJw3CRmd/qqjucQzOTPg/2JA4/9XqDZDSWKKBwGTOgeiFjKaa4xPFO/bvpbECqR4y7TDh7k7zSjMCDD624b8k6LyWiaerh50ShU2CSi3cTjpyZWloolQWRotLM="
+  - REPO: "ASPP/pelita"
+
+# install dependencies and pelita
 install:
-  - pip install pytest-cov codecov coveralls
-  - pip install -e .
-# command to run tests
+- pip install pytest-cov codecov coveralls
+- pip install -e .
+
+# test scripts
 script:
-  - >
-      python -c "import zmq; print('Using pyzmq {} and zmq {}.'.format(zmq.pyzmq_version(), zmq.zmq_version()))" &&
-      python -m pytest --cov=pelita -v test/ &&
-      python -m pelita.scripts.pelita_main --progress &&
-      pelita --null --rounds 100 --filter small $player 2>&1
-  - if [[ $TRAVIS_PYTHON_VERSION == 3.6 || $TRAVIS_PYTHON_VERSION == 3.7 ]]; then pelita-tournament --non-interactive --viewer null ; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == 3.6 || $TRAVIS_PYTHON_VERSION == 3.7 ]]; then git clone https://github.com/ASPP/pelita_template && ( cd pelita_template/ && python -m pytest . ) ; fi
+- >
+    python -c "import zmq; print('Using pyzmq {} and zmq {}.'.format(zmq.pyzmq_version(), zmq.zmq_version()))" &&
+    python -m pytest --cov=pelita -v test/ &&
+    python -m pelita.scripts.pelita_main --progress &&
+    pelita --null --rounds 100 --filter small $player 2>&1
+- >
+    if [[ $TRAVIS_PYTHON_VERSION == 3.6 || $TRAVIS_PYTHON_VERSION == 3.7 ]] ; then
+      pelita-tournament --non-interactive --viewer null
+    fi
+- >
+    if [[ $TRAVIS_PYTHON_VERSION == 3.6 || $TRAVIS_PYTHON_VERSION == 3.7 ]] ; then
+      git clone https://github.com/ASPP/pelita_template && ( cd pelita_template/ && python -m pytest . )
+    fi
 
-
+# push coverage
 after_success:
-  - codecov
-  - coveralls
+- codecov
+- coveralls
 
+# generate sphinx documentation in doc/build/html/
 before_deploy:
-  - python -m pip install sphinx
-  - . ./build-docs.sh
+- python -m pip install sphinx
+- . ./build-docs.sh
 
+# deploy docs
 deploy:
   provider: pages
   local-dir: doc/build/html/
@@ -42,5 +52,4 @@ deploy:
   keep-history: true
   on:
     branch: master
-    python: "3.7"
-
+    python: 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ script:
       python -m pelita.scripts.pelita_main --progress &&
       pelita --null --rounds 100 --filter small $player 2>&1
   - if [[ $TRAVIS_PYTHON_VERSION == 3.6 || $TRAVIS_PYTHON_VERSION == 3.7 ]]; then pelita-tournament --non-interactive --viewer null ; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == 3.6 || $TRAVIS_PYTHON_VERSION == 3.7 ]]; then git clone https://github.com/ASPP/pelita_template && cd pelita_template/ && python -m pytest . ; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.6 || $TRAVIS_PYTHON_VERSION == 3.7 ]]; then git clone https://github.com/ASPP/pelita_template && ( cd pelita_template/ && python -m pytest . ) ; fi
 
 
 after_success:

--- a/build-docs.sh
+++ b/build-docs.sh
@@ -5,7 +5,6 @@ git_describe=$(git describe)
 
 # make the documentation, hope it doesn't fail
 echo "Generating doc from $git_describe"
-(cd doc; git clean -n -x -d)
 
 # Generate _contributors.rst
 CONTRIBUTORS=doc/source/_contributors.rst

--- a/build-docs.sh
+++ b/build-docs.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+# get the 'git describe' output
+git_describe=$(git describe)
+
+# Generate _contributors.rst
+CONTRIBUTORS=doc/source/_contributors.rst
+
+echo "As of \`\`${git_describe}\`\` the developers and contributors are::" > $CONTRIBUTORS
+echo "" >> $CONTRIBUTORS
+git shortlog -sn | awk '{first = $1; $1 = "   "; print $0; }' >> $CONTRIBUTORS
+
+# make the documentation, hope it doesn't fail
+echo "Generating doc from $git_describe"
+(cd doc; git clean -n -x -d)
+(cd doc; make clean)
+if ! (cd doc; make html) ; then
+  echo "Fatal: 'make'ing the docs failed cannot commit!"
+  exit 2
+fi
+
+docdirectory=doc/build/html/
+
+# Add a .nojekyll file
+# This prevents the GitHub jekyll website generator from running
+touch $docdirectory".nojekyll"
+

--- a/build-docs.sh
+++ b/build-docs.sh
@@ -3,6 +3,10 @@
 # get the 'git describe' output
 git_describe=$(git describe)
 
+# make the documentation, hope it doesn't fail
+echo "Generating doc from $git_describe"
+(cd doc; git clean -n -x -d)
+
 # Generate _contributors.rst
 CONTRIBUTORS=doc/source/_contributors.rst
 
@@ -10,9 +14,6 @@ echo "As of \`\`${git_describe}\`\` the developers and contributors are::" > $CO
 echo "" >> $CONTRIBUTORS
 git shortlog -sn | awk '{first = $1; $1 = "   "; print $0; }' >> $CONTRIBUTORS
 
-# make the documentation, hope it doesn't fail
-echo "Generating doc from $git_describe"
-(cd doc; git clean -n -x -d)
 (cd doc; make clean)
 if ! (cd doc; make html) ; then
   echo "Fatal: 'make'ing the docs failed cannot commit!"

--- a/make-doc-tree.sh
+++ b/make-doc-tree.sh
@@ -10,31 +10,9 @@ if ! git diff-index --cached --quiet --ignore-submodules HEAD ; then
   exit 1
 fi
 
-# get the 'git describe' output
-git_describe=$(git describe)
-
-
-# Generate _contributors.rst
-CONTRIBUTORS=doc/source/_contributors.rst
-
-echo "As of \`\`${git_describe}\`\` the developers and contributors are::" > $CONTRIBUTORS
-echo "" >> $CONTRIBUTORS
-git shortlog -sn | awk '{first = $1; $1 = "   "; print $0; }' >> $CONTRIBUTORS
-
-# make the documentation, hope it doesn't fail
-echo "Generating doc from $git_describe"
-(cd doc; git clean -n -x -d)
-(cd doc; make clean)
-if ! (cd doc; make html) ; then
-  echo "Fatal: 'make'ing the docs failed cannot commit!"
-  exit 2
-fi
+./build-docs.sh
 
 docdirectory=doc/build/html/
-
-# Add a .nojekyll file
-# This prevents the GitHub jekyll website generator from running
-touch $docdirectory".nojekyll"
 
 # Adding the doc files to the index
 git add -f $docdirectory


### PR DESCRIPTION
Even though I think we did a nice job with our `commit-doc-tree.sh` script and exploited some nice low-level git features there, the automatic updating of the pelita website has been broken for quite a while now and travis would not inform us what went wrong.

This PR uses the travis deploy mechanism to automatically publish our generated docs.

(This PR comes with a companion PR #540 that does the same thing but uses travis stages.)