### PR TITLE
BF: Fix for Bot.random in setup_test_game

### DIFF
--- a/pelita/utils/__init__.py
+++ b/pelita/utils/__init__.py
@@ -60,4 +60,7 @@ def setup_test_game(*, layout, game=None, is_blue=True, round=None, score=None, 
                      round=None,
                      bot_turn=0,
                      seed=seed)
+    # TODO: Random handling needs to be improved
+    bot.random = random.Random(seed)
     return bot
+


### PR DESCRIPTION
`setup_test_game` would not set Bot.random anymore. This needs to be fixed a little more thoroughly at a later point.