### PR TITLE
Adapt the Tk viewer to the new API and add it to run_game

### DIFF
--- a/pelita/exceptions.py
+++ b/pelita/exceptions.py
@@ -1,0 +1,15 @@
+
+class FatalException(Exception): # TODO rename to FatalGameException etc
+    pass
+
+class NonFatalException(Exception):
+    pass
+
+class PlayerTimeout(NonFatalException):
+    pass
+
+class PlayerDisconnected(FatalException):
+    # unsure, if PlayerDisconnected should be fatal in the sense of that the team loses
+    # it could simply be a network error for both teams
+    # and it would be random who will be punished
+    pass

--- a/pelita/game.py
+++ b/pelita/game.py
@@ -118,7 +118,7 @@ class GameState:
     controller: typing.Optional
 
     def pretty_str(self):
-        return (layout.layout_as_str(walls=self.walls, food=self.food, bots=self.bots) + "\n" +
+        return (layout.layout_as_str(walls=self.walls, food=list(self.food[0] | self.food[1]), bots=self.bots) + "\n" +
                 str({ f.name: getattr(self, f.name) for f in dataclasses.fields(self) if f.name not in ['walls', 'food']}))
 
 

--- a/pelita/game.py
+++ b/pelita/game.py
@@ -7,25 +7,11 @@ import sys
 import typing
 
 from . import layout
+from .exceptions import FatalException, NonFatalException
 from .gamestate_filters import noiser
 from .player.team import make_team
 
 _logger = logging.getLogger(__name__)
-
-class FatalException(Exception): # TODO rename to FatalGameException etc
-    pass
-
-class NonFatalException(Exception):
-    pass
-
-class PlayerTimeout(NonFatalException):
-    pass
-
-class PlayerDisconnected(FatalException):
-    # unsure, if PlayerDisconnected should be fatal in the sense of that the team loses
-    # it could simply be a network error for both teams
-    # and it would be random who will be punished
-    pass
 
 @dataclasses.dataclass
 class GameState:
@@ -308,7 +294,7 @@ def play_turn(game_state):
         game_state['fatal_errors'][team].append(exception_event)
         position = None
     except NonFatalException as e:
-        # NoneFatalExceptions (such as Timeouts and ValueErrors in the JSON handling)
+        # NonFatalExceptions (such as Timeouts and ValueErrors in the JSON handling)
         # are collected and added to team_errors
         exception_event = {
             'type': str(e),

--- a/pelita/game.py
+++ b/pelita/game.py
@@ -165,7 +165,7 @@ def setup_game(team_specs, layout_dict, max_rounds=300, seed=None):
     
     game_state['team_specs'] = []
     for idx, team_spec in enumerate(team_specs):
-        team, zmq_context = make_team(team_spec)
+        team, zmq_context = make_team(team_spec, idx=idx)
         team_name = team.set_initial(idx, prepare_bot_state(game_state, idx))
         game_state['team_specs'].append(team)
 

--- a/pelita/network.py
+++ b/pelita/network.py
@@ -1,0 +1,77 @@
+
+import logging
+
+import json
+import time
+import zmq
+
+from .simplesetup import bind_socket
+
+_logger = logging.getLogger(__name__)
+
+class Controller:
+    def __init__(self, address='tcp://127.0.0.1:*', zmq_context=None):
+        self.address = address
+        if zmq_context:
+            self.context = zmq_context
+        else:
+            self.context = zmq.Context()
+        # We use a ROUTER which we bind.
+        # This means other DEALERs can connect and
+        # each one can take over control.
+        self.socket = self.context.socket(zmq.ROUTER)
+        self.socket_addr = bind_socket(self.socket, self.address)
+        self.pollin = zmq.Poller()
+        self.pollin.register(self.socket, zmq.POLLIN)
+        _logger.debug("Bound zmq.ROUTER to {}".format(self.socket_addr))
+
+    def await_action(self, await_action, timeout=None, accept_exit=True):
+        """ Waits `timeout` seconds to receive an action. """
+        t_start = time.monotonic()
+        if timeout is None:
+            t_end = float("inf")
+        else:
+            t_end = t_start + timeout
+
+        while time.monotonic() < t_end:
+
+            # TODO: Proper time left handling
+            timeoutmillis = timeout * 1000 if timeout is not None else None
+
+            sock = dict(self.pollin.poll(timeoutmillis)) # poll needs milliseconds
+            if sock.get(self.socket) == zmq.POLLIN:
+                try:
+                    sender, msg = self.socket.recv_multipart()
+                    msg = json.loads(msg)
+                    action = msg['__action__']
+                    _logger.debug('Received action %r from %r', action, sender)
+                except ValueError:
+                    _logger.warning('Could not deserialize message from %r', sender)
+                    continue
+                except (TypeError, KeyError):
+                    _logger.warning('No action in message from %r', sender)
+                    continue
+
+                expected_actions = [await_action]
+                if accept_exit:
+                    expected_actions.append('exit') 
+                if action in expected_actions:
+                    return action
+                _logger.warning('Unexpected action %r. (Expected: %s) Ignoring.', action, ", ".join(expected_actions))
+                continue
+
+
+    def recv_start(self, timeout=None):
+        """ Waits `timeout` seconds for start message.
+        
+        Returns `True`, when the message arrives, `False` when an exit
+        message arrives or a timeout occurs.
+        """
+
+
+def setup_controller(zmq_context=None):
+    if not zmq_context:
+        import zmq
+        zmq_context = zmq.Context()
+    controller = Controller(zmq_context=zmq_context)
+    return controller

--- a/pelita/player/team.py
+++ b/pelita/player/team.py
@@ -10,6 +10,7 @@ import zmq
 
 from . import AbstractTeam
 from .. import libpelita
+from ..exceptions import PlayerDisconnected, PlayerTimeout
 from ..simplesetup import ZMQConnection, ZMQConnectionError, ZMQReplyTimeout, ZMQUnreachablePeer, DEAD_CONNECTION_TIMEOUT
 
 

--- a/pelita/player/team.py
+++ b/pelita/player/team.py
@@ -145,7 +145,7 @@ class RemoteTeam:
     address
         The zmq address (an address will be chosen randomly, if empty)
     """
-    def __init__(self, team_spec, team_name=None, address="tcp://", zmq_context=None, timeout_length=3):
+    def __init__(self, team_spec, team_name=None, address="tcp://", zmq_context=None, timeout_length=3, idx=None):
         if zmq_context is None:
             zmq_context = zmq.Context()
         socket = zmq_context.socket(zmq.PAIR)
@@ -155,7 +155,11 @@ class RemoteTeam:
         self.bound_to_address =f"tcp://localhost:{port}"
         self.zmqconnection = ZMQConnection(socket)
         self.timeout_length = timeout_length
-        self.proc = self._call_pelita_player(team_spec, self.bound_to_address)
+        if idx == 0:
+            color='blue'
+        if idx == 1:
+            color='red'
+        self.proc = self._call_pelita_player(team_spec, self.bound_to_address, color=color)
 
     def _call_pelita_player(self, team_spec, address, color='', dump=None):
         """ Starts another process with the same Python executable,
@@ -244,7 +248,7 @@ class RemoteTeam:
         return f"RemoteTeam<{self._team_spec}{team_name} on {self.bound_to_address}>" 
 
 
-def make_team(team_spec, team_name=None, zmq_context=None):
+def make_team(team_spec, team_name=None, zmq_context=None, idx=None):
     """ Creates a Team object for the given team_spec.
 
     If no zmq_context is passed for a remote team, then a new context
@@ -285,7 +289,7 @@ def make_team(team_spec, team_name=None, zmq_context=None):
             # start pelita-player
             if not zmq_context:
                 zmq_context = zmq.Context()
-            team_player = RemoteTeam(team_spec=team_spec, zmq_context=zmq_context)
+            team_player = RemoteTeam(team_spec=team_spec, zmq_context=zmq_context, idx=idx)
 
     return team_player, zmq_context
 

--- a/pelita/player/team.py
+++ b/pelita/player/team.py
@@ -588,7 +588,7 @@ def bot_from_layout(layout, is_blue, score, round, team_name, timeout_count):
         'bot_positions': layout.bots[:],
         'team_index': 0 if is_blue else 1,
         'score': 0,
-        'has_respawned': False,
+        'has_respawned': True,
         'timeout_count': 0,
         'food': [food for food in layout.food if in_homezone(food, is_blue)],
     }

--- a/pelita/player/team.py
+++ b/pelita/player/team.py
@@ -398,7 +398,7 @@ class Bot:
     @property
     def turn(self):
         """ The turn of our bot. """
-        return self.bot_index // 2
+        return self.bot_index % 2
 
     @property
     def other(self):

--- a/pelita/scripts/pelita_main.py
+++ b/pelita/scripts/pelita_main.py
@@ -361,27 +361,40 @@ def main():
     
     print("Using layout '%s'" % layout_name)
 
-    with libpelita.channel_setup(publish_to=args.publish_to) as channels:
-        if args.viewer.startswith('tk'):
-            geometry = args.geometry
-            delay = int(1000./args.fps)
-            controller = channels["controller"]
-            controller_addr = controller.socket_addr
-            publisher = channels["publisher"]
-            if args.viewer == 'tk-no-sync':
-                controller = None
-                controller_addr = None
-            viewer = libpelita.run_external_viewer(publisher.socket_addr, controller_addr,
-                                                   geometry=geometry, delay=delay, stop_after=args.stop_after)
-        else:
-            controller = None
-            publisher = None
+#   with libpelita.channel_setup(publish_to=args.publish_to) as channels:
+#       if args.viewer.startswith('tk'):
+#           geometry = args.geometry
+#           delay = int(1000./args.fps)
+#           controller = channels["controller"]
+#           controller_addr = controller.socket_addr
+#           publisher = channels["publisher"]
+#           if args.viewer == 'tk-no-sync':
+#               controller = None
+#               controller_addr = None
+#           viewer = libpelita.run_external_viewer(publisher.socket_addr, controller_addr,
+#                                                  geometry=geometry, delay=delay, stop_after=args.stop_after)
+#       else:
+#           controller = None
+#           publisher = None
 
         #libpelita.run_game(team_specs=team_specs, rounds=args.rounds, layout=layout_string, layout_name=layout_name,
         #                   seed=args.seed, dump=args.dump, max_timeouts=args.max_timeouts, timeout_length=args.timeout_length,
         #                   viewers=viewers, controller=controller, publisher=publisher)
-        layout_dict = layout.parse_layout(layout_string)
-        game.run_game(team_specs=team_specs, max_rounds=args.rounds, layout_dict=layout_dict, layout_name=layout_name, seed=args.seed)
+    
+    geometry = args.geometry
+    delay = int(1000./args.fps)
+    stop_after = args.stop_after
+
+    viewer_options = {
+        "geometry": geometry,
+        "delay": delay,
+        "stop_at": stop_after
+    }
+
+    layout_dict = layout.parse_layout(layout_string)
+    game.run_game(team_specs=team_specs, max_rounds=args.rounds, layout_dict=layout_dict, layout_name=layout_name, seed=args.seed,
+                  timeout_length=args.timeout_length, max_team_errors=args.max_timeouts, dump=args.dump,
+                  viewers=[args.viewer], viewer_options=viewer_options)
 
 if __name__ == '__main__':
     main()

--- a/pelita/scripts/pelita_player.py
+++ b/pelita/scripts/pelita_player.py
@@ -53,7 +53,13 @@ def make_client(team_spec, address, color=None):
 
         raise
 
-    print("%s team '%s' -> '%s'" % (color, team_spec, team.team_name))
+    if color == 'blue':
+        pie = '\033[94m' + 'ᗧ' + '\033[0m'
+    elif color == 'red':
+        pie = '\033[91m' + 'ᗧ' + '\033[0m'
+    else:
+        pie = 'ᗧ'
+    print(f"{pie} {color} team '{team_spec}' -> '{team.team_name}'")
 
     client = pelita.simplesetup.SimpleClient(team, address=address)
     return client

--- a/pelita/scripts/pelita_tkviewer.py
+++ b/pelita/scripts/pelita_tkviewer.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import os
 
 import pelita
 from pelita.ui.tk_viewer import TkViewer
@@ -18,6 +19,8 @@ def geometry_string(s):
         msg = "%s is not a valid geometry specification" %s
         raise argparse.ArgumentTypeError(msg)
     return geometry
+
+LOG_TK = os.environ.get("PELITA_LOG_TK", None)
 
 parser = argparse.ArgumentParser(description='Open a Tk viewer')
 parser.add_argument('subscribe_sock', metavar="URL", type=str,
@@ -48,7 +51,7 @@ def main():
         sys.exit(0)
 
 
-    if args.log:
+    if LOG_TK or args.log:
         pelita.libpelita.start_logging(args.log)
 
     tkargs = {

--- a/pelita/simplesetup.py
+++ b/pelita/simplesetup.py
@@ -623,6 +623,7 @@ class SimplePublisher(AbstractViewer):
 
 
     def _send(self, message):
+        _logger.debug("--#>")
         as_json = json.dumps(message)
         self.socket.send_unicode(as_json)
 
@@ -635,6 +636,12 @@ class SimplePublisher(AbstractViewer):
         message = {"__action__": "observe",
                    "__data__": {"game_state": game_state}}
         self._send(message)
+
+    def show_state(self, game_state):
+        message = {"__action__": "observe",
+                   "__data__": game_state}
+        self._send(message)
+
 
 class SimpleSubscriber(AbstractViewer):
     """ Subscribes to a given zmq socket and passes

--- a/pelita/ui/tk_canvas.py
+++ b/pelita/ui/tk_canvas.py
@@ -680,6 +680,9 @@ class TkApplication:
     def request_step(self):
         if not self.controller_socket:
             return
+        
+        if self._game_state['gameover']:
+            return
 
         if self._stop_after is not None:
             next_step = update_round_counter(self._game_state)
@@ -698,6 +701,9 @@ class TkApplication:
         if not self.controller_socket:
             return
 
+        if self._game_state['gameover']:
+            return
+
         if self._game_state['round'] is not None:
             next_step = update_round_counter(self._game_state)
             self._stop_after = next_step['round'] + 1
@@ -708,13 +714,10 @@ class TkApplication:
 
     def observe(self, game_state):
         # TODO
-        game_state['timeout_teams'] = [0, 0]
-        game_state['times_killed'] = [0, 0]
-        game_state['team_time'] = [0, 0]
-        game_state['teams_disqualified'] = [0, 0]
+        game_state['timeout_teams'] = [len(errors) for errors in game_state['errors']]
+        game_state['teams_disqualified'] = [fatal and fatal[0]['type'] for fatal in game_state['fatal_errors']]
         game_state['bot_destroyed'] = []
         game_state['food_eaten'] = []
-        game_state['say'] = ["", "", "", ""]
         self.update(game_state)
         if self._stop_after is not None:
             if self._stop_after == 0:

--- a/pelita/ui/tk_canvas.py
+++ b/pelita/ui/tk_canvas.py
@@ -630,6 +630,10 @@ class TkApplication:
         if not self.size_changed:
             return
         self.ui.game_canvas.delete("wall")
+        # we keep all wall items stored in a list
+        # some versions of Python seem to forget about drawing
+        # them otherwise
+        self.wall_items = []
         num = 0
         for wall in game_state['walls']:
             model_x, model_y = wall
@@ -639,6 +643,7 @@ class TkApplication:
                               if [model_x + dx, model_y + dy] in game_state['walls']]
             wall_item = Wall(self.mesh_graph, wall_neighbors=wall_neighbors, position=(model_x, model_y))
             wall_item.draw(self.ui.game_canvas)
+            self.wall_items.append(wall_item)
             num += 1
 
     def init_bot_sprites(self, bot_positions):

--- a/pelita/ui/tk_canvas.py
+++ b/pelita/ui/tk_canvas.py
@@ -8,6 +8,7 @@ import tkinter
 import tkinter.font
 
 from ..libpelita import firstNN
+from ..game import update_round_counter
 from .tk_sprites import BotSprite, Food, Wall, col
 from .tk_utils import wm_delete_window_handler
 from .tk_sprites import BotSprite, Food, Wall, RED, BLUE, YELLOW, GREY, BROWN
@@ -681,10 +682,8 @@ class TkApplication:
             return
 
         if self._stop_after is not None:
-            if self._game_state['round'] is None:
-                _logger.debug('---> play_step')
-                self.controller_socket.send_json({"__action__": "play_step"})
-            elif (self._game_state['round'] < self._stop_after):
+            next_step = update_round_counter(self._game_state)
+            if (next_step['round'] < self._stop_after):
                 _logger.debug('---> play_step')
                 self.controller_socket.send_json({"__action__": "play_step"})
             else:
@@ -699,8 +698,9 @@ class TkApplication:
         if not self.controller_socket:
             return
 
-        if self._game_state['round']:
-            self._stop_after = self._game_state['round'] + 1
+        if self._game_state['round'] is not None:
+            next_step = update_round_counter(self._game_state)
+            self._stop_after = next_step['round'] + 1
         else:
             self._stop_after = 1
             self._delay = self._min_delay

--- a/pelita/ui/tk_canvas.py
+++ b/pelita/ui/tk_canvas.py
@@ -7,7 +7,6 @@ import zmq
 import tkinter
 import tkinter.font
 
-from ..datamodel import CTFUniverse
 from ..libpelita import firstNN
 from .tk_sprites import BotSprite, Food, Wall, col
 from .tk_utils import wm_delete_window_handler
@@ -299,9 +298,9 @@ class TkApplication:
             self.master.after_idle(self.request_initial)
 
 
-    def init_mesh(self, universe):
-        width = universe.maze.width
-        height = universe.maze.height
+    def init_mesh(self, game_state):
+        width = max(game_state['walls'])[0] + 1
+        height = max(game_state['walls'])[1] + 1
 
         if self.geometry is None:
             screensize = (
@@ -315,13 +314,13 @@ class TkApplication:
         scale = int(min(scale_x, scale_y, 50))
 
         self.mesh_graph = MeshGraph(width, height, scale * width, scale * height)
-        self.init_bot_sprites(universe)
+        self.init_bot_sprites(game_state['bots'])
 
-    def update(self, universe=None, game_state=None):
+    def update(self, game_state=None):
         # Update the times for the fps calculation (if we are running)
         # Our fps is only relevant for how often the bots update our viewer.
         # When the viewer updates itself, we do not count it.
-        if self.running and universe and game_state:
+        if self.running and game_state:
             self._times.append(time.monotonic())
             if len(self._times) > 3:
                 # take the mean of the last two time differences
@@ -336,19 +335,17 @@ class TkApplication:
                 # Garbage collect old times
                 self._times = self._times[-3:]
 
-        if universe is not None:
-            self._universe = universe
         if game_state is not None:
             self._game_state = game_state
-        universe = self._universe
         game_state = self._game_state
-
-        if not universe:
+        if not game_state:
             return
 
-        if game_state['game_uuid'] != self.game_uuid:
-            self.game_uuid = game_state['game_uuid']
-            self.init_mesh(universe)
+        #if game_state['game_uuid'] != self.game_uuid:
+        if not self.game_uuid:
+            #self.game_uuid = game_state['game_uuid']
+            self.game_uuid = 1
+            self.init_mesh(game_state)
 
         if ((self.mesh_graph.screen_width, self.mesh_graph.screen_height)
             != (self.ui.game_canvas.winfo_width(), self.ui.game_canvas.winfo_height())):
@@ -364,39 +361,48 @@ class TkApplication:
             if self._default_font.cget('size') != self._default_font_size:
                 self._default_font.configure(size=self._default_font_size)
 
-        self.draw_universe(universe, game_state)
+        self.draw_universe(game_state)
 
-        for food_eaten in game_state["food_eaten"]:
-            food_tag = Food.food_pos_tag(tuple(food_eaten["food_pos"]))
-            self.ui.game_canvas.delete(food_tag)
+# TODO
+#        for food_eaten in game_state["food_eaten"]:
+#            food_tag = Food.food_pos_tag(tuple(food_eaten["food_pos"]))
+#            self.ui.game_canvas.delete(food_tag)
 
-        winning_team_idx = game_state.get("team_wins")
-        if winning_team_idx is not None:
-            team_name = game_state["team_name"][winning_team_idx]
-            self.draw_game_over(team_name)
-        elif game_state.get("game_draw"):
-            self.draw_game_draw()
-        else:
+        eaten_food = []
+        for food_pos, food_item in self.food_items.items():
+            if not list(food_pos) in game_state["food"]:
+                self.ui.game_canvas.delete(food_item.tag)
+                eaten_food.append(food_pos)
+        for food_pos in eaten_food:
+            del self.food_items[food_pos]
+
+        winning_team_idx = game_state.get("whowins")
+        if winning_team_idx is None:
             self.draw_end_of_game(None)
+        elif winning_team_idx in (0, 1):
+            team_name = game_state["team_names"][winning_team_idx]
+            self.draw_game_over(team_name)
+        elif winning_team_idx == 2:
+            self.draw_game_draw()
 
         self.size_changed = False
 
-    def draw_universe(self, universe, game_state):
-        self.mesh_graph.num_x = universe.maze.width
-        self.mesh_graph.num_y = universe.maze.height
+    def draw_universe(self, game_state):
+        self.mesh_graph.num_x = max(game_state['walls'])[0] + 1
+        self.mesh_graph.num_y = max(game_state['walls'])[1] + 1
 
-        self.draw_grid(universe)
-        self.draw_selected(universe, game_state)
-        self.draw_background(universe)
-        self.draw_maze(universe)
-        self.draw_food(universe)
+        self.draw_grid()
+        self.draw_selected(game_state)
+        self.draw_background()
+        self.draw_maze(game_state)
+        self.draw_food(game_state)
 
-        self.draw_title(universe, game_state)
-        self.draw_bots(universe, game_state)
+        self.draw_title(game_state)
+        self.draw_bots(game_state)
 
-        self.draw_status_info(universe, game_state)
+        self.draw_status_info(game_state)
 
-    def draw_grid(self, universe):
+    def draw_grid(self):
         """ Draws a light grid on the background.
         """
         if not self.size_changed:
@@ -443,7 +449,7 @@ class TkApplication:
             self.selected = (x, y)
         self.update()
 
-    def draw_background(self, universe):
+    def draw_background(self):
         """ Draws a line between blue and red team.
         """
         if not self.size_changed:
@@ -460,7 +466,7 @@ class TkApplication:
             y_bottom = self.mesh_graph.mesh_to_screen_y(self.mesh_graph.mesh_height - 1, 0)
             self.ui.game_canvas.create_line(x_orig, y_top, x_orig, y_bottom, width=scale, fill=color, tag="background")
 
-    def draw_title(self, universe, game_state):
+    def draw_title(self, game_state):
         self.ui.header_canvas.delete("title")
 
         center = self.ui.header_canvas.winfo_width() // 2
@@ -470,8 +476,8 @@ class TkApplication:
         except (KeyError, TypeError):
             team_time = [0, 0]
 
-        left_team = "%s %d " % (game_state["team_name"][0], universe.teams[0].score)
-        right_team = " %d %s" % (universe.teams[1].score, game_state["team_name"][1])
+        left_team = "%s %d " % (game_state["team_names"][0], game_state["score"][0])
+        right_team = " %d %s" % (game_state["score"][1], game_state["team_names"][1])
         font_size = guess_size(left_team + ' : ' + right_team,
                                self.ui.header_canvas.winfo_width(),
                                30,
@@ -504,10 +510,10 @@ class TkApplication:
         bottom_text = self.ui.header_canvas.create_text(0 + 5, 15 + font_size, text=" " + left_status, font=(None, status_font_size), tag="title", anchor=tkinter.W)
         self.ui.header_canvas.create_text(self.ui.header_canvas.winfo_width() - 5, 15 + font_size, text=right_status + " ", font=(None, status_font_size), tag="title", anchor=tkinter.E)
 
-    def draw_status_info(self, universe, game_state):
-        round = firstNN(game_state.get("round_index"), "–")
-        max_rounds = firstNN(game_state.get("game_time"), "–")
-        turn = firstNN(game_state.get("bot_id"), "–")
+    def draw_status_info(self, game_state):
+        round = firstNN(game_state.get("round"), "–")
+        max_rounds = firstNN(game_state.get("max_rounds"), "–")
+        turn = firstNN(game_state.get("turn"), "–")
         layout_name = firstNN(game_state.get("layout_name"), "–")
 
         roundturn = "Bot %s, Round % 3s/%s" % (turn, round, max_rounds)
@@ -521,14 +527,14 @@ class TkApplication:
         self.ui.status_round_info.config(text=roundturn)
         self.ui.status_layout_info.config(text=layout_name)
 
-    def draw_selected(self, universe, game_state):
+    def draw_selected(self, game_state):
         self.ui.game_canvas.delete("selected")
         if self.selected:
             def field_status(pos):
-                has_food = pos in universe.food
-                is_wall = universe.maze[pos]
-                bots = [str(bot.index) for bot in universe.bots if bot.current_pos == pos]
-                if pos[0] < universe.maze.width // 2:
+                has_food = pos in game_state['food']
+                is_wall = pos in game_state['walls']
+                bots = [idx for idx, bot in enumerate(game_state['bots']) if bot==pos]
+                if pos[0] < (max(game_state['walls'])[0] + 1) // 2:
                     zone = "blue"
                 else:
                     zone = "red"
@@ -608,48 +614,49 @@ class TkApplication:
     def clear(self):
         self.ui.game_canvas.delete(tkinter.ALL)
 
-    def draw_food(self, universe):
+    def draw_food(self, game_state):
         if not self.size_changed:
             return
         self.ui.game_canvas.delete("food")
-        for position in universe.food_list:
+        self.food_items = {}
+        for position in game_state['food']:
             model_x, model_y = position
             food_item = Food(self.mesh_graph, position=(model_x, model_y))
             food_item.draw(self.ui.game_canvas)
+            self.food_items[tuple(position)] = food_item
 
-    def draw_maze(self, universe):
+    def draw_maze(self, game_state):
         if not self.size_changed:
             return
         self.ui.game_canvas.delete("wall")
         num = 0
-        for position, wall in universe.maze.items():
-            model_x, model_y = position
-            if wall:
-                wall_neighbors = [(dx, dy)
-                                  for dx in [-1, 0, 1]
-                                  for dy in [-1, 0, 1]
-                                  if universe.maze.get((model_x + dx, model_y + dy), None)]
-                wall_item = Wall(self.mesh_graph, wall_neighbors=wall_neighbors, position=(model_x, model_y))
-                wall_item.draw(self.ui.game_canvas)
-                num += 1
+        for wall in game_state['walls']:
+            model_x, model_y = wall
+            wall_neighbors = [(dx, dy)
+                              for dx in [-1, 0, 1]
+                              for dy in [-1, 0, 1]
+                              if [model_x + dx, model_y + dy] in game_state['walls']]
+            wall_item = Wall(self.mesh_graph, wall_neighbors=wall_neighbors, position=(model_x, model_y))
+            wall_item.draw(self.ui.game_canvas)
+            num += 1
 
-    def init_bot_sprites(self, universe):
+    def init_bot_sprites(self, bot_positions):
         for sprite in self.bot_sprites.values():
             sprite.delete(self.ui.game_canvas)
         self.bot_sprites = {
-            bot.index: BotSprite(self.mesh_graph, team=bot.team_index, bot_id=bot.index, position=bot.current_pos)
-            for bot in universe.bots
+            idx: BotSprite(self.mesh_graph, team=idx % 2, bot_id=idx, position=bot)
+            for idx, bot in enumerate(bot_positions)
         }
 
-    def draw_bots(self, universe, game_state):
+    def draw_bots(self, game_state):
         if game_state:
             for bot in game_state["bot_destroyed"]:
-                self.bot_sprites[bot["bot_id"]].position = None
+                self.bot_sprites[bot["turn"]].position = None
         for bot_id, bot_sprite in self.bot_sprites.items():
-            say = game_state and game_state["bot_talk"][bot_id]
-            bot_sprite.move_to(universe.bots[bot_sprite.bot_id].current_pos,
+            say = game_state and game_state["say"][bot_id]
+            bot_sprite.move_to(game_state["bots"][bot_sprite.bot_id],
                                self.ui.game_canvas,
-                               universe,
+                               game_state,
                                force=self.size_changed,
                                say=say,
                                show_id=self._grid_enabled)
@@ -666,41 +673,56 @@ class TkApplication:
 
     def request_initial(self):
         if self.controller_socket:
+            _logger.debug('---> set_initial')
             self.controller_socket.send_json({"__action__": "set_initial"})
 
     def request_step(self):
-        if self.controller_socket:
-            self.controller_socket.send_json({"__action__": "play_step"})
+        if not self.controller_socket:
+            return
 
-    def request_round(self):
         if self._stop_after is not None:
-            if self._game_state['round_index'] is None:
-                if self.controller_socket:
-                    self.controller_socket.send_json({"__action__": "play_round"})
-            elif (self._game_state['round_index'] < self._stop_after - 1):
-                if self._game_state['bot_id'] == 3:
-                    if self.controller_socket:
-                        self.controller_socket.send_json({"__action__": "play_round"})
+            if self._game_state['round'] is None:
+                _logger.debug('---> play_step')
+                self.controller_socket.send_json({"__action__": "play_step"})
+            elif (self._game_state['round'] < self._stop_after):
+                _logger.debug('---> play_step')
+                self.controller_socket.send_json({"__action__": "play_step"})
             else:
                 self._stop_after = None
                 self.running = False
                 self._delay = self._stop_after_delay
         else:
-            if self.controller_socket:
-                self.controller_socket.send_json({"__action__": "play_round"})
+            _logger.debug('---> play_step')
+            self.controller_socket.send_json({"__action__": "play_step"})
 
-    def observe(self, data):
-        game_state = data["game_state"]
-        universe = CTFUniverse._from_json_dict(game_state)
+    def request_round(self):
+        if not self.controller_socket:
+            return
 
-        self.update(universe, game_state)
+        if self._game_state['round']:
+            self._stop_after = self._game_state['round'] + 1
+        else:
+            self._stop_after = 1
+            self._delay = self._min_delay
+        self.request_step()
+
+    def observe(self, game_state):
+        # TODO
+        game_state['timeout_teams'] = [0, 0]
+        game_state['times_killed'] = [0, 0]
+        game_state['team_time'] = [0, 0]
+        game_state['teams_disqualified'] = [0, 0]
+        game_state['bot_destroyed'] = []
+        game_state['food_eaten'] = []
+        game_state['say'] = ["", "", "", ""]
+        self.update(game_state)
         if self._stop_after is not None:
             if self._stop_after == 0:
                 self._stop_after = None
                 self.running = False
                 self._delay = self._stop_after_delay
             else:
-                self.master.after(self._delay, self.request_round)
+                self.master.after(self._delay, self.request_step)
         elif self.running:
             self.master.after(self._delay, self.request_step)
 
@@ -709,6 +731,7 @@ class TkApplication:
         """
         self.running = False
         if self.controller_socket:
+            _logger.debug('---> exit')
             self.controller_socket.send_json({"__action__": "exit"})
         else:
             # force closing the window (though this might not work)

--- a/pelita/ui/tk_viewer.py
+++ b/pelita/ui/tk_viewer.py
@@ -138,9 +138,9 @@ class TkViewer:
 
             _logger.debug(message["__action__"])
             # we curretly don’t care about the action
-            data = message["__data__"]
-            if data:
-                self.app.observe(data)
+            game_state = message["__data__"]
+            if game_state:
+                self.app.observe(game_state)
 
             self._delay = 2
             self._after(2, self.read_queue)


### PR DESCRIPTION
This PR changes the Tk viewer to run with a (still unoptimised) `game_state` and gets rid of all the old datamodel/universe API. Not all features are ported yet and there may be silent failures for some of the changed keys in `game_state`. Also, there is an UI bug (on OS X at least) where the maze loses some of its elements during the game. It is yet unclear to me why this is.

Additionally, viewers are now initialised in `run_game` (or rather `setup_game`). To ensure that the viewer can properly control the running game (and also ensure that the game waits until the viewer is ready) and exit it correctly, some minimal control code has been added to the loop in `run_game`. It is our aim to keep this control code and the loop as simple as possible, so that users can build their own game loops easily for testing.

Fixes #508.