### PR TITLE
RF: Store universe in GameMaster.game_state and remove it from APIs

### DIFF
--- a/pelita/player/base.py
+++ b/pelita/player/base.py
@@ -16,9 +16,9 @@ class AbstractTeam(metaclass=abc.ABCMeta):
     """
 
     @abc.abstractmethod
-    def set_initial(self, team_id, universe, game_state):
+    def set_initial(self, team_id, game_state):
         """ Tells the team about its id and gives initial information
-         about the universe and game state.
+         about the game state.
 
         Players who want write their own team class need to supply
         a method with the same signature.
@@ -27,8 +27,6 @@ class AbstractTeam(metaclass=abc.ABCMeta):
         ----------
         team_id : int
             The id of the team
-        universe : Universe
-            The initial universe
         game_state : dict
             The initial game state
 
@@ -39,7 +37,7 @@ class AbstractTeam(metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
-    def get_move(self, bot_id, universe, game_state):
+    def get_move(self, bot_id, game_state):
         """ Requests a move from the bot with id `bot_id`.
 
         This method returns a dict with a key `move` and a value specifying the direction
@@ -49,10 +47,8 @@ class AbstractTeam(metaclass=abc.ABCMeta):
         ----------
         bot_id : int
             The id of the bot who needs to play
-        universe : Universe
-            The initial universe
         game_state : dict
-            The initial game state
+            The game state
 
         Returns
         -------
@@ -98,7 +94,7 @@ class SimpleTeam(AbstractTeam):
         self._remote_game = False
         self.remote_game = False
 
-    def set_initial(self, team_id, universe, game_state):
+    def set_initial(self, team_id, game_state):
         """ Sets the bot indices for the team and tells each player
         about the universe and game state by calling `_set_index` and `_set_initial`.
 
@@ -106,8 +102,6 @@ class SimpleTeam(AbstractTeam):
         ----------
         team_id : int
             The id of the team
-        universe : Universe
-            The initial universe
         game_state : dict
             The initial game state
 
@@ -121,6 +115,7 @@ class SimpleTeam(AbstractTeam):
         # only iterate about those player which are in bot_players
         # we might have defined more players than we have received
         # indexes for.
+        universe = datamodel.CTFUniverse._from_json_dict(game_state)
         team_bots = universe.team_bots(team_id)
 
         if len(team_bots) > len(self._players):
@@ -135,7 +130,7 @@ class SimpleTeam(AbstractTeam):
 
         return self.team_name
 
-    def get_move(self, bot_id, universe, game_state):
+    def get_move(self, bot_id, game_state):
         """ Requests a move from the Player who controls the Bot with id `bot_id`.
 
         This method returns a dict with a key `move` and a value specifying the direction
@@ -154,6 +149,7 @@ class SimpleTeam(AbstractTeam):
         -------
         move : dict
         """
+        universe = datamodel.CTFUniverse._from_json_dict(game_state)
         return self._bot_players[bot_id]._get_move(universe, game_state)
 
     @property

--- a/pelita/player/team.py
+++ b/pelita/player/team.py
@@ -36,7 +36,7 @@ class Team(AbstractTeam):
 
         self._team_move = team_move
 
-    def set_initial(self, team_id, universe, game_state):
+    def set_initial(self, team_id, game_state):
         """ Sets the bot indices for the team and returns the team name.
         Currently, we do not call _set_initial on the user side.
 
@@ -44,8 +44,6 @@ class Team(AbstractTeam):
         ----------
         team_id : int
             The id of the team
-        universe : Universe
-            The initial universe
         game_state : dict
             The initial game state
 
@@ -55,6 +53,7 @@ class Team(AbstractTeam):
             The name of the team
 
         """
+        universe = datamodel.CTFUniverse._from_json_dict(game_state)
 
         #: Storage for the team state
         self._team_state = None
@@ -81,7 +80,7 @@ class Team(AbstractTeam):
 
         return self.team_name
 
-    def get_move(self, bot_id, universe, game_state):
+    def get_move(self, bot_id, game_state):
         """ Requests a move from the Player who controls the Bot with id `bot_id`.
 
         This method returns a dict with a key `move` and a value specifying the direction
@@ -91,8 +90,6 @@ class Team(AbstractTeam):
         ----------
         bot_id : int
             The id of the bot who needs to play
-        universe : Universe
-            The initial universe
         game_state : dict
             The initial game state
 
@@ -101,6 +98,7 @@ class Team(AbstractTeam):
         move : dict
         """
 
+        universe = datamodel.CTFUniverse._from_json_dict(game_state)
         bots = bots_from_universe(universe,
                                   rng=self._bot_random,
                                   round=game_state['round_index'],

--- a/pelita/scripts/pelita_main.py
+++ b/pelita/scripts/pelita_main.py
@@ -11,7 +11,7 @@ import sys
 import time
 
 import pelita
-from pelita import libpelita
+from pelita import libpelita, datamodel
 
 # silence stupid warnings from logging module
 logging.root.manager.emittedNoHandlerWarning = 1
@@ -54,7 +54,8 @@ class ReplayPublisher:
                 yield self.publisher._send(message)
 
 class ResultPrinter(pelita.viewer.AbstractViewer):
-    def observe(self, universe, game_state):
+    def observe(self, game_state):
+        universe = datamodel.CTFUniverse._from_json_dict(game_state)
         self.print_bad_bot_status(universe, game_state)
         if game_state["finished"]:
             self.print_possible_winner(universe, game_state)

--- a/pelita/ui/tk_canvas.py
+++ b/pelita/ui/tk_canvas.py
@@ -690,9 +690,8 @@ class TkApplication:
                 self.controller_socket.send_json({"__action__": "play_round"})
 
     def observe(self, data):
-        universe = data["universe"]
-        universe = CTFUniverse._from_json_dict(universe)
         game_state = data["game_state"]
+        universe = CTFUniverse._from_json_dict(game_state)
 
         self.update(universe, game_state)
         if self._stop_after is not None:

--- a/pelita/viewer.py
+++ b/pelita/viewer.py
@@ -35,29 +35,44 @@ class ProgressViewer(AbstractViewer):
         sys.stdout.write(string + ("\b" * len(string)))
         sys.stdout.flush()
 
+        state = {}
+        state.update(game_state)
+        del state['maze']
+        del state['food']
+        del state['teams']
+        del state['bots']
+
         if game_state["finished"]:
             sys.stdout.write("\n")
-            print("Final state:", game_state)
+            print("Final state:", state)
 
 class AsciiViewer(AbstractViewer):
     """ A viewer that dumps ASCII charts on stdout. """
 
     def observe(self, game_state):
         universe = datamodel.CTFUniverse._from_json_dict(game_state)
+
+        state = {}
+        state.update(game_state)
+        del state['maze']
+        del state['food']
+        del state['teams']
+        del state['bots']
+
         info = (
             "Round: {round!r} Turn: {turn!r} Score {s0}:{s1}\n"
-            "Game State: {game_state!r}\n"
+            "Game State: {state!r}\n"
             "\n"
             "{universe}"
         ).format(round=game_state["round_index"],
                  turn=game_state["bot_id"],
                  s0=universe.teams[0].score,
                  s1=universe.teams[1].score,
-                 game_state=game_state,
+                 state=state,
                  universe=universe.compact_str)
 
         print(info)
-        winning_team_idx = game_state.get("team_wins")
+        winning_team_idx = state.get("team_wins")
         if winning_team_idx is not None:
             print(("Game Over: Team: '%s' wins!" %
                 game_state["team_name"][winning_team_idx]))

--- a/pelita/viewer.py
+++ b/pelita/viewer.py
@@ -101,17 +101,13 @@ class ReplyToViewer(AbstractViewer):
             self.sock.send_unicode(as_json, flags=zmq.NOBLOCK)
 
     def set_initial(self, game_state):
-        universe = datamodel.CTFUniverse._from_json_dict(game_state)
         message = {"__action__": "set_initial",
-                   "__data__": {"universe": universe._to_json_dict(),
-                                "game_state": game_state}}
+                   "__data__": {"game_state": game_state}}
         self._send(message)
 
     def observe(self, game_state):
-        universe = datamodel.CTFUniverse._from_json_dict(game_state)
         message = {"__action__": "observe",
-                   "__data__": {"universe": universe._to_json_dict(),
-                                "game_state": game_state}}
+                   "__data__": {"game_state": game_state}}
         self._send(message)
 
 
