### PR TITLE
Fix timeout handling in RemoteTeam

### DIFF
--- a/pelita/game.py
+++ b/pelita/game.py
@@ -129,6 +129,9 @@ class GameState:
     #: Random number generator
     rnd: typing.Any
 
+    #: Timeout length
+    timeout_length: typing.Optional[int]
+
     #: Viewers
     viewers: typing.List
 
@@ -188,7 +191,7 @@ def run_game(team_specs, *, max_rounds, layout_dict, layout_name="", seed=None, 
     """ Run a match for `max_rounds` rounds. """
 
     # we create the initial game state
-    state = setup_game(team_specs, layout_dict=layout_dict, max_rounds=max_rounds, seed=seed,
+    state = setup_game(team_specs, layout_dict=layout_dict, max_rounds=max_rounds, timeout_length=timeout_length, seed=seed,
                        viewers=viewers, controller=controller, viewer_options=viewer_options)
 
     # Play the game until it is gameover.
@@ -323,7 +326,8 @@ def setup_game(team_specs, *, layout_dict, max_rounds=300, layout_name="", seed=
         controller=None,
         team_time=[0, 0],
         times_killed=[0, 0],
-        respawned=[True] * 4
+        respawned=[True] * 4,
+        timeout_length=timeout_length
     )
     game_state = dataclasses.asdict(game_state)
 
@@ -473,7 +477,8 @@ def prepare_bot_state(game_state, idx=None):
         'team': team_state,
         'enemy': enemy_state,
         'round': game_state['round'],
-        'bot_turn': bot_turn
+        'bot_turn': bot_turn,
+        'timeout_length': game_state['timeout_length']
     }
 
     return bot_state

--- a/pelita/game.py
+++ b/pelita/game.py
@@ -360,14 +360,15 @@ def setup_teams(team_specs, game_state):
     """ Creates the teams according to the `teams`. """
 
     # we start with a dummy zmq_context
-    # make_team will generate and return a new context, if it is needed
+    # make_team will generate and return a new zmq_context,
+    # if it is needed for a remote team
     zmq_context = None
 
     teams = []
     # First, create all teams
     # If a team is a RemoteTeam, this will start a subprocess
     for idx, team_spec in enumerate(team_specs):
-        team, zmq_context = make_team(team_spec, idx=idx)
+        team, zmq_context = make_team(team_spec, idx=idx, zmq_context=zmq_context)
         teams.append(team)
 
     # Send the initial state to the teams and await the team name
@@ -383,7 +384,6 @@ def setup_teams(team_specs, game_state):
                 'round': None,
             }
             game_state['fatal_errors'][idx].append(exception_event)
-            position = None
             if len(e.args) > 1:
                 game_print(idx, f"{type(e).__name__} ({e.args[0]}): {e.args[1]}")
                 team_name = f"%%%{e.args[0]}%%%"
