### PR TITLE
Improving the logic of the round and turn handling

### DIFF
--- a/pelita/game.py
+++ b/pelita/game.py
@@ -115,6 +115,9 @@ class GameState:
 
 def run_game(team_specs, *, max_rounds, layout_dict, layout_name="", seed=None, dump=False,
              max_team_errors=5, timeout_length=3, viewers=None):
+    """ Run a match for `max_rounds` rounds.
+
+    """
 
     if viewers is None:
         viewers = []
@@ -262,6 +265,18 @@ def prepare_viewer_state(game_state):
 
 
 def play_turn(game_state):
+    """ Plays the next turn of the game.
+
+    This function increases the round and turn counters, requests a move
+    and returns a new game_state.
+
+    Raises
+    ------
+    ValueError
+        If gamestate['gameover'] is True
+    """
+    # TODO: Return a copy of the game_state
+
     # if the game is already over, we return a value error
     if game_state['gameover']:
         raise ValueError("Game is already over!")
@@ -418,7 +433,20 @@ def apply_move(gamestate, bot_position):
 
 
 def update_round_counter(game_state):
-    """ Returns a dict with updated turn and round numbers. """
+    """ Takes the round and turn from the game state dict, increases them by one
+    and returns a new dict.
+
+    Returns
+    -------
+    dict { 'round' , 'turn' }
+        The updated round and turn
+
+    Raises
+    ------
+    ValueError
+        If gamestate['gameover'] is True
+    """
+
     if game_state['gameover']:
         raise ValueError("Game is already over")
     turn = game_state['turn']
@@ -445,6 +473,16 @@ def update_round_counter(game_state):
 
 
 def check_gameover(game_state):
+    """ Checks for errors and fatal errors in `game_state` and sets the winner
+    accordingly.
+
+    Returns
+    -------
+    dict { 'gameover' , 'whowins' }
+        Flags if the game is over and who won it
+
+    """
+
     # check for game over
     whowins = None
     gameover = False
@@ -462,7 +500,14 @@ def check_gameover(game_state):
 
 
 def check_final_move(game_state):
-    "Checks if this was the final move."
+    """ Checks if this was the final move in the game or
+    if one team has lost all their food.
+
+    Returns
+    -------
+    dict { 'gameover' , 'whowins' }
+        Flags if the game is over and who won it
+    """
     whowins = None
     gameover = False
 

--- a/pelita/game.py
+++ b/pelita/game.py
@@ -113,7 +113,7 @@ class GameState:
         return (layout.layout_as_str(walls=self.walls, food=self.food, bots=self.bots) + "\n" +
                 str({ f.name: getattr(self, f.name) for f in dataclasses.fields(self) if f.name not in ['walls', 'food']}))
 