@@ -131,16 +127,12 @@ class DumpingViewer(AbstractViewer):
         self.stream.flush()
 
     def set_initial(self, game_state):
-        universe = datamodel.CTFUniverse._from_json_dict(game_state)
         message = {"__action__": "set_initial",
-                   "__data__": {"universe": universe._to_json_dict(),
-                                "game_state": game_state}}
+                   "__data__": {"game_state": game_state}}
         self._send(message)
 
     def observe(self, game_state):
-        universe = datamodel.CTFUniverse._from_json_dict(game_state)
         message = {"__action__": "observe",
-                   "__data__": {"universe": universe._to_json_dict(),
-                                "game_state": game_state}}
+                   "__data__": {"game_state": game_state}}
         self._send(message)
 

--- a/test/test_player_base.py
+++ b/test/test_player_base.py
@@ -37,7 +37,7 @@ class TestAbstractPlayer:
             SimpleTeam(player_1, player_3)
         ]
         game_master = GameMaster(test_layout, teams, 4, 2, noise=False)
-        universe = game_master.universe
+        universe = datamodel.CTFUniverse._from_json_dict(game_master.game_state)
         game_master.set_initial()
 
         assert universe.bots[0] == player_0.me
@@ -98,23 +98,25 @@ class TestAbstractPlayer:
         assert player_1.current_state["bot_id"] == None
 
         game_master.play_round()
