### PR TITLE
RF: Remove ambiguous load_layout function.

### DIFF
--- a/pelita/layout.py
+++ b/pelita/layout.py
@@ -17,35 +17,6 @@ class LayoutEncodingException(Exception):
     """ Signifies a problem with the encoding of a layout. """
     pass
 
-def load_layout(layout_name=None, layout_file=None):
-    """ Returns the layout_name and layout_string for a given parameter.
-
-    The Parameters 'layout_name' and 'layout_file' are mutually exclusive.
-
-    Parameters
-    ----------
-    layout_name : string, optional
-        The name of an available layout
-    layout_file : filename, optional
-        A file which holds a layout
-
-    Returns
-    -------
-    layout : tuple(str, str)
-        the name of the layout, a random layout string
-    """
-    if layout_name and not layout_file:
-        layout_name = layout_name
-        layout_string = get_layout_by_name(layout_name)
-    elif layout_file and not layout_name:
-        with open(layout_file) as file:
-            layout_name = file.name
-            layout_string = file.read()
-    else:
-        raise  ValueError("Can only supply one of: 'layout_name' or 'layout_file'")
-
-    return layout_name, layout_string
-
 def get_random_layout(filter=''):
     """ Return a random layout string from the available ones.
 

--- a/pelita/scripts/pelita_main.py
+++ b/pelita/scripts/pelita_main.py
@@ -5,6 +5,7 @@ import contextlib
 import json
 import logging
 import os
+from pathlib import Path
 import random
 import subprocess
 import sys
@@ -347,8 +348,13 @@ def main():
         pass
     random.seed(args.seed)
 
-    if args.layout or args.layoutfile:
-        layout_name, layout_string = pelita.layout.load_layout(layout_name=args.layout, layout_file=args.layoutfile)
+    if args.layout:
+        layout_name = args.layout
+        layout_string = pelita.layout.get_layout_by_name(args.layout)
+    elif args.layoutfile:
+        layout_path = Path(args.layoutfile)
+        layout_name = str(layout_path)
+        layout_string = layout_path.read_text()
     else:
         layout_name, layout_string = pelita.layout.get_random_layout(args.filter)
     

--- a/test/test_layout.py
+++ b/test/test_layout.py
@@ -5,25 +5,6 @@ from pelita.layout import *
 
 
 class TestLayoutModule:
-
-    def test_load_layout(self):
-        # check that too many layout args raise an error
-        layout_name = "layout_normal_with_dead_ends_001"
-        layout_file = "test/test_layout.layout"
-        with pytest.raises(ValueError):
-            load_layout(layout_name=layout_name,
-                layout_file=layout_file)
-        # check that unknown layout_name raises an appropriate error
-        with pytest.raises(ValueError):
-            load_layout(layout_name="foobar")
-        # check that a non existent file raises an error
-        with pytest.raises(IOError):
-            load_layout(layout_file="foobar")
-        # check that stuff behaves as it should
-        assert "layout_normal_with_dead_ends_001" == load_layout(layout_name=layout_name)[0]
-        assert "test/test_layout.layout" == load_layout(layout_file=layout_file)[0]
-
-
     def test_get_available_layouts(self):
         available = get_available_layouts()
         assert 600 == len(available)


### PR DESCRIPTION
This removes `layout.load_layout` because it is at best unneeded and at worst confusing because of its mutually exclusive call interface (and also because it would only return a string of a layout and not automatically parse it).
If one wants to load an internal layout (from `__layouts.py`) one should use `get_layout_by_name` directly. If one wants to load a layout from a file, reading the file with `pathlib.Path` serves the same purpose.