### PR TITLE
Only send the current error to the viewers

### DIFF
--- a/pelita/simplesetup.py
+++ b/pelita/simplesetup.py
@@ -34,7 +34,6 @@ import uuid
 
 import zmq
 
-from .viewer import simplify_state
 
 _logger = logging.getLogger(__name__)
 
@@ -368,8 +367,7 @@ class SimplePublisher:
         self.socket.send_unicode(as_json)
 
     def show_state(self, game_state):
-        state = simplify_state(game_state)
         message = {"__action__": "observe",
-                   "__data__": state}
+                   "__data__": game_state}
         self._send(message)
 

--- a/pelita/simplesetup.py
+++ b/pelita/simplesetup.py
@@ -34,6 +34,8 @@ import uuid
 
 import zmq
 
+from .viewer import simplify_state
+
 _logger = logging.getLogger(__name__)
 
 class ZMQUnreachablePeer(Exception):
@@ -365,18 +367,9 @@ class SimplePublisher:
         as_json = json.dumps(message)
         self.socket.send_unicode(as_json)
 
-    def set_initial(self, game_state):
-        message = {"__action__": "set_initial",
-                   "__data__": {"game_state": game_state}}
-        self._send(message)
-
-    def observe(self, game_state):
-        message = {"__action__": "observe",
-                   "__data__": {"game_state": game_state}}
-        self._send(message)
-
     def show_state(self, game_state):
+        state = simplify_state(game_state)
         message = {"__action__": "observe",
-                   "__data__": game_state}
+                   "__data__": state}
         self._send(message)
 

--- a/pelita/ui/tk_canvas.py
+++ b/pelita/ui/tk_canvas.py
@@ -488,7 +488,7 @@ class TkApplication:
 
         def status(team_idx):
             try:
-                ret = "Timeouts: %d, Killed: %d, Time: %.2f" % (game_state["timeout_teams"][team_idx], game_state["times_killed"][team_idx], game_state["team_time"][team_idx])
+                ret = "Errors: %d, Killed: %d, Time: %.2f" % (game_state["num_errors"][team_idx], game_state["times_killed"][team_idx], game_state["team_time"][team_idx])
                 disqualified = game_state["teams_disqualified"][team_idx]
                 if disqualified is not None:
                     ret += ", Disqualified: %s" % disqualified
@@ -727,7 +727,6 @@ class TkApplication:
             skip_request = False
             self._observed_steps.add(step)
         # TODO
-        game_state['timeout_teams'] = [len(errors) for errors in game_state['errors']]
         game_state['teams_disqualified'] = [fatal and fatal[0]['type'] for fatal in game_state['fatal_errors']]
         game_state['bot_destroyed'] = []
         game_state['food_eaten'] = []

--- a/pelita/viewer.py
+++ b/pelita/viewer.py
@@ -9,6 +9,33 @@ from . import layout
 
 _logger = logging.getLogger(__name__)
 
+
+def simplify_state(game_state):
+    """ Simplify the state dict that is sent to a viewer
+    by reducing the amount of redundant information.
+
+    Returns
+    -------
+    state : dict
+        a new state dict
+    """
+    state = {}
+    state.update(game_state)
+    # we only send the current error
+    round_turn = (game_state["round"], game_state["turn"])
+
+    # reset error list so that we don’t overwrite
+    # the one from game_state
+    state["errors"] = []
+    state["num_errors"] = []
+    for team_errors in game_state["errors"]:
+        state["num_errors"].append(len(team_errors))
+        # retrieve the current error or None
+        current_error = team_errors.get(round_turn)
+        state["errors"].append(current_error)
+    return state
+
+
 class ProgressViewer:
     def show_state(self, game_state):
         score = game_state["score"]
@@ -121,7 +148,8 @@ class DumpingViewer:
         self.stream.flush()
 
     def show_state(self, game_state):
-        self._send(game_state)
+        state = simplify_state(game_state)
+        self._send(state)
 
 
 class ResultPrinter:

--- a/pelita/viewer.py
+++ b/pelita/viewer.py
@@ -10,31 +10,6 @@ from . import layout
 _logger = logging.getLogger(__name__)
 
 
-def simplify_state(game_state):
-    """ Simplify the state dict that is sent to a viewer
-    by reducing the amount of redundant information.
-
-    Returns
-    -------
-    state : dict
-        a new state dict
-    """
-    state = {}
-    state.update(game_state)
-    # we only send the current error
-    round_turn = (game_state["round"], game_state["turn"])
-
-    # reset error list so that we don’t overwrite
-    # the one from game_state
-    state["errors"] = []
-    state["num_errors"] = []
-    for team_errors in game_state["errors"]:
-        state["num_errors"].append(len(team_errors))
-        # retrieve the current error or None
-        current_error = team_errors.get(round_turn)
-        state["errors"].append(current_error)
-    return state
-
 
 class ProgressViewer:
     def show_state(self, game_state):
@@ -148,8 +123,7 @@ class DumpingViewer:
         self.stream.flush()
 
     def show_state(self, game_state):
-        state = simplify_state(game_state)
-        self._send(state)
+        self._send(game_state)
 
 
 class ResultPrinter:


### PR DESCRIPTION
`(round, turn)` cannot be used as a key in json but it is a good thing anyway not to send all the information that the viewer already knows about (especially in the case of past errors it is rather special interest anyway).

Future code may exclude the walls from serialisation too, at least when sending them to the zmq viewers (for local viewers there is not much harm in keeping them in the dict).

Closes #603.