+        universe = datamodel.CTFUniverse._from_json_dict(game_master.game_state)
 
         assert player_1.current_pos == (15, 2)
         assert player_1.previous_pos == (15, 2)
         assert player_1.initial_pos == (15, 2)
         assert player_1.current_state["round_index"] == 0
-        assert player_1.current_state["bot_id"] is None
+        assert player_1.current_state["bot_id"] == 1
         assert universe.bots[1].current_pos == (15, 1)
         assert universe.bots[1].initial_pos == (15, 2)
         self.assertUniversesEqual(player_1.current_uni, player_1.universe_states[-1])
 
         game_master.play_round()
+        universe = datamodel.CTFUniverse._from_json_dict(game_master.game_state)
 
         assert player_1.current_pos == (15, 1)
         assert player_1.previous_pos == (15, 2)
         assert player_1.initial_pos == (15, 2)
         assert player_1.current_state["round_index"] == 1
-        assert player_1.current_state["bot_id"] is None
+        assert player_1.current_state["bot_id"] == 1
         assert universe.bots[1].current_pos == (14, 1)
         assert universe.bots[1].initial_pos == (15, 2)
         self.assertUniversesNotEqual(player_1.current_uni,
@@ -291,17 +293,19 @@ class TestSteppingPlayer:
             SimpleTeam(SteppingPlayer(movements_1), SteppingPlayer(movements_1))
         ]
         gm = GameMaster(test_layout, teams, 4, 2)
+        universe = datamodel.CTFUniverse._from_json_dict(gm.game_state)
 
-        assert gm.universe.bots[0].current_pos == (1, 1)
-        assert gm.universe.bots[1].current_pos == (10, 1)
-        assert gm.universe.bots[2].current_pos == (1, 2)
-        assert gm.universe.bots[3].current_pos == (10, 2)
+        assert universe.bots[0].current_pos == (1, 1)
+        assert universe.bots[1].current_pos == (10, 1)
+        assert universe.bots[2].current_pos == (1, 2)
+        assert universe.bots[3].current_pos == (10, 2)
 
         gm.play()
