### PR TITLE
BF/TST: Fix bug in noiser and adapt old tests

### DIFF
--- a/pelita/gamestate_filters.py
+++ b/pelita/gamestate_filters.py
@@ -103,26 +103,28 @@ def alter_pos(bot_pos, noise_radius, rnd, walls):
 
     possible_positions = [
         (i, j)
-        for i in range(x_min, x_max)
-        for j in range(y_min, y_max)
+        for i in range(x_min, x_max + 1) # max + 1 since range is not inclusive at upper end
+        for j in range(y_min, y_max + 1) # max + 1 since range is not inclusive at upper end
         if manhattan_dist((i, j), bot_pos) <= noise_radius
+        and not (i, j) in walls # check that the bot won't returned as positioned on a wall square
     ]
 
-    # shuffle the list of positions
-    rnd.shuffle(possible_positions)
-    final_pos = bot_pos
-    noisy = False
-    for pos in possible_positions:
-        # check that the bot won't returned as positioned on a wall square
-        if pos in walls:
-            continue
-        else:
-            final_pos = pos
-            noisy = True
-            break
-            # return the final_pos and a flag if it is noisy or not
+    if len(possible_positions) < 1:
+        # this should not happen
+        # anyway. return the bot’s current position
+        # TODO: Should probably raise?
+        final_pos = bot_pos
+        noisy = False
+    elif len(possible_positions) == 1:
+        final_pos = possible_positions[0]
+        noisy = False
+    else:
+        # select a random position
+        final_pos = rnd.choice(possible_positions)
+        noisy = True
+
+    # return the final_pos and a flag if it is noisy or not
     return (final_pos, noisy)
-    # return ((0,0), True)
 
 
 def manhattan_dist(pos1, pos2):

--- a/test/test_filter_gamestates.py
+++ b/test/test_filter_gamestates.py
@@ -1,11 +1,12 @@
 
 import pytest
 
+import collections
 import random
 
 from pelita import gamestate_filters as gf
-from pelita import layout as lt
 from pelita.game import setup_game, prepare_bot_state
+from pelita.layout import parse_layout
 
 
 def make_gamestate():
@@ -23,7 +24,7 @@ def make_gamestate():
         #2     .##. ... .#
         ################## """
 
-    lt_dict = lt.parse_layout(layout)
+    lt_dict = parse_layout(layout)
     game_state = setup_game([dummy_team, dummy_team], layout_dict=lt_dict, max_rounds=1)
 
     return game_state
@@ -301,3 +302,194 @@ def test_noiser_noising_at_noise_radius_extreme(ii):
         assert noised_pos not in gamestate["walls"]
         assert 0 <= noised_pos[0] < max(gamestate["walls"])[0]
         assert 0 <= noised_pos[1] < max(gamestate["walls"])[1]