-def run_game(team_specs, *, rounds, layout_dict, layout_name="", seed=None, dump=False,
+def run_game(team_specs, *, max_rounds, layout_dict, layout_name="", seed=None, dump=False,
              max_team_errors=5, timeout_length=3, viewers=None):
 
     if viewers is None:
@@ -121,7 +121,7 @@ def run_game(team_specs, *, rounds, layout_dict, layout_name="", seed=None, dump
 
     # we create the initial game state
     # initialize the exceptions lists
-    state = setup_game(team_specs, layout_dict, max_rounds=rounds, seed=seed)
+    state = setup_game(team_specs, layout_dict, max_rounds=max_rounds, seed=seed)
 
     while not state.get('gameover'):
         state = play_turn(state)

--- a/pelita/game.py
+++ b/pelita/game.py
@@ -415,6 +415,16 @@ def apply_move(gamestate, bot_position):
             bots[enemy_idx] = init_positions[enemy_idx]
             deaths[abs(team-1)] = deaths[abs(team-1)] + 1
             _logger.info(f"Bot {enemy_idx} respawns at {bots[enemy_idx]}.")
+    else:
+        # check if bot was eaten itself
+        enemies_on_target = [idx for idx in enemy_idx if bots[idx] == bot_position]
+        if len(enemies_on_target) > 0:
+            _logger.info(f"Bot {turn} was eaten by bots {enemies_on_target} at {bot_position}.")
+            score[1 - team] = score[1 - team] + 5
+            init_positions = initial_positions(walls)
+            bots[turn] = init_positions[turn]
+            deaths[team] = deaths[team] + 1
+            _logger.info(f"Bot {turn} respawns at {bots[turn]}.")
 
     gamestate.update(check_gameover(gamestate))
 

--- a/pelita/game.py
+++ b/pelita/game.py
@@ -163,7 +163,7 @@ def setup_game(team_specs, layout_dict, max_rounds=300, seed=None):
         food=food,
         walls=layout_dict['walls'][:],
         deaths=[0] * 2,
-        say=[""] * 2,
+        say=[""] * 4,
         layout_name=None,
         team_names=[None] * 2,
         fatal_errors=[False] * 2,
@@ -508,10 +508,16 @@ def check_final_move(game_state):
     dict { 'gameover' , 'whowins' }
         Flags if the game is over and who won it
     """
-    whowins = None
-    gameover = False
 
-    if not game_state['gameover']:
+    if game_state['gameover']:
+        # Game already finished.
+        whowins = game_state['whowins']
+        gameover = game_state['gameover']
+
+    else:
+        whowins = None
+        gameover = False
+
         # The game is over when the next step would give us
         # game_state['round'] == game_state['max_rounds']
         # or when one team has lost all their food

--- a/pelita/game.py
+++ b/pelita/game.py
@@ -256,6 +256,12 @@ def play_turn(game_state):
         game_state['round'] = 0
         game_state['turn'] = 0
 
+    if game_state['round'] >= game_state['max_rounds']:
+        # TODO
+        # set gameover state properly
+        game_state['gameover'] = True
+        return game_state
+
     team = game_state['turn'] % 2
     # request a new move from the current team
     try:

--- a/pelita/scripts/pelita_main.py
+++ b/pelita/scripts/pelita_main.py
@@ -381,7 +381,7 @@ def main():
         #                   seed=args.seed, dump=args.dump, max_timeouts=args.max_timeouts, timeout_length=args.timeout_length,
         #                   viewers=viewers, controller=controller, publisher=publisher)
         layout_dict = layout.parse_layout(layout_string)
-        game.run_game(team_specs=team_specs, rounds=args.rounds, layout_dict=layout_dict, layout_name=layout_name, seed=args.seed)
+        game.run_game(team_specs=team_specs, max_rounds=args.rounds, layout_dict=layout_dict, layout_name=layout_name, seed=args.seed)
 
 if __name__ == '__main__':
     main()

--- a/test/test_game.py
+++ b/test/test_game.py
@@ -432,7 +432,10 @@ def test_update_round_counter():
     for (round0, turn0), (round1, turn1) in tests.items():
         res = game.update_round_counter({'turn': turn0, 'round': round0, 'gameover': False})
         assert res == {'turn': turn1, 'round': round1}
-    pass
+
+    for (round0, turn0), (round1, turn1) in tests.items():
+        with pytest.raises(ValueError):
+            res = game.update_round_counter({'turn': turn0, 'round': round0, 'gameover': True})
 
 
 @pytest.mark.parametrize('bot_to_move', [0, 1, 2, 3])

--- a/test/test_game.py
+++ b/test/test_game.py
@@ -343,6 +343,47 @@ def setup_specific_basic_gamestate(layout_id):
     return game_state
 
 
+def test_max_rounds():
+    l = """
+    ########
+    #20  13#
+    #      #
+    ########
+    """
+    def move(bot, s):
+        # in the first round (round #0),
+        # all bots move to the south
+        if bot.round == 0:
+            # go one step to the right
+            return (bot.position[0], bot.position[1] + 1), s
+        else:
+            # There should not be more then one round in this test
+            raise RuntimeError("We should not be here in this test")
+    
+    l = layout.parse_layout(l)
+    assert l['bots'][0] == (2, 1)
+    assert l['bots'][1] == (5, 1)
+    assert l['bots'][2] == (1, 1)
+    assert l['bots'][3] == (6, 1)
+    # max_rounds == 0 should not call move at all
+    final_state = run_game([move, move], layout_dict=l, rounds=0)
+#    assert final_state['round'] == 0
+    assert final_state['bots'][0] == (2, 1)
+    assert final_state['bots'][1] == (5, 1)
+    assert final_state['bots'][2] == (1, 1)
+    assert final_state['bots'][3] == (6, 1)
+    # max_rounds == 1 should call move just once
+    final_state = run_game([move, move], layout_dict=l, rounds=1)
+#    assert final_state['round'] == 1
+    assert final_state['bots'][0] == (2, 1)
+    assert final_state['bots'][0] == (2, 2)
+    assert final_state['bots'][1] == (5, 2)
+    assert final_state['bots'][2] == (1, 2)
+    assert final_state['bots'][3] == (6, 2)
+    with pytest.raises(RuntimeError):
+        final_state = run_game([move, move], layout_dict=l, rounds=2)
+
+
 def test_minimal_game():
     def move(b, s):
         return b.position, s

--- a/test/test_game.py
+++ b/test/test_game.py
@@ -400,15 +400,78 @@ def test_cascade_kill():
     layouts = [layout.parse_layout(l) for l in cascade]
     state = setup_game([move, move], max_rounds=5, layout_dict=layout.parse_layout(cascade[0]))
     assert state['bots'] == layouts[0]['bots']
-    state = game.play_turn(state) # Bot 0 moves
+    state = game.play_turn(state) # Bot 0 stands
     assert state['bots'] == layouts[0]['bots']
-    state = game.play_turn(state) # Bot 1 moves
-    state = game.play_turn(state) # Bot 2 moves
+    state = game.play_turn(state) # Bot 1 stands
+    state = game.play_turn(state) # Bot 2 stands
     state = game.play_turn(state) # Bot 3 moves, kills 0. Bot 0 and 1 are on same spot
     assert state['bots'] == layouts[1]['bots']
-    state = game.play_turn(state) # Bot 0 moves, kills 1. Bot 1 and 2 are on same spot
+    state = game.play_turn(state) # Bot 0 stands, kills 1. Bot 1 and 2 are on same spot
     assert state['bots'] == layouts[2]['bots']
-    state = game.play_turn(state) # Bot 1 moves, kills 2.
+    state = game.play_turn(state) # Bot 1 stands, kills 2.
+    assert state['bots'] == layouts[3]['bots']
+
+
+def test_cascade_kill_2():
+    """ Checks that killing occurs only for the bot whose turn it is
+    or for any bot that this bot moves onto.
+    If a bot respawns on an enemy, it will only be killed when it is its own
+    or the enemy’s turn (and neither of them moves).
+    """
+    cascade = [
+    """
+    ########
+    #30.. 2#
+    #1     #
+    ########
+    """,
+    """
+    ########
+    #0 .. 2#
+    #1     #
+    ########
+
+    ########
+    #  .. 3#
+    #      #
+    ########
+    """,
+    """
+    ########
+    #0 .. 3#
+    #1     #
+    ########
+
+    ########
+    #  ..  #
+    #2     #
+    ########
+    """,
+    """
+    ########
+    #0 .. 3#
+    #2    1#
+    ########
+    """
+    ]
+    def move(bot, state):
+        if bot.is_blue and bot.turn == 0 and bot.round == 0:
+            return (1, 1), state
+        return bot.position, state
+    layouts = [layout.parse_layout(l) for l in cascade]
+    state = setup_game([move, move], max_rounds=5, layout_dict=layout.parse_layout(cascade[0]))
+    assert state['bots'] == layouts[0]['bots']
+    state = game.play_turn(state) # Bot 0 moves, kills 3. Bot 2 and 3 are on same spot
+    assert state['bots'] == layouts[1]['bots']
+    state = game.play_turn(state) # Bot 1 stands. Bot 2 and 3 are on same spot
+    assert state['bots'] == layouts[1]['bots']
+    state = game.play_turn(state) # Bot 2 stands, gets killed. Bot 1 and 2 are on same spot
+    assert state['bots'] == layouts[2]['bots']
+    state = game.play_turn(state) # Bot 3 stands. Bot 1 and 2 are on same spot
+    assert state['bots'] == layouts[2]['bots']
+    state = game.play_turn(state) # Bot 0 stands. Bot 1 and 2 are on same spot
+    assert state['bots'] == layouts[2]['bots']
+    state = game.play_turn(state) # Bot 1 stands, kills 2.
     assert state['bots'] == layouts[3]['bots']
 
 

--- a/test/test_game.py
+++ b/test/test_game.py
@@ -366,22 +366,22 @@ def test_max_rounds():
     assert l['bots'][2] == (1, 1)
     assert l['bots'][3] == (6, 1)
     # max_rounds == 0 should not call move at all
-    final_state = run_game([move, move], layout_dict=l, rounds=0)
 #    assert final_state['round'] == 0
+    final_state = run_game([move, move], layout_dict=l, max_rounds=0)
     assert final_state['bots'][0] == (2, 1)
     assert final_state['bots'][1] == (5, 1)
     assert final_state['bots'][2] == (1, 1)
     assert final_state['bots'][3] == (6, 1)
     # max_rounds == 1 should call move just once
-    final_state = run_game([move, move], layout_dict=l, rounds=1)
 #    assert final_state['round'] == 1
     assert final_state['bots'][0] == (2, 1)
+    final_state = run_game([move, move], layout_dict=l, max_rounds=1)
     assert final_state['bots'][0] == (2, 2)
     assert final_state['bots'][1] == (5, 2)
     assert final_state['bots'][2] == (1, 2)
     assert final_state['bots'][3] == (6, 2)
     with pytest.raises(RuntimeError):
-        final_state = run_game([move, move], layout_dict=l, rounds=2)
+        final_state = run_game([move, move], layout_dict=l, max_rounds=2)
 
 
 @pytest.mark.parametrize('bot_to_move', [0, 1, 2, 3])
@@ -402,7 +402,7 @@ def test_finished_when_no_food(bot_to_move):
         return bot.position, s
 
     l = layout.parse_layout(l)
-    final_state = run_game([move, move], layout_dict=l, rounds=20)
+    final_state = run_game([move, move], layout_dict=l, max_rounds=20)
     assert final_state['round'] == 0
     assert final_state['turn'] == bot_to_move
 
@@ -414,7 +414,7 @@ def test_minimal_game():
 
     layout_name, layout_string = layout.get_random_layout()
     l = layout.parse_layout(layout_string)
-    final_state = run_game([move, move], rounds=20, layout_dict=l)
+    final_state = run_game([move, move], max_rounds=20, layout_dict=l)
     assert final_state['gameover'] is True
     assert final_state['score'] == [0, 0]
     assert final_state['round'] == 19
@@ -431,7 +431,7 @@ def test_minimal_losing_game_has_one_error():
 
     layout_name, layout_string = layout.get_random_layout()
     l = layout.parse_layout(layout_string)
-    final_state = run_game([move0, move1], rounds=20, layout_dict=l)
+    final_state = run_game([move0, move1], max_rounds=20, layout_dict=l)
     assert final_state['gameover'] is True
     assert final_state['score'] == [0, 0]
     assert len(final_state['errors'][0]) == 1
@@ -445,8 +445,8 @@ def test_minimal_remote_game():
 
     layout_name, layout_string = layout.get_random_layout()
     l = layout.parse_layout(layout_string)
-    final_state = run_game(["test/demo01_stopping.py", move], rounds=20, layout_dict=l)
-    final_state = run_game(["test/demo01_stopping.py", 'test/demo02_random.py'], rounds=20, layout_dict=l)
+    final_state = run_game(["test/demo01_stopping.py", move], max_rounds=20, layout_dict=l)
+    final_state = run_game(["test/demo01_stopping.py", 'test/demo02_random.py'], max_rounds=20, layout_dict=l)
     assert final_state['gameover'] is True
     assert final_state['score'] == [0, 0]
     assert final_state['round'] == 19

--- a/test/test_game.py
+++ b/test/test_game.py
@@ -254,6 +254,63 @@ def test_play_turn_friendly_fire(setups):
     assert game_state_new["score"][team] == 5
 
 
+def test_multiple_enemies_killing():
+    """ Check that you can kill multiple enemies at once. """
+
+    l0 = """
+    ########
+    #  ..  #
+    # 210  #
+    ########
+
+    ########
+    #  ..  #
+    #  3   #
+    ########
+    """
+
+    l1 = """
+    ########
+    #  ..  #
+    #  103 #
+    ########
+
+    ########
+    #  ..  #
+    #   2  #
+    ########
+    """
+    # dummy bots
+    stopping = lambda bot, s: (bot.position, s)
+
+    parsed_l0 = layout.parse_layout(l0)
+    for bot in (0, 2):
+        game_state = setup_game([stopping, stopping], layout_dict=parsed_l0)
+
+        game_state['turn'] = bot
+        # get position of bots 1 (and 3)
+        kill_position = game_state['bots'][1]
+        assert kill_position == game_state['bots'][3]
+        new_state = apply_move(game_state, kill_position)
+        # team 0 scores twice
+        assert new_state['score'] == [10, 0]
+        # bots 1 and 3 are back to origin
+        assert new_state['bots'][1::2] == [(6, 2), (6, 1)]
+
+    parsed_l1 = layout.parse_layout(l1)
+    for bot in (1, 3):
+        game_state = setup_game([stopping, stopping], layout_dict=parsed_l1)
+
+        game_state['turn'] = bot
+        # get position of bots 0 (and 2)
+        kill_position = game_state['bots'][0]
+        assert kill_position == game_state['bots'][2]
+        new_state = apply_move(game_state, kill_position)
+        # team 1 scores twice
+        assert new_state['score'] == [0, 10]
+        # bots 0 and 2 are back to origin
+        assert new_state['bots'][0::2] == [(1, 1), (1, 2)]
+
 
 @pytest.mark.parametrize('score', ([[3, 3], 2], [[1, 13], 1], [[13, 1], 0]))
 def test_play_turn_maxrounds(score):

--- a/test/test_game.py
+++ b/test/test_game.py
@@ -175,11 +175,9 @@ def test_play_turn_eating_enemy_food(turn, which_food):
     #5# #0# ###.  .  # # #
     #6# #2     .##. ... .#
     #7# ##################
-    game_state = setup_specific_basic_gamestate("layouts/small_without_dead_ends_001.layout")
-    prev_len_food = [len(team_food) for team_food in game_state["food"]]
-    #turn = 0
+    game_state = setup_specific_basic_gamestate("layouts/small_without_dead_ends_001.layout", round=0, turn=turn)
     team = turn % 2
-    game_state["turn"] = turn
+    prev_len_food = [len(team_food) for team_food in game_state["food"]]
 
     if which_food == 1:
         # food belongs to team 1
@@ -291,55 +289,30 @@ def test_play_turn_move():
 
 
 
-def setup_random_basic_gamestate():
+def setup_random_basic_gamestate(*, round=0, turn=0):
     """helper function for testing play turn"""
     turn = 0
     l = Path("layouts/small_without_dead_ends_100.layout").read_text()
     parsed_l = layout.parse_layout(l)
-    game_state = {
-        "food": parsed_l["food"],
-        "walls": parsed_l["walls"],
-        "bots": parsed_l["bots"],
-        "max_rounds": 300,
-        "team_names": ("a", "b"),
-        "turn": turn,
-        "round": 0,
-        "timeout": [],
-        "gameover": False,
-        "whowins": None,
-        "team_say": "bla",
-        "score": [0, 0],
-        "deaths": 0,
-        "errors": [[], []],
-        "fatal_errors": [{}, {}],
-        "rnd": random.Random()
-        }
+
+    stopping = lambda bot, s: (bot.position, s)
+
+    game_state = setup_game([stopping, stopping], layout_dict=parsed_l)
+    game_state['round'] = round
+    game_state['turn'] = turn
     return game_state
 
 
-def setup_specific_basic_gamestate(layout_id):
+def setup_specific_basic_gamestate(layout_id, *, round=0, turn=0):
     """helper function for testing play turn"""
-    turn = 0
     l = Path(layout_id).read_text()
     parsed_l = layout.parse_layout(l)
-    game_state = {
-        "food": parsed_l["food"],
-        "walls": parsed_l["walls"],
-        "bots": parsed_l["bots"],
-        "max_rounds": 300,
-        "team_names": ("a", "b"),
-        "turn": turn,
-        "round": 0,
-        "timeout": [],
-        "gameover": False,
-        "whowins": None,
-        "team_say": "bla",
-        "score": [0, 0],
-        "deaths": [0, 0],
-        "errors": [[], []],
-        "fatal_errors": [{}, {}],
-        "rnd": random.Random()
-        }
+
+    stopping = lambda bot, s: (bot.position, s)
+
+    game_state = setup_game([stopping, stopping], layout_dict=parsed_l)
+    game_state['round'] = round
+    game_state['turn'] = turn
     return game_state
 
 

--- a/test/test_game.py
+++ b/test/test_game.py
@@ -475,6 +475,102 @@ def test_cascade_kill_2():
     assert state['bots'] == layouts[3]['bots']
 
 
+def test_cascade_kill_rescue_1():
+    """ Checks that killing occurs only for the bot whose turn it is
+    or for any bot that this bot moves onto.
+    If a bot respawns on an enemy, it will only be killed when it is its own
+    or the enemy’s turn (and neither of them moves).
+    If bot moves before it is the enemy’s turn. Bot is rescued.
+    """
+    cascade = [
+    """
+    ########
+    #30.. 2#
+    #1     #
+    ########
+    """,
+    """
+    ########
+    #0 .. 2#
+    #1     #
+    ########
+
+    ########
+    #  .. 3#
+    #      #
+    ########
+    """,
+    """
+    ########
+    #0 ..23#
+    #1     #
+    ########
+    """
+    ]
+    def move(bot, state):
+        if bot.is_blue and bot.turn == 0 and bot.round == 0:
+            return (1, 1), state
+        if bot.is_blue and bot.turn == 1 and bot.round == 0:
+            return (5, 1), state
+        return bot.position, state
+    layouts = [layout.parse_layout(l) for l in cascade]
+    state = setup_game([move, move], max_rounds=5, layout_dict=layout.parse_layout(cascade[0]))
+    assert state['bots'] == layouts[0]['bots']
+    state = game.play_turn(state) # Bot 0 moves, kills 3. Bot 2 and 3 are on same spot
+    assert state['bots'] == layouts[1]['bots']
+    state = game.play_turn(state) # Bot 1 stands. Bot 2 and 3 are on same spot
+    assert state['bots'] == layouts[1]['bots']
+    state = game.play_turn(state) # Bot 2 moves. Rescues itself
+    assert state['bots'] == layouts[2]['bots']
+
+
+def test_cascade_kill_rescue_2():
+    """ Checks that killing occurs only for the bot whose turn it is
+    or for any bot that this bot moves onto.
+    If a bot respawns on an enemy, it will only be killed when it is its own
+    or the enemy’s turn (and neither of them moves).
+    If enemy moves before it is the bot’s turn. Bot is rescued.
+    """
+    cascade = [
+    """
+    ########
+    #3 ..  #
+    #10   2#
+    ########
+    """,
+    """
+    ########
+    #3 ..  #
+    #0    1#
+    ########
+
+    ########
+    #  ..  #
+    #     2#
+    ########
+    """,
+    """
+    ########
+    #3 ..  #
+    #0   12#
+    ########
+    """
+    ]
+    def move(bot, state):
+        if bot.is_blue and bot.turn == 0 and bot.round == 0:
+            return (1, 2), state
+        if not bot.is_blue and bot.turn == 0 and bot.round == 0:
+            return (5, 2), state
+        return bot.position, state
+    layouts = [layout.parse_layout(l) for l in cascade]
+    state = setup_game([move, move], max_rounds=5, layout_dict=layout.parse_layout(cascade[0]))
+    assert state['bots'] == layouts[0]['bots']
+    state = game.play_turn(state) # Bot 0 moves, kills 1. Bot 1 and 2 are on same spot
+    assert state['bots'] == layouts[1]['bots']
+    state = game.play_turn(state) # Bot 1 moves. Bot 2 is rescued.
+    assert state['bots'] == layouts[2]['bots']
+
+
 def test_cascade_suicide():
     cascade = [
     """


### PR DESCRIPTION
The logic is as follows:

run_game is basically a loop with the following conventions:

    def run_game(**game_kwargs):

        game_state = setup_game(**game_kwargs)
        assert game_state['round'] == None
        assert game_state['turn'] == None

        while not game_state['gameover']:
            game_state = play_turn(game_state)

            assert game_state['round'] >= 0
            # round is always smaller than max_rounds
            assert game_state['round'] < game_state['max_rounds']
            assert 0 <= game_state['turn'] < 4

The round and turn in a `game_state` _in this loop_ will always signify the bot that has last moved. If no bot has moved yet, these are naturally `None`. The same state will be given to the viewers (this happens inside `play_turn`) to avoid confusion. A function `check_final_move` is added to properly check whether another move can be played or whether we are in the last turn of the final round.

A bot will however see the _current_ round and turn. I.e. turn == the bot’s own index.