### PR TITLE
Remove load_layout function from Layout and fix test_game

### DIFF
--- a/pelita/layout.py
+++ b/pelita/layout.py
@@ -16,35 +16,6 @@ class LayoutEncodingException(Exception):
     """ Signifies a problem with the encoding of a layout. """
     pass
 
-def load_layout(layout_name=None, layout_file=None):
-    """ Returns the layout_name and layout_string for a given parameter.
-
-    The Parameters 'layout_name' and 'layout_file' are mutually exclusive.
-
-    Parameters
-    ----------
-    layout_name : string, optional
-        The name of an available layout
-    layout_file : filename, optional
-        A file which holds a layout
-
-    Returns
-    -------
-    layout : tuple(str, str)
-        the name of the layout, a random layout string
-    """
-    if layout_name and not layout_file:
-        layout_name = layout_name
-        layout_string = get_layout_by_name(layout_name)
-    elif layout_file and not layout_name:
-        with open(layout_file) as file:
-            layout_name = file.name
-            layout_string = file.read()
-    else:
-        raise  ValueError("Can only supply one of: 'layout_name' or 'layout_file'")
-
-    return layout_name, layout_string
-
 def get_random_layout(filter=''):
     """ Return a random layout string from the available ones.
 

--- a/pelita/scripts/pelita_main.py
+++ b/pelita/scripts/pelita_main.py
@@ -5,6 +5,7 @@ import contextlib
 import json
 import logging
 import os
+from pathlib import Path
 import random
 import subprocess
 import sys
@@ -347,8 +348,13 @@ def main():
         pass
     random.seed(args.seed)
 
-    if args.layout or args.layoutfile:
-        layout_name, layout_string = pelita.layout.load_layout(layout_name=args.layout, layout_file=args.layoutfile)
+    if args.layout:
+        layout_name = args.layout
+        layout_string = pelita.layout.get_layout_by_name(args.layout)
+    elif args.layoutfile:
+        layout_path = Path(args.layoutfile)
+        layout_name = str(layout_path)
+        layout_string = layout_path.read_text()
     else:
         layout_name, layout_string = pelita.layout.get_random_layout(args.filter)
     

--- a/test/test_game.py
+++ b/test/test_game.py
@@ -1,11 +1,11 @@
 """Tests for Pelita game module"""
 import pytest
+
+from pathlib import Path
 import numpy as np
-from pelita.game import initial_positions
-from pelita.game import play_turn
-from pelita.game import get_legal_moves
 
 from pelita import layout
+from pelita.game import initial_positions, get_legal_moves, play_turn
 
 def test_initial_positions_basic():
     """Checks basic example for initial positions"""
@@ -87,8 +87,8 @@ def test_initial_positions_same_in_layout_random(n_times):
 @pytest.mark.parametrize('layout_name', layout.get_available_layouts())
 def test_initial_positions_same_in_layout(layout_name):
     """Check initial positions are the same as what the layout says for all layouts"""
-    l = layout.load_layout(layout_name=layout_name)
-    parsed_l = layout.parse_layout(l[1])
+    l = layout.get_layout_by_name(layout_name=layout_name)
+    parsed_l = layout.parse_layout(l)
     exp = parsed_l["bots"]
     walls = parsed_l["walls"]
     out = initial_positions(walls)
@@ -96,9 +96,8 @@ def test_initial_positions_same_in_layout(layout_name):
 
 def test_get_legal_moves_basic():
     """Check that the output of legal moves contains all legal moves for one example layout"""
-    l = layout.load_layout(layout_name="layout_small_without_dead_ends_100")
-    # l = layout.load_layout(layout_name="layout_normal_with_dead_ends_100")
-    parsed_l = layout.parse_layout(l[1])
+    l = layout.get_layout_by_name(layout_name="layout_small_without_dead_ends_100")
+    parsed_l = layout.parse_layout(l)
     legal_moves = get_legal_moves(parsed_l["walls"], parsed_l["bots"][0])
     exp = [(2, 5), (1, 6), (1, 5)]
     assert legal_moves == exp
@@ -278,8 +277,8 @@ def test_play_turn_move():
     seedval = np.random.randint(2**32)
     print(f'seedval: {seedval}')
     turn = 0
-    l = layout.load_layout(layout_file="layouts/small_without_dead_ends_100.layout")
-    parsed_l = layout.parse_layout(l[1])
+    l = Path("layouts/small_without_dead_ends_100.layout").read_text()
+    parsed_l = layout.parse_layout(l)
     game_state = {
         "food": parsed_l["food"],
         "walls": parsed_l["walls"],
@@ -315,8 +314,8 @@ def test_minimal_game():
 def setup_random_basic_gamestate():
     """helper function for testing play turn"""
     turn = 0
-    l = layout.load_layout(layout_file="layouts/small_without_dead_ends_100.layout")
-    parsed_l = layout.parse_layout(l[1])
+    l = Path("layouts/small_without_dead_ends_100.layout").read_text()
+    parsed_l = layout.parse_layout(l)
     game_state = {
         "food": parsed_l["food"],
         "walls": parsed_l["walls"],
@@ -340,8 +339,8 @@ def setup_random_basic_gamestate():
 def setup_specific_basic_gamestate(layout_id):
     """helper function for testing play turn"""
     turn = 0
-    l = layout.load_layout(layout_file=layout_id)
-    parsed_l = layout.parse_layout(l[1])
+    l = Path(layout_id).read_text()
+    parsed_l = layout.parse_layout(l)
     game_state = {
         "food": parsed_l["food"],
         "walls": parsed_l["walls"],

--- a/test/test_layout.py
+++ b/test/test_layout.py
@@ -16,23 +16,6 @@ LAYOUT2="""
 ########
 """
 
-def test_load_layout():
-    # check that too many layout args raise an error
-    layout_name = "layout_normal_with_dead_ends_001"
-    layout_file = "test/test_layout.layout"
-    with pytest.raises(ValueError):
-        load_layout(layout_name=layout_name,
-            layout_file=layout_file)
-    # check that unknown layout_name raises an appropriate error
-    with pytest.raises(ValueError):
-        load_layout(layout_name="foobar")
-    # check that a non existent file raises an error
-    with pytest.raises(IOError):
-        load_layout(layout_file="foobar")
-    # check that stuff behaves as it should
-    assert "layout_normal_with_dead_ends_001" == load_layout(layout_name=layout_name)[0]
-    assert "test/test_layout.layout" == load_layout(layout_file=layout_file)[0]
-
 
 def test_get_available_layouts():
     available = get_available_layouts()


### PR DESCRIPTION
`load_layout(layout_file=FILE)` can be replaced with `Path(FILE).read_text()`.
`load_layout(layout_name=NAME)` can be replaced with `get_layout_by_name(NAME)`.