### PR TITLE
NF: SVG Viewer.

### DIFF
--- a/pelita/game.py
+++ b/pelita/game.py
@@ -17,7 +17,7 @@ from .layout import initial_positions, get_legal_moves
 from .libpelita import get_python_process, SimplePublisher
 from .network import bind_socket, setup_controller
 from .player.team import make_team
-from .viewer import ProgressViewer, AsciiViewer, ReplyToViewer, DumpingViewer, ResultPrinter
+from .viewer import ProgressViewer, AsciiViewer, ReplyToViewer, DumpingViewer, ResultPrinter, SVGViewer
 
 _logger = logging.getLogger(__name__)
 _mswindows = (sys.platform == "win32")
@@ -247,7 +247,8 @@ def setup_viewers(viewers=None, options=None):
                                 stop_after=options.get('stop_at'),
                                 geometry=options.get('geometry'),
                                 delay=options.get('delay'))
-
+        elif len(viewer) == 2 and viewer[0] == 'svg':
+            viewer_state['viewers'].append(SVGViewer(viewer[1]))
         else:
             raise ValueError(f"Unknown viewer {viewer}.")
 

--- a/pelita/scripts/pelita_main.py
+++ b/pelita/scripts/pelita_main.py
@@ -107,6 +107,8 @@ viewer_opt.add_argument('--tk', action='store_const', const='tk',
 viewer_opt.add_argument('--tk-no-sync', action='store_const', const='tk-no-sync',
                         dest='viewer', help=long_help('Uses the tk viewer in an unsynchronized mode.'))
 parser.set_defaults(viewer='tk')
+parser.add_argument('--export-svg', dest="export_svg", type=str, metavar='FOLDER',
+                    help=long_help('Export svg to given folder.'))
 
 advanced_settings = parser.add_argument_group('Advanced settings')
 advanced_settings.add_argument('--reply-to', type=str, metavar='URL', dest='reply_to',
@@ -193,6 +195,9 @@ def main():
         viewers = []
     else:
         viewers = [args.viewer]
+
+    if args.export_svg:
+        viewers.append(('svg', args.export_svg))
 
     geometry = args.geometry
     delay = int(1000./args.fps)

--- a/pelita/viewer.py
+++ b/pelita/viewer.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+from pathlib import Path
 
 import zmq
 
@@ -76,6 +77,163 @@ class AsciiViewer:
             else:
                 winner = game_state["team_names"][state["whowins"]]
                 print(f"Game Over: Team: '{winner}' wins!")
+
+
+class SVGViewer:
+    def __init__(self, folder):
+        _logger.info(f"Writing SVG to {folder}.")
+        self.folder = Path(folder)
+        self.folder.mkdir()
+        self.index = 0
+    def show_state(self, game_state):
+        # svg scaled up by a factor of 12
+        SCALE = 12
+
+        # blue_col = rgb(94, 158, 217)
+        # red_col = rgb(235, 90, 90)
+
+        width, height = layout.wall_dimensions(game_state['walls'])
+
+        wall_elems = []
+        for x, y in game_state['walls']:
+            x1 = x
+            y1 = y
+            neighbor_elems = [
+                (x + dx, y + dy) for dx, dy in [(-1, 0), (1, 0), (0, 1), (0, -1)]
+                if (x + dx, y + dy) in game_state['walls']
+            ]
+            if neighbor_elems:
+                for x2, y2 in neighbor_elems:
+                    wall_elems.append((x1 + 0.5, x2 + 0.5, y1 + 0.5, y2 + 0.5))
+            else:
+                wall_elems.append((x1 + 0.5, x1 + 0.5, y1 + 0.5, y1 + 0.5))
+
+
+        border_paths = "\n".join(
+            f"""<line x1="{x1 * SCALE}" x2="{x2 * SCALE}" y1="{y1 * SCALE}" y2="{y2 * SCALE}" />"""
+            for x1, x2, y1, y2 in wall_elems
+        )
+
+        bots = []
+        border = width // 2
+        for idx, bot in enumerate(game_state['bots']):
+            if idx % 2 == 0:
+                col = "blue"
+                bot_type = "ghost" if bot[0] < border else "pacman"
+            else:
+                col = "red"
+                bot_type = "pacman" if bot[0] < border else "ghost"
+            dx = bot[0] * SCALE
+            dy = bot[1] * SCALE
+            bot_def = f""" <use transform="translate({dx},{dy})" xlink:href="#{bot_type}" class="{col}" /> """
+            bots.append(bot_def)
+        bots = "\n".join(bots)
+
+        food = "\n".join(
+            f"""<circle cx="{x * SCALE + 6}" cy="{y * SCALE + 6}" r="3" class="{"foodblue" if x < border else "foodred"}"/> """
+            for x, y in game_state['food']
+        )
+
+        template = f"""
+        <svg width="{width * 12}"
+                height="{height * 12}"
+                xmlns="http://www.w3.org/2000/svg"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+        >
+        <defs>
+        <style type="text/css"><![CDATA[
+        line {{
+            stroke: #000000;
+            stroke-linecap: round;
+            stroke-width: 3;
+        }}
+        .foodblue {{
+            stroke: rgb(94, 158, 217);
+            fill: none;
+        }}
+        .foodred {{
+            stroke: rgb(235, 90, 90);
+            fill: none;
+        }}
+        .blue {{
+            fill: rgb(94, 158, 217);
+        }}
+        .red {{
+            fill: rgb(235, 90, 90);
+        }}
+        ]]></style>
+
+        <g id="pacman">
+        <path d="M 9.98
+        7.73
+        A 4.38 4.38 0 1 1 9.98 3.8
+        L 6.05 5.8
+        Z"
+        />
+        </g>
+
+        <g id="ghost">
+            <path d="M 2 6 
+        C 2 3.79 3.8 2 6 2
+        C 8.21 2 10 3.8 10 6
+        L 10 10
+        L 9.01 8.81
+        L 8.01 10
+        L 7 8.81
+        L 6.01 10
+        L 5.01 8.81
+        L 4 10
+        L 3 8.81
+        L 2 10
+        L 2 6
+        Z
+        M 4.39 6.54
+        C 4.9 6.54 5.31 6.03 5.31 5.38
+        C 5.31 4.74 4.9 4.22 4.39 4.22
+        C 3.88 4.22 3.47 4.74 3.47 5.38
+        C 3.47 6.03 3.88 6.54 4.39 6.54
+        Z
+        M 6.9 6.54
+        C 7.41 6.54 7.82 6.03 7.82 5.38
+        C 7.82 4.74 7.41 4.22 6.9 4.22
+        C 6.39 4.22 5.98 4.74 5.98 5.38
+        C 5.98 6.03 6.39 6.54 6.9 6.54
+        Z
+        M 4.25 6
+        C 4.44 6 4.6 5.79 4.6 5.53
+        C 4.6 5.27 4.44 5.05 4.25 5.05
+        C 4.05 5.05 3.89 5.27 3.89 5.53
+        C 3.89 5.79 4.05 6 4.25 6
+        Z
+        M 6.76 6
+        C 6.95 6 7.11 5.79 7.11 5.53
+        C 7.11 5.27 6.95 5.05 6.76 5.05
+        C 6.56 5.05 6.4 5.27 6.4 5.53
+        C 6.4 5.79 6.56 6 6.76 6
+        Z"></path>
+        </g>
+            
+        </defs>
+
+        <g id="walls">
+        {border_paths}
+        </g>
+
+        <g id="food">
+        {food}
+        </g>
+
+        <g id="bots">
+        {bots}
+        </g>
+
+        </svg>
+        """
+
+        filename = self.folder / f"pelita-{self.index:04d}.svg"
+        _logger.info(f"Writing SVG file {filename}.")
+        filename.write_text(template)
+        self.index += 1
 
 
 class ReplyToViewer:


### PR DESCRIPTION
Work in progress (help with SVG welcome)

Very rough SVG exporter that should eventually be used for movie generation. Writing the SVG files during a match is very quick (and thanks to cross-references, it should be possible to write the maze just once and then include the definition into all other files without having to write it again).

As a bonus, SVG works well with Jupyter, so we can have a picture instead of our HTML table, when working in a notebook.

The shapes are not consistent with the rest of the Pelita UI (I copy-pasted and recalculated the code from somewhere). We should adapt them to our own shapes.

<img width="1155" alt="image" src="https://user-images.githubusercontent.com/216179/59311457-da385f80-8ca9-11e9-8b24-84fe610f79c6.png">
