### PR TITLE
Add RemoteTeam class

### DIFF
--- a/pelita/player/team.py
+++ b/pelita/player/team.py
@@ -297,6 +297,9 @@ def create_homezones(width, height):
                 for y in range(0, height)]
     ]
 
+def _ensure_tuples(list):
+    """ Ensures that an iterable is a list of position tuples. """
+    return [tuple(item) for item in list]
 
 class Bot:
     def __init__(self, *, bot_index,
@@ -325,12 +328,12 @@ class Bot:
         self.is_on_team = is_on_team
 
         self.random = random
-        self.position = position
-        self.initial_position = initial_position
-        self.walls = walls
+        self.position = tuple(position)
+        self.initial_position = tuple(initial_position)
+        self.walls = _ensure_tuples(walls)
 
-        self.homezone = homezone
-        self.food = food
+        self.homezone = _ensure_tuples(homezone)
+        self.food = _ensure_tuples(food)
         self.score  = score
         self.bot_index  = bot_index
         self.round = round

--- a/pelita/player/team.py
+++ b/pelita/player/team.py
@@ -92,6 +92,7 @@ class Team(AbstractTeam):
         move : dict
         """
         me = make_bots(**game_state)
+        me.random = self._bot_random
 
         team = me._team
 

--- a/pelita/scripts/pelita_main.py
+++ b/pelita/scripts/pelita_main.py
@@ -12,7 +12,7 @@ import sys
 import time
 
 import pelita
-from pelita import libpelita, datamodel
+from pelita import libpelita, game, layout
 
 # silence stupid warnings from logging module
 logging.root.manager.emittedNoHandlerWarning = 1
@@ -377,9 +377,11 @@ def main():
             controller = None
             publisher = None
 
-        libpelita.run_game(team_specs=team_specs, rounds=args.rounds, layout=layout_string, layout_name=layout_name,
-                           seed=args.seed, dump=args.dump, max_timeouts=args.max_timeouts, timeout_length=args.timeout_length,
-                           viewers=viewers, controller=controller, publisher=publisher)
+        #libpelita.run_game(team_specs=team_specs, rounds=args.rounds, layout=layout_string, layout_name=layout_name,
+        #                   seed=args.seed, dump=args.dump, max_timeouts=args.max_timeouts, timeout_length=args.timeout_length,
+        #                   viewers=viewers, controller=controller, publisher=publisher)
+        layout_dict = layout.parse_layout(layout_string)
+        game.run_game(team_specs=team_specs, rounds=args.rounds, layout_dict=layout_dict, layout_name=layout_name, seed=args.seed)
 
 if __name__ == '__main__':
     main()

--- a/pelita/scripts/pelita_player.py
+++ b/pelita/scripts/pelita_player.py
@@ -17,7 +17,7 @@ import sys
 import zmq
 
 import pelita
-from ..player.team import new_style_team
+from ..player.team import new_style_team, make_team
 
 _logger = logging.getLogger(__name__)
 
@@ -79,6 +79,14 @@ def check_team_name(name):
     if name.isspace():
         raise ValueError('Invalid team name (no letters): "%s"'%name)
 
+# helper teams for the demo mode
+# TODO: Rewrite the old demo players to the new API
+def stopping(bot, state):
+    return bot.position, state
+
+def random(bot, state):
+    import random
+    return random.choice(bot.legal_positions), state
 
 def load_team(spec):
     """ Tries to load a team from a given spec.
@@ -87,11 +95,14 @@ def load_team(spec):
     If this fails, it will try to load a factory.
     """
     if spec == '0':
-        from ..player.FoodEatingPlayer import team
-        return team()
+        #from ..player.FoodEatingPlayer import team
+        #return team()
+        team, _ = make_team(stopping, team_name="stopping")
+        return team
     elif spec == '1':
-        from ..player.RandomExplorerPlayer import team
-        return team()
+        #from ..player.RandomExplorerPlayer import team
+        team, _ = make_team(random, team_name="random")
+        return team
     try:
         factory = load_factory(spec)
     except (FileNotFoundError, ImportError, ValueError,

--- a/pelita/simplesetup.py
+++ b/pelita/simplesetup.py
@@ -587,8 +587,8 @@ class SimpleClient:
     def set_initial(self, team_id, game_state):
         return self.team.set_initial(team_id, game_state)
 
-    def get_move(self, bot_id, game_state):
-        return self.team.get_move(bot_id, game_state)
+    def get_move(self, game_state):
+        return self.team.get_move(game_state)
 
     def exit(self):
         raise ExitLoop()

--- a/test/demo01_stopping.py
+++ b/test/demo01_stopping.py
@@ -1,0 +1,8 @@
+# This bot does not ever move (useful for testing)
+
+TEAM_NAME = 'StoppingBots'
+
+def move(bot, state):
+    # do not move at all
+    next_move = bot.position
+    return next_move, state

--- a/test/demo02_random.py
+++ b/test/demo02_random.py
@@ -1,0 +1,10 @@
+# This bot takes random moves, chosen among the legal ones for its current
+# position
+
+TEAM_NAME = 'RandomBots'
+
+def move(bot, state):
+    # make a reference to our bot with a shorter name
+    # mostly useful for longer code, of course
+    next_move = bot.random.choice(bot.legal_positions)
+    return next_move, state

--- a/test/test_game.py
+++ b/test/test_game.py
@@ -372,3 +372,16 @@ def test_minimal_losing_game_has_one_error():
     assert len(final_state['errors'][0]) == 1
     assert len(final_state['errors'][1]) == 0
     assert final_state['round'] == 19
+
+
+def test_minimal_remote_game():
+    def move(b, s):
+        return b.position, s
+
+    layout_name, layout_string = layout.get_random_layout()
+    l = layout.parse_layout(layout_string)
+    final_state = run_game(["test/demo01_stopping.py", move], rounds=20, layout_dict=l)
+    final_state = run_game(["test/demo01_stopping.py", 'test/demo02_random.py'], rounds=20, layout_dict=l)
+    assert final_state['gameover'] is True
+    assert final_state['score'] == [0, 0]
+    assert final_state['round'] == 19


### PR DESCRIPTION
Given the methods in `game.py`, a `RemoteTeam` behaves just as a `Team` class (it is generated with `make_team` but takes a string instead of a `move` method) such as `set_initial` and `get_move`). Underneath however, it starts a subprocess of `pelita-player` with the `team_spec` as an argument.
When the class is cleaned up, the `__del__` method is (hopefully) called, which will then terminate the subprocesses (in case this hasn’t happened yet).

NB: This means that test games that run a few rounds of `play_turn`, then store the `game_state` in a list for example and then start a new game for a few rounds etc. will have dozens or more of still-running `pelita-player` processes around, since the teams are saved inside `game_state` and will therefore not be garbage collected. We might want to add a `finalize_game_state` function at some point.

NB2: We probably want to register the running processes with `atexit` as well.