+
+
+@pytest.mark.parametrize('noise_radius, expected', [
+    [0, [(3, 3)]], # original position. not noised
+    [1, [(2, 3), (3, 3), (4, 3)]],
+    [2, [(1, 3), (2, 3), (3, 1), (3, 3), (4, 3), (5, 3)]],
+    [5, [(1, 1), (1, 2), (1, 3), (2, 3), (3, 3),
+         (4, 3), (5, 3), (6, 3), (7, 3), (7, 2),
+         (6, 1), (5, 1), (4, 1), (3, 1)]]
+])
+def test_uniform_noise_manhattan(noise_radius, expected, test_layout=None):
+    # Test how bot 1 observers bot 0
+    if not test_layout:
+        test_layout = (
+        """ ##################
+            # #.  .  # .     #
+            # #####    ##### #
+            #  0  . #  .  .#1#
+            ################## """)
+    parsed = parse_layout(test_layout)
+
+    position_bucket = collections.defaultdict(int)
+    for i in range(200):
+        noised = gf.noiser(walls=parsed['walls'],
+                            bot_position=parsed['bots'][1],
+                            enemy_positions=[parsed['bots'][0]],
+                            noise_radius=noise_radius)
+        if noise_radius == 0:
+            assert noised['is_noisy'] == [False]
+        else:
+            assert noised['is_noisy'] == [True]
+
+        noised_pos = noised['enemy_positions'][0]
+        position_bucket[noised_pos] += 1
+    assert 200 == sum(position_bucket.values())
+    # Since this is a randomized algorithm we need to be a bit lenient with
+    # our tests. We check that each position was selected at least once.
+    assert set(position_bucket.keys()) == set(expected)
+
+
+@pytest.mark.parametrize('noise_radius, test_layout', [
+    [0, """
+        ##################
+        # #      #       #
+        # #####    ##### #
+        #  0    #      #1#
+        ################## """], # original position. not noised
+    [1, """
+        ##################
+        #   .            #
+        #  .0.        1  #
+        #   .            #
+        ################## """], # noised by one
+    [1, """
+        ##################
+        #                #
+        #   .         1  #
+        #  .0.           #
+        ################## """], # noised by one
+    [1, """
+        ##################
+        #                #
+        #.            1  #
+        #0.              #
+        ################## """], # noised by one
+    [1, """
+        ##################
+        #              .0#
+        #  1            .#
+        #                #
+        ################## """], # noised by on
+    [1, """
+        ##################
+        # #      #       #
+        # #####    ##### #
+        # .0.   #      #1#
+        ################## """], # noised by one
+    [1, """
+        ##################
+        # #      #       #
+        # #####    #####.#
+        #  1    #      #0#
+        ################## """], # noised by one
+    [1, """
+        ##################
+        # #      #   .0. #
+        # #####    ##### #
+        #  1    #      # #
+        ################## """], # noised by one
+])
+def test_uniform_noise_manhattan_graphical(noise_radius, test_layout):
+    # Test how bot 1 observers bot 0
+    # the expected locations are where the food is placed
+    parsed = parse_layout(test_layout)
+    expected = parsed['food'] + [parsed['bots'][0]]
+    test_uniform_noise_manhattan(noise_radius, expected, test_layout=test_layout)
+
+
+def test_uniform_noise_4_bots_manhattan():
+    test_layout = (
+    """ ##################
+        # #. 2.  # .     #
+        # #####    #####3#
+        #   0  . # .  .#1#
+        ################## """)
+    parsed = parse_layout(test_layout)
+
+    expected_0 = [(1, 1), (1, 2), (1, 3), (2, 3), (3, 3),
+                  (4, 3), (5, 3), (6, 3), (7, 3), (7, 2),
+                  (7, 1), (6, 1), (5, 1), (4, 1), (3, 1),
+                  (8, 2), (8, 3)]
+    position_bucket_0 = collections.defaultdict(int)
+
+    expected_2 = [(1, 1), (1, 2), (2, 3), (3, 3), (4, 3),
+                  (5, 3), (6, 3), (7, 3), (8, 2), (8, 1),
+                  (7, 1), (6, 1), (5, 1), (4, 1), (3, 1),
+                  (9, 2), (8, 3), (7, 2), (10, 1)]
+    position_bucket_2 = collections.defaultdict(int)
+
+    for i in range(200):
+        noised = gf.noiser(walls=parsed['walls'],
+                           bot_position=parsed['bots'][1],
+                           enemy_positions=parsed['bots'][0::2])
+
+        assert noised['is_noisy'] == [True, True]
+        position_bucket_0[noised['enemy_positions'][0]] += 1
+        position_bucket_2[noised['enemy_positions'][1]] += 1
+    assert 200 == sum(position_bucket_0.values())
+    assert 200 == sum(position_bucket_2.values())
+    # Since this is a randomized algorithm we need to be a bit lenient with
+    # our tests. We check that each position was selected at least once.
+    assert set(position_bucket_0.keys()) == set(expected_0)
+    assert set(position_bucket_2.keys()) == set(expected_2)
+
+
+def test_uniform_noise_4_bots_no_noise_manhattan():
+    test_layout = (
+    """ ##################
+        # #.  .  # . 2   #
+        # #####    #####3#
+        #  0  . #  .  .#1#
+        ################## """)
+    parsed = parse_layout(test_layout)
+
+    expected_0 = [(1, 1), (3, 1), (4, 1), (5, 1), (6, 1),
+                  (1, 2), (1, 3), (2, 3), (3, 3), (4, 3), (5, 3),
+                  (6, 3), (7, 3), (7, 2) ]
+    position_bucket_0 = collections.defaultdict(int)
+
+    expected_2 = [(13, 1)]
+    position_bucket_2 = {(13, 1) : 0}
+
+    for i in range(200):
+        noised = gf.noiser(walls=parsed['walls'],
+                           bot_position=parsed['bots'][1],
+                           enemy_positions=parsed['bots'][0::2])
+
+        assert noised['is_noisy'] == [True, False]
+        position_bucket_0[noised['enemy_positions'][0]] += 1
+        position_bucket_2[noised['enemy_positions'][1]] += 1
+    assert 200 == sum(position_bucket_0.values())
+    assert 200 == sum(position_bucket_2.values())
+    # Since this is a randomized algorithm we need to be a bit lenient with
+    # our tests. We check that each position was selected at least once.
+    assert set(position_bucket_0.keys()) == set(expected_0)
+    assert set(position_bucket_2.keys()) == set(expected_2)
+
+
+def test_noise_manhattan_failure():
+    test_layout = (
+    """ ##################
+        ########## . 2   #
+        ########## #####3#
+        ###0###### .  . 1#
+        ################## """)
+    # we test what bot 1 sees
+    # bot 0 should not be noised
+    # bot 2 should not be noised
+    parsed = parse_layout(test_layout)
+    expected = parsed['food'] + [parsed['bots'][0]]
+
+    position_bucket = collections.defaultdict(int)
+    # check a few times
+    for i in range(5):
+        noised = gf.noiser(walls=parsed['walls'],
+                            bot_position=parsed['bots'][1],
+                            enemy_positions=parsed['bots'][0::2])
+                            
+        assert noised['is_noisy'] == [False, False]
+        noised_pos = noised['enemy_positions']
+        assert noised_pos == parsed['bots'][0::2]


### PR DESCRIPTION
Interestingly, there was a position missing from the list of expected
positions in test_uniform_noise_4_bots_manhattan. Either the old
algorithm had an error or the new one still has.