@@ -469,7 +469,7 @@ def prepare_bot_state(game_state, idx=None):
 
     bot_state = {
         'walls': game_state['walls'], # only in initial round
-        'seed': seed, # only used in set_intital phase
+        'seed': seed, # only used in set_initial phase
         'team': team_state,
         'enemy': enemy_state,
         'round': game_state['round'],

--- a/pelita/player/team.py
+++ b/pelita/player/team.py
@@ -625,21 +625,6 @@ def make_bots(*, walls, team, enemy, round, bot_turn, rng):
     return team_bots[bot_turn]
 
 
-
-
-def new_style_team(module):
-    """ Looks for a new-style team in `module`.
-    """
-    # look for a new-style team
-    move = getattr(module, "move")
-    name = getattr(module, "TEAM_NAME")
-    if not callable(move):
-        raise TypeError("move is not a function")
-    if type(name) is not str:
-        raise TypeError("TEAM_NAME is not a string")
-    return lambda: Team(move, team_name=name)
-
-
 # @dataclass
 class Layout:
     def __init__(self, walls, food, bots, enemy):

--- a/pelita/player/team.py
+++ b/pelita/player/team.py
@@ -240,8 +240,8 @@ class RemoteTeam:
             return self._team_name
 
         try:
-            self.zmqconnection.send("team_name", {})
-            team_name = self.zmqconnection.recv_timeout(self._request_timeout)
+            msg_id = self.zmqconnection.send("team_name", {})
+            team_name = self.zmqconnection.recv_timeout(msg_id, self._request_timeout)
             if team_name:
                 self._team_name = team_name
             return team_name
@@ -255,9 +255,9 @@ class RemoteTeam:
     def set_initial(self, team_id, game_state):
         timeout_length = game_state['timeout_length']
         try:
-            self.zmqconnection.send("set_initial", {"team_id": team_id,
+            msg_id = self.zmqconnection.send("set_initial", {"team_id": team_id,
                                                     "game_state": game_state})
-            team_name = self.zmqconnection.recv_timeout(timeout_length)
+            team_name = self.zmqconnection.recv_timeout(msg_id, timeout_length)
             if team_name:
                 self._team_name = team_name
             return team_name
@@ -278,8 +278,8 @@ class RemoteTeam:
     def get_move(self, game_state):
         timeout_length = game_state['timeout_length']
         try:
-            self.zmqconnection.send("get_move", {"game_state": game_state})
-            reply = self.zmqconnection.recv_timeout(timeout_length)
+            msg_id = self.zmqconnection.send("get_move", {"game_state": game_state})
+            reply = self.zmqconnection.recv_timeout(msg_id, timeout_length)
             # make sure it is a dict
             reply = dict(reply)
             if "error" in reply:

--- a/test/test_pelita_player.py
+++ b/test/test_pelita_player.py
@@ -7,7 +7,7 @@ import tempfile
 
 import pelita
 from pelita import libpelita
-from pelita.scripts.pelita_player import load_factory, load_team
+from pelita.scripts.pelita_player import load_team_from_module, load_team
 
 SIMPLE_MODULE = """
 from pelita.player import stopping_player
@@ -33,7 +33,7 @@ class TestLoadFactory:
                 f.write(SIMPLE_MODULE)
 
             spec = str(module)
-            load_factory(spec)
+            load_team_from_module(spec)
 
     def test_simple_file_import(self):
         modules_before = list(sys.modules.keys())
@@ -45,7 +45,7 @@ class TestLoadFactory:
                 f.write(SIMPLE_MODULE)
 
             spec = str(initfile)
-            load_factory(spec)
+            load_team_from_module(spec)
 
     def test_failing_import(self):
         modules_before = list(sys.modules.keys())
@@ -58,7 +58,7 @@ class TestLoadFactory:
 
             spec = str(module)
             with pytest.raises(AttributeError):
-                load_factory(spec)
+                load_team_from_module(spec)
 
     def test_import_of_pyc(self):
         with tempfile.TemporaryDirectory() as d:
@@ -72,7 +72,7 @@ class TestLoadFactory:
             initfile.unlink()
 
             spec = str(pycfile)
-            load_factory(spec)
+            load_team_from_module(spec)
 
 class TestLoadTeam:
     def test_simple_module_import_forbidden_names(self):
@@ -104,13 +104,16 @@ class TestLoadTeam:
                 spec = str(module)
                 load_team(spec)
 
+    # These test cases need to be handled in one function
+    # ie. not in a parametrized test, as the will need
+    # to be run inside the same Python session
     load_team_cases = [
         ("pelita/player/StoppingPlayer", None),
 #        ("StoppingPlayer,StoppingPlayer", None),
         ("NonExistingPlayer", ImportError),
 #        ("StoppingPlayer,StoppingPlayer,FoodEatingPlayer", ValueError),
-        ('doc/source/groupN:team', None),
-        ('doc/source/groupN/__init__.py', ImportError),
+        ('doc/source/groupN', AttributeError), # TODO: Should be rewritten for a proper team
+        ('doc/source/groupN/__init__.py', ImportError), # TODO: Should be rewritten for a proper team
         ('doc/source/groupN', ValueError), # Has already been imported
     ]
 


### PR DESCRIPTION
Closes #598. Further refactoring of RemoteTeam/ZMQConnection will come in later PRs.

This PR also removes old-style factory-based loading `def team` and fixes a bug where a belated message from a client would lead to a newer message being ignored (thus giving a second time out).