### PR TITLE
Minimal working version of run_game

### DIFF
--- a/pelita/player/team.py
+++ b/pelita/player/team.py
@@ -210,6 +210,20 @@ class Bot:
         return legal_moves
 
     @property
+    def legal_positions(self):
+        """ The legal positions that the bot can reach from its current position,
+        including the current position.
+        """
+        legal_positions = []
+
+        for move in [(0, 0), (-1, 0), (1, 0), (0, 1), (0, -1)]:
+            new_pos = (self.position[0] + move[0], self.position[1] + move[1])
+            if not new_pos in self.walls:
+                legal_positions.append(new_pos)
+
+        return legal_positions
+
+    @property
     def _team(self):
        """ Both of our bots.
        """

--- a/pelita/player/team.py
+++ b/pelita/player/team.py
@@ -53,17 +53,15 @@ class Team(AbstractTeam):
             The name of the team
 
         """
-        universe = datamodel.CTFUniverse._from_json_dict(game_state)
-
         #: Storage for the team state
         self._team_state = None
         self._team_game = [None, None]
 
         #: Storage for the random generator
-        self._bot_random = [None] * len(universe.bots)
+        self._bot_random = [None] * len(game_state['positions'])
 
         #: Store the last known bot positions
-        self._last_know_position = [b.current_pos for b in universe.bots if b.team_index == team_id]
+        self._last_know_position = game_state['positions'][:]
 
         #: Store a history of bot positions
         self._bot_track = [[], []]
@@ -74,9 +72,9 @@ class Team(AbstractTeam):
         # To make things a little simpler, we also initialise a random generator
         # for all enemy bots
 
-        for bot in universe.bots:
+        for idx, bot in enumerate(game_state['positions']):
             # we take the bot’s index as a value for the seed_offset
-            self._bot_random[bot.index] = random.Random(game_state["seed"] + bot.index)
+            self._bot_random[idx] = random.Random(game_state["rng"] + idx)
 
         return self.team_name
 
@@ -97,13 +95,8 @@ class Team(AbstractTeam):
         -------
         move : dict
         """
+        bots = make_bots(**game_state)
 
-        universe = datamodel.CTFUniverse._from_json_dict(game_state)
-        bots = bots_from_universe(universe,
-                                  rng=self._bot_random,
-                                  round=game_state['round_index'],
-                                  team_name=game_state['team_name'],
-                                  timeout_count=game_state['timeout_teams'])
 
         me = bots[bot_id]
         team = bots[bot_id]._team
@@ -412,7 +405,7 @@ def make_bots(*, walls, food, positions, initial_positions, score, is_noisy, rng
                   food=[f for f in food if f in homezone],
                   is_noisy=is_noisy[i],
                   score=score[i % 2],
-                  random=rng[i],
+                  random=rng,
                   round=round,
                   is_blue=(i % 2 == 0),
                   team_name=team_name[i % 2],


### PR DESCRIPTION
This adds a minimal working version of `run_game` (only for local move functions currently). The interface of `prepare_bot_state` and `prepare_viewer_state` still has to be defined properly (with regards of serialisation).

Additionally, the third commit adds a (Python 3.7 only) dataclass for the GameState, which currently serves as a normative description of what we allow in our internal game_state dict.

We might, however, decide that dataclasses (arguably, we could do the same thing with a normal class as the serialisation is done in the specialised functions `prepare_bot_state` anyway) are not such a bad idea after all, and use it to its full potential. (Replacing `game_state['food']` → `game_state.food` and the notorious `max(game_state['walls'])[0]` → `game_state.width`.)