### PR TITLE
Fixes in call_pelita (parsing of the reply-to dict) and tournament

### DIFF
--- a/pelita/libpelita.py
+++ b/pelita/libpelita.py
@@ -286,11 +286,9 @@ def call_pelita(team_specs, *, rounds, filter, viewer, dump, seed):
                 socket_ready = evts.get(reply_sock, False)
                 if socket_ready:
                     try:
-                        pelita_status = json.loads(reply_sock.recv_string())
-                        game_state = pelita_status['__data__']['game_state']
-                        finished = game_state.get("finished", None)
-                        team_wins = game_state.get("team_wins", None)
-                        game_draw = game_state.get("game_draw", None)
+                        game_state = json.loads(reply_sock.recv_string())
+                        finished = game_state.get("gameover", None)
+                        whowins = game_state.get("whowins", None)
                         if finished:
                             final_game_state = game_state
                             break

--- a/pelita/tournament/tournament.py
+++ b/pelita/tournament/tournament.py
@@ -237,7 +237,6 @@ def present_teams(config):
 def set_name(team):
     """Get name of team."""
     try:
-        team = libpelita.prepare_team(team)
         return libpelita.check_team(team)
     except Exception:
         print("*** ERROR: I could not load team {team}. Please help!".format(team=team))

--- a/pelita/tournament/tournament.py
+++ b/pelita/tournament/tournament.py
@@ -291,15 +291,14 @@ def start_match(config, teams, shuffle=False):
 
     (final_state, stdout, stderr) = play_game_with_config(config, teams)
     try:
-        game_draw = final_state['game_draw']
-        team_wins = final_state['team_wins']
+        whowins = final_state['whowins']
 
-        if game_draw:
+        if whowins == 2:
             config.print('‘{t1}’ and ‘{t2}’ had a draw.'.format(t1=config.team_name(team1),
                                                                 t2=config.team_name(team2)))
             return False
-        elif team_wins == 0 or team_wins == 1:
-            winner = teams[team_wins]
+        elif whowins == 0 or whowins == 1:
+            winner = teams[whowins]
             config.print('‘{team}’ wins'.format(team=config.team_name(winner)))
             return winner
         else:

--- a/test/test_filter_gamestates.py
+++ b/test/test_filter_gamestates.py
@@ -24,7 +24,7 @@ def make_gamestate():
         ################## """
 
     lt_dict = lt.parse_layout(layout)
-    game_state = setup_game([dummy_team, dummy_team], lt_dict)
+    game_state = setup_game([dummy_team, dummy_team], layout_dict=lt_dict, max_rounds=1)
 
     return game_state
 

--- a/test/test_libpelita.py
+++ b/test/test_libpelita.py
@@ -23,20 +23,20 @@ class TestCallPelita:
 
         teams = ["pelita/player/StoppingPlayer", "pelita/player/StoppingPlayer"]
         (state, stdout, stderr) = libpelita.call_pelita(teams, rounds=rounds, viewer='null', filter=filter, dump=None, seed=None)
-        assert state['team_wins'] is None
-        assert state['game_draw'] is True
+        assert state['gameover'] is True
+        assert state['whowins'] == 2
         # Quick assert that there is text in stdout
         assert len(stdout.split('\n')) == 6
 
         teams = ["pelita/player/SmartEatingPlayer", "pelita/player/StoppingPlayer"]
         (state, stdout, stderr) = libpelita.call_pelita(teams, rounds=rounds, viewer=viewer, filter=filter, dump=None, seed=None)
-        assert state['team_wins'] == 0
-        assert state['game_draw'] is None
+        assert state['gameover'] is True
+        assert state['whowins'] == 0
 
         teams = ["pelita/player/StoppingPlayer", "pelita/player/SmartEatingPlayer"]
         (state, stdout, stderr) = libpelita.call_pelita(teams, rounds=rounds, viewer=viewer, filter=filter, dump=None, seed=None)
-        assert state['team_wins'] == 1
-        assert state['game_draw'] is None
+        assert state['gameover'] is True
+        assert state['whowins'] == 1
 
 
 def test_check_team_external():

--- a/test/test_tournament.py
+++ b/test/test_tournament.py
@@ -140,8 +140,7 @@ class TestSingleMatch:
 
         teams = ["pelita/player/StoppingPlayer", "pelita/player/StoppingPlayer"]
         (state, stdout, stderr) = tournament.play_game_with_config(config, teams)
-        assert state['team_wins'] == None
-        assert state['game_draw'] == True
+        assert state['whowins'] == 2
 
         config.rounds = 200
         config.team_spec = lambda x: x
@@ -149,16 +148,14 @@ class TestSingleMatch:
         teams = ["pelita/player/SmartEatingPlayer", "pelita/player/StoppingPlayer"]
         (state, stdout, stderr) = tournament.play_game_with_config(config, teams)
         print(state)
-        assert state['team_wins'] == 0
-        assert state['game_draw'] == None
+        assert state['whowins'] == 0
 
         config.rounds = 200
         config.team_spec = lambda x: x
         config.viewer = 'ascii'
         teams = ["pelita/player/StoppingPlayer", "pelita/player/SmartEatingPlayer"]
         (state, stdout, stderr) = tournament.play_game_with_config(config, teams)
-        assert state['team_wins'] == 1
-        assert state['game_draw'] == None
+        assert state['whowins'] == 1
 
     def test_start_match(self):
         stdout = []


### PR DESCRIPTION
Tournament tests rely on #590 to be merged. Otherwise the players won’t work.