### PR TITLE
Add same-process mode to run_game that allows for easier debugging and profiling

### DIFF
--- a/pelita/libpelita.py
+++ b/pelita/libpelita.py
@@ -347,19 +347,22 @@ def prepare_team(team_spec):
         address = "tcp://127.0.0.1"
     return TeamSpec(module, address)
 
-def run_game(team_specs, game_config, viewers=None, controller=None):
+def run_game(team_specs, *, rounds, layout, layout_name="", seed=None, dump=False,
+                            max_timeouts=5, timeout_length=3,
+                            viewers=None, controller=None, publisher=None):
+
     if viewers is None:
         viewers = []
 
     teams = [prepare_team(team_spec) for team_spec in team_specs]
 
-    server = SimpleServer(layout_string=game_config["layout_string"],
-                          rounds=game_config["rounds"],
+    server = SimpleServer(layout_string=layout,
+                          rounds=rounds,
                           bind_addrs=[team.address for team in teams],
-                          max_timeouts=game_config["max_timeouts"],
-                          timeout_length=game_config["timeout_length"],
-                          layout_name=game_config["layout_name"],
-                          seed=game_config["seed"])
+                          max_timeouts=max_timeouts,
+                          timeout_length=timeout_length,
+                          layout_name=layout_name,
+                          seed=seed)
 
     # Update our teams with the bound addresses
     teams = [
@@ -379,7 +382,7 @@ def run_game(team_specs, game_config, viewers=None, controller=None):
             print("Waiting for external team %d to connect to %s." % (idx, team.address))
 
     external_players = [
-        call_pelita_player(team.module, team.address, color[team], dump=game_config['dump'])
+        call_pelita_player(team.module, team.address, color[team], dump=dump)
         for team in teams
         if team.module
     ]
@@ -387,8 +390,8 @@ def run_game(team_specs, game_config, viewers=None, controller=None):
     for viewer in viewers:
         server.game_master.register_viewer(viewer)
 
-    if game_config.get("publisher"):
-        server.game_master.register_viewer(game_config["publisher"])
+    if publisher:
+        server.game_master.register_viewer(publisher)
 
     with autoclose_subprocesses(external_players):
         if controller is not None:

--- a/pelita/libpelita.py
+++ b/pelita/libpelita.py
@@ -337,6 +337,9 @@ def strip_module_prefix(module):
         return ModuleSpec(prefix=None, module=module)
 
 def prepare_team(team_spec):
+    # check, if team_spec is a move function
+    if callable(team_spec):
+        return TeamSpec(module=None, address=team_spec)
     # check if we've been given an address which a remote
     # player wants to connect to
     if "://" in team_spec:

--- a/pelita/scripts/pelita_main.py
+++ b/pelita/scripts/pelita_main.py
@@ -351,17 +351,8 @@ def main():
         layout_name, layout_string = pelita.layout.load_layout(layout_name=args.layout, layout_file=args.layoutfile)
     else:
         layout_name, layout_string = pelita.layout.get_random_layout(args.filter)
+    
     print("Using layout '%s'" % layout_name)
-
-    game_config = {
-        "rounds": args.rounds,
-        "max_timeouts": args.max_timeouts,
-        "timeout_length": args.timeout_length,
-        "layout_name": layout_name,
-        "layout_string": layout_string,
-        "seed": args.seed,
-        "dump": args.dump,
-    }
 
     with libpelita.channel_setup(publish_to=args.publish_to) as channels:
         if args.viewer.startswith('tk'):
@@ -370,7 +361,6 @@ def main():
             controller = channels["controller"]
             controller_addr = controller.socket_addr
             publisher = channels["publisher"]
-            game_config["publisher"] = publisher
             if args.viewer == 'tk-no-sync':
                 controller = None
                 controller_addr = None
@@ -379,7 +369,9 @@ def main():
         else:
             controller = None
 
-        libpelita.run_game(team_specs=team_specs, game_config=game_config, viewers=viewers, controller=controller)
+        libpelita.run_game(team_specs=team_specs, rounds=args.rounds, layout=layout_string, layout_name=layout_name,
+                           seed=args.seed, dump=args.dump, max_timeouts=args.max_timeouts, timeout_length=args.timeout_length,
+                           viewers=viewers, controller=controller)
 
 if __name__ == '__main__':
     main()

--- a/pelita/simplesetup.py
+++ b/pelita/simplesetup.py
@@ -373,41 +373,51 @@ class SimpleServer:
         self.team_players = []
 
         for address in bind_addrs:
-            if address.startswith("remote:"):
-                _logger.info("Received remote address.")
-                send_addr = address[len("remote:"):]
-                address = "tcp://*"
+            if callable(address):
+                # address is a move function
+#                self.sockets.append(socket)
+                self.bind_addresses.append(None)
 
-                socket = self.context.socket(zmq.DEALER)
-                socket.connect(send_addr)
-                _logger.info("Connecting zmq.DEALER to {}.".format(send_addr))
-                socket.send_json({"REQUEST": address})
+                from .player.team import Team as _Team
+                team_player = _Team('local-team', address)
+                team_player._exit = lambda: None
+                self.team_players.append(team_player)
             else:
-                socket = self.context.socket(zmq.PAIR)
+                if address.startswith("remote:"):
+                    _logger.info("Received remote address.")
+                    send_addr = address[len("remote:"):]
+                    address = "tcp://*"
 
-                bind_to_random = False
-                if address.startswith("tcp://"):
-                    split_address = address.split("tcp://")
-                    if not ":" in split_address[1]:
-                        # assume no port has been given:
-                        bind_to_random = True
+                    socket = self.context.socket(zmq.DEALER)
+                    socket.connect(send_addr)
+                    _logger.info("Connecting zmq.DEALER to {}.".format(send_addr))
+                    socket.send_json({"REQUEST": address})
+                else:
+                    socket = self.context.socket(zmq.PAIR)
 
-                try:
-                    if bind_to_random:
-                        socket_port = socket.bind_to_random_port(address)
-                        address = address + (":%d" % socket_port)
-                    else:
-                        socket.bind(address)
-                    _logger.info("Bound zmq.PAIR to %s", address)
-                except zmq.ZMQError:
-                    print("ZMQError while trying to bind {}".format(address))
-                    raise
+                    bind_to_random = False
+                    if address.startswith("tcp://"):
+                        split_address = address.split("tcp://")
+                        if not ":" in split_address[1]:
+                            # assume no port has been given:
+                            bind_to_random = True
 
-            self.sockets.append(socket)
-            self.bind_addresses.append(address)
+                    try:
+                        if bind_to_random:
+                            socket_port = socket.bind_to_random_port(address)
+                            address = address + (":%d" % socket_port)
+                        else:
+                            socket.bind(address)
+                        _logger.info("Bound zmq.PAIR to %s", address)
+                    except zmq.ZMQError:
+                        print("ZMQError while trying to bind {}".format(address))
+                        raise
 
-            team_player = RemoteTeamPlayer(socket)
-            self.team_players.append(team_player)
+                self.sockets.append(socket)
+                self.bind_addresses.append(address)
+
+                team_player = RemoteTeamPlayer(socket)
+                self.team_players.append(team_player)
 
         self.game_master = GameMaster(layout_string, self.team_players,
                                       self.players, self.rounds,


### PR DESCRIPTION
This PR makes a few API changes to the `libpelita.run_game` function, eliminating the need to pass a `game_config` dict in favour of explicit arguments (with sensible defaults). This should make it easier to use `run_game` in bulk testing similar to the following snippet:

    for enemy in ["enemy_players/team1", "enemy_players/team2"]:
        layout = get_layout() # ...
        game_state = run_game([my_move, enemy], rounds=300, layout=layout)
        # ...

Additionally, the team arguments to `run_game` may now be either team spec strings (as one would use on the pelita command line and which run in a subprocess) as well as plain `move(bot, state)` functions which will run in the same process and therefore allow for debugging (there is no timeout by design) and profiling.

A simple script for profiling might look as follows (the FoodEatingPlayer could be any other enemy):

    import pelita
    import time

    @profile
    def move(bot, state):
        time.sleep(0.01)
        return (0, 0), state

    name, layout = pelita.layout.get_random_layout()
    pelita.libpelita.run_game([move, "pelita/player/FoodEatingPlayer.py"], rounds=30, layout=layout)

And could be run with `kernprof -v -l profile.py` to yield:

    Wrote profile results to profile.py.lprof
    Timer unit: 1e-06 s

    Total time: 0.684961 s
    File: profile.py
    Function: move at line 7

    Line #      Hits         Time  Per Hit   % Time  Line Contents
    ==============================================================
         7                                           @profile
         8                                           def move(bot, state):
         9        60     684431.0  11407.2     99.9      time.sleep(0.01)
        10        60        530.0      8.8      0.1      return (0, 0), state


Closes #545. Closes #552. Addresses issues mentioned in #433.