### PR TITLE
Make tournament work on Windows.

### DIFF
--- a/pelita/tournament/tournament.py
+++ b/pelita/tournament/tournament.py
@@ -30,9 +30,6 @@ POINTS_WIN = 2
 
 LOGFILE = None
 
-if os.name != 'posix':
-    raise RuntimeError("Tournament can only run on Posix systems.")
-
 
 def create_team_id(team_id, idx):
     """ Checks that the team_id in the config is valid or else

--- a/test/test_libpelita.py
+++ b/test/test_libpelita.py
@@ -13,7 +13,6 @@ class TestLibpelitaUtils:
         assert libpelita.firstNN(None, None, None) == None
         assert libpelita.firstNN() == None
 
-@pytest.mark.skipif(sys.platform == 'win32', reason="does not run on windows")
 class TestCallPelita:
     def test_call_pelita(self):
         rounds = 200
@@ -21,9 +20,11 @@ class TestCallPelita:
         filter = 'small'
 
         teams = ["pelita/player/StoppingPlayer", "pelita/player/StoppingPlayer"]
-        (state, stdout, stderr) = libpelita.call_pelita(teams, rounds=rounds, viewer=viewer, filter=filter, dump=None, seed=None)
+        (state, stdout, stderr) = libpelita.call_pelita(teams, rounds=rounds, viewer='null', filter=filter, dump=None, seed=None)
         assert state['team_wins'] is None
         assert state['game_draw'] is True
+        # Quick assert that there is text in stdout
+        assert len(stdout.split('\n')) == 6
 
         teams = ["pelita/player/SmartEatingPlayer", "pelita/player/StoppingPlayer"]
         (state, stdout, stderr) = libpelita.call_pelita(teams, rounds=rounds, viewer=viewer, filter=filter, dump=None, seed=None)

--- a/test/test_tournament.py
+++ b/test/test_tournament.py
@@ -1,9 +1,6 @@
 import pytest
 from unittest.mock import MagicMock
 
-import sys
-pytestmark = pytest.mark.skipif(sys.platform == 'win32', reason="tournament does not run on windows")
-
 import re
 from textwrap import dedent
 


### PR DESCRIPTION
The subprocess in `call_pelita` now uses temporary files instead of pipes for stdout/stderr, which did not work on Windows.