-        assert gm.universe.bots[0].current_pos == (3, 1)
-        assert gm.universe.bots[1].current_pos == (8, 1)
-        assert gm.universe.bots[2].current_pos == (3, 2)
-        assert gm.universe.bots[3].current_pos == (8, 2)
+        universe = datamodel.CTFUniverse._from_json_dict(gm.game_state)
+        assert universe.bots[0].current_pos == (3, 1)
+        assert universe.bots[1].current_pos == (8, 1)
+        assert universe.bots[2].current_pos == (3, 2)
+        assert universe.bots[3].current_pos == (8, 2)
 
     def test_shorthand(self):
         test_layout = (
@@ -319,10 +323,9 @@ class TestSteppingPlayer:
         player1_expected_positions = [(10,2), (9,2), (9,1), (10,1), (10,2)]
         gm.set_initial()
         for i in range(num_rounds):
-            assert gm.universe.bots[0].current_pos == \
-                player0_expected_positions[i]
-            assert gm.universe.bots[1].current_pos == \
-                player1_expected_positions[i]
+            universe = datamodel.CTFUniverse._from_json_dict(gm.game_state)
+            assert universe.bots[0].current_pos == player0_expected_positions[i]
+            assert universe.bots[1].current_pos == player1_expected_positions[i]
             gm.play_round()
 
     def test_too_many_moves(self):
@@ -357,17 +360,19 @@ class TestRoundBasedPlayer:
             SimpleTeam(RoundBasedPlayer(movements_1_0), RoundBasedPlayer(movements_1_1))
         ]
         gm = GameMaster(test_layout, teams, 4, 3)
+        universe = datamodel.CTFUniverse._from_json_dict(gm.game_state)
 
-        assert gm.universe.bots[0].current_pos == (1, 1)
-        assert gm.universe.bots[1].current_pos == (10, 1)
-        assert gm.universe.bots[2].current_pos == (1, 2)
-        assert gm.universe.bots[3].current_pos == (10, 2)
+        assert universe.bots[0].current_pos == (1, 1)
+        assert universe.bots[1].current_pos == (10, 1)
+        assert universe.bots[2].current_pos == (1, 2)
+        assert universe.bots[3].current_pos == (10, 2)
 
         gm.play()
-        assert gm.universe.bots[0].current_pos == (3, 1)
-        assert gm.universe.bots[1].current_pos == (8, 1)
-        assert gm.universe.bots[2].current_pos == (3, 2)
-        assert gm.universe.bots[3].current_pos == (9, 2)
+        universe = datamodel.CTFUniverse._from_json_dict(gm.game_state)
+        assert universe.bots[0].current_pos == (3, 1)
+        assert universe.bots[1].current_pos == (8, 1)
+        assert universe.bots[2].current_pos == (3, 2)
+        assert universe.bots[3].current_pos == (9, 2)
 
 class TestRandomPlayerSeeds:
     def test_demo_players(self):
@@ -387,12 +392,14 @@ class TestRandomPlayerSeeds:
             SimpleTeam(RandomPlayer())
         ]
         gm = GameMaster(test_layout, teams, 2, 5, seed=20)
-        assert gm.universe.bots[0].current_pos == (4, 4)
-        assert gm.universe.bots[1].current_pos == (4 + 7, 4)
+        universe = datamodel.CTFUniverse._from_json_dict(gm.game_state)
+        assert universe.bots[0].current_pos == (4, 4)
+        assert universe.bots[1].current_pos == (4 + 7, 4)
         gm.play()
 
-        pos_left_bot = gm.universe.bots[0].current_pos
-        pos_right_bot = gm.universe.bots[1].current_pos
+        universe = datamodel.CTFUniverse._from_json_dict(gm.game_state)
+        pos_left_bot = universe.bots[0].current_pos
+        pos_right_bot = universe.bots[1].current_pos
 
         # running again to test seed:
         teams = [
@@ -401,8 +408,9 @@ class TestRandomPlayerSeeds:
         ]
         gm = GameMaster(test_layout, teams, 2, 5, seed=20)
         gm.play()
-        assert gm.universe.bots[0].current_pos == pos_left_bot
-        assert gm.universe.bots[1].current_pos == pos_right_bot
+        universe = datamodel.CTFUniverse._from_json_dict(gm.game_state)
+        assert universe.bots[0].current_pos == pos_left_bot
+        assert universe.bots[1].current_pos == pos_right_bot
 
         # running again with other seed:
         teams = [
@@ -411,10 +419,11 @@ class TestRandomPlayerSeeds:
         ]
         gm = GameMaster(test_layout, teams, 2, 5, seed=200)
         gm.play()
+        universe = datamodel.CTFUniverse._from_json_dict(gm.game_state)
         # most probably, either the left bot or the right bot or both are at
         # a different position
-        assert gm.universe.bots[0].current_pos != pos_left_bot \
-                     or gm.universe.bots[1].current_pos != pos_right_bot
+        assert universe.bots[0].current_pos != pos_left_bot \
+                     or universe.bots[1].current_pos != pos_right_bot
 
     def test_random_seeds(self):
         test_layout = (
@@ -538,7 +547,7 @@ class TestSimpleTeam:
         team1 = SimpleTeam(SteppingPlayer('^'))
 
         with pytest.raises(ValueError):
-            team1.set_initial(0, dummy_universe, {})
+            team1.set_initial(0, dummy_universe._to_json_dict())
 
 class TestAbstracts:
     class BrokenPlayer(AbstractPlayer):

--- a/test/test_players.py
+++ b/test/test_players.py
@@ -16,8 +16,9 @@ class TestNQRandom_Player:
         ]
         gm = GameMaster(test_layout, team, 2, 1)
         gm.play()
-        assert gm.universe.bots[0].current_pos == (1, 1)
-        assert gm.universe.bots[1].current_pos == (9, 1)
+        universe = CTFUniverse._from_json_dict(gm.game_state)
+        assert universe.bots[0].current_pos == (1, 1)
+        assert universe.bots[1].current_pos == (9, 1)
 
     def test_path(self):
         test_layout = (
@@ -32,8 +33,9 @@ class TestNQRandom_Player:
         ]
         gm = GameMaster(test_layout, team, 2, 7)
         gm.play()
-        assert gm.universe.bots[0].current_pos == (4, 3)
-        assert gm.universe.bots[1].current_pos == (10, 3)
+        universe = CTFUniverse._from_json_dict(gm.game_state)
+        assert universe.bots[0].current_pos == (4, 3)
+        assert universe.bots[1].current_pos == (10, 3)
 
 class TestPlayers:
     # Simple checks that the players are running to avoid API discrepancies

--- a/test/test_team.py
+++ b/test/test_team.py
@@ -1,5 +1,6 @@
 import pytest
 
+from pelita.datamodel import CTFUniverse
 from pelita.game_master import GameMaster
 from pelita.player.team import Team, split_layout_str, create_layout, _rebuild_universe, bots_from_universe
 from pelita.utils import setup_test_game
@@ -202,8 +203,9 @@ class TestStoppingTeam:
         ]
         gm = GameMaster(test_layout, team, 4, 1)
         gm.play()
-        assert gm.universe.bots[0].current_pos == (1, 1)
-        assert gm.universe.bots[1].current_pos == (10, 1)
+        universe = CTFUniverse._from_json_dict(gm.game_state)
+        assert universe.bots[0].current_pos == (1, 1)
+        assert universe.bots[1].current_pos == (10, 1)
         assert round_counting._storage['rounds'] == 1
 
 
@@ -214,9 +216,10 @@ class TestStoppingTeam:
         ]
         gm = GameMaster(test_layout, team, 4, 3)
         gm.play()
-        print(gm.universe.pretty)
-        assert gm.universe.bots[0].current_pos == (1, 1)
-        assert gm.universe.bots[1].current_pos == (10, 1)
+        universe = CTFUniverse._from_json_dict(gm.game_state)
+        print(universe.pretty)
+        assert universe.bots[0].current_pos == (1, 1)
+        assert universe.bots[1].current_pos == (10, 1)
         assert round_counting._storage['rounds'] == 3
 
 


### PR DESCRIPTION
We store the dict representation of CTFUniverse in the game_state. Since the universe is only accessed in a few methods in GameMaster, we can live with a small number of conversions. The worst drawback, however, is that we use GameMaster.universe extensively in the tests, where conversions are more annoying but hopefully only temporary.

Removing the universe arguments in the AbstractViewer and AbstractTeam APIs should make integration with the new core rewrite easier. The API for SimpleTeam or AbstractPlayer have not been changed yet.

This patch does not necessarily have to go to master (the conversions might make it a little slower even) but it will make the compatibility interface to the new core-2.0 much nicer (which makes for easier testing). In any case, I would also apply it to core-2.0 later (or rebase).