### PR TITLE
Renamed --dump and added storage option for a player’s stdout/stderr

### DIFF
--- a/contrib/ci_engine.py
+++ b/contrib/ci_engine.py
@@ -103,7 +103,6 @@ class CI_Engine:
         self.rounds = config['general'].getint('rounds', None)
         self.filter = config['general'].get('filter', None)
         self.viewer = config['general'].get('viewer', 'null')
-        self.dump = config['general'].get('dump', None)
         self.seed = config['general'].get('seed', None)
 
         self.db_file = config.get('general', 'db_file')
@@ -156,7 +155,6 @@ class CI_Engine:
                                                             rounds=self.rounds,
                                                             filter=self.filter,
                                                             viewer=self.viewer,
-                                                            dump=self.dump,
                                                             seed=self.seed)
 
         if final_state['whowins'] == 2:

--- a/pelita/game.py
+++ b/pelita/game.py
@@ -187,13 +187,15 @@ def controller_exit(state, await_action='play_step'):
         elif todo in ('play_step', 'set_initial'):
             return False
 
-def run_game(team_specs, *, max_rounds, layout_dict, layout_name="", seed=None, dump=False,
-             max_team_errors=5, timeout_length=3, viewers=None, controller=None, viewer_options=None):
+def run_game(team_specs, *, max_rounds, layout_dict, layout_name="", seed=None,
+             max_team_errors=5, timeout_length=3, viewers=None, controller=None, viewer_options=None,
+             store_output=False):
     """ Run a match for `max_rounds` rounds. """
 
     # we create the initial game state
     state = setup_game(team_specs, layout_dict=layout_dict, max_rounds=max_rounds, timeout_length=timeout_length, seed=seed,
-                       viewers=viewers, controller=controller, viewer_options=viewer_options)
+                       viewers=viewers, controller=controller, viewer_options=viewer_options,
+                       store_output=store_output)
 
     # Play the game until it is gameover.
     while not state.get('gameover'):
@@ -261,8 +263,9 @@ def setup_viewers(viewers=None, options=None):
     return viewer_state
 
 
-def setup_game(team_specs, *, layout_dict, max_rounds=300, layout_name="", seed=None, dump=False,
-               max_team_errors=5, timeout_length=3, viewers=None, controller=None, viewer_options=None):
+def setup_game(team_specs, *, layout_dict, max_rounds=300, layout_name="", seed=None,
+               max_team_errors=5, timeout_length=3, viewers=None, controller=None, viewer_options=None,
+               store_output=False):
     """ Generates a game state for the given teams and layout with otherwise default values. """
 
     # check that two teams have been given
@@ -348,7 +351,7 @@ def setup_game(team_specs, *, layout_dict, max_rounds=300, layout_name="", seed=
     # to answer to the server.
     update_viewers(game_state)
 
-    team_state = setup_teams(team_specs, game_state)
+    team_state = setup_teams(team_specs, game_state, store_output=store_output)
     game_state.update(team_state)
 
     # Check if one of the teams has already generate a fatal error
@@ -361,7 +364,7 @@ def setup_game(team_specs, *, layout_dict, max_rounds=300, layout_name="", seed=
     return game_state
 
 
-def setup_teams(team_specs, game_state):
+def setup_teams(team_specs, game_state, store_output=False):
     """ Creates the teams according to the `teams`. """
 
     # we start with a dummy zmq_context
@@ -373,7 +376,7 @@ def setup_teams(team_specs, game_state):
     # First, create all teams
     # If a team is a RemoteTeam, this will start a subprocess
     for idx, team_spec in enumerate(team_specs):
-        team, zmq_context = make_team(team_spec, idx=idx, zmq_context=zmq_context)
+        team, zmq_context = make_team(team_spec, idx=idx, zmq_context=zmq_context, store_output=store_output)
         teams.append(team)
 
     # Send the initial state to the teams and await the team name

--- a/pelita/game.py
+++ b/pelita/game.py
@@ -18,7 +18,7 @@ from .layout import initial_positions, get_legal_positions
 from .libpelita import get_python_process, SimplePublisher
 from .network import bind_socket, setup_controller
 from .player.team import make_team
-from .viewer import ProgressViewer, AsciiViewer, ReplyToViewer, DumpingViewer, ResultPrinter
+from .viewer import ProgressViewer, AsciiViewer, ReplyToViewer, ReplayWriter, ResultPrinter
 
 _logger = logging.getLogger(__name__)
 _mswindows = (sys.platform == "win32")
@@ -233,8 +233,8 @@ def setup_viewers(viewers=None, options=None):
             viewer_state['viewers'].append(ProgressViewer())
         elif len(viewer) == 2 and viewer[0] == 'reply-to':
             viewer_state['viewers'].append(ReplyToViewer(viewer[1]))
-        elif len(viewer) == 2 and viewer[0] == 'dump-to':
-            viewer_state['viewers'].append(DumpingViewer(open(viewer[1], 'w')))
+        elif len(viewer) == 2 and viewer[0] == 'write-replay-to':
+            viewer_state['viewers'].append(ReplayWriter(open(viewer[1], 'w')))
         elif viewer in ('tk', 'tk-no-sync'):
             if not zmq_publisher:
                 zmq_publisher = SimplePublisher(address='tcp://127.0.0.1:*')

--- a/pelita/libpelita.py
+++ b/pelita/libpelita.py
@@ -225,7 +225,7 @@ def run_and_terminate_process(args, **kwargs):
                     p.kill()
 
 
-def call_pelita(team_specs, *, rounds, filter, viewer, dump, seed):
+def call_pelita(team_specs, *, rounds, filter, viewer, seed, write_replay=False):
     """ Starts a new process with the given command line arguments and waits until finished.
 
     Returns
@@ -250,17 +250,17 @@ def call_pelita(team_specs, *, rounds, filter, viewer, dump, seed):
     rounds = ['--rounds', str(rounds)] if rounds else []
     filter = ['--filter', filter] if filter else []
     viewer = ['--' + viewer] if viewer else []
-    dump = ['--dump', dump] if dump else []
     seed = ['--seed', seed] if seed else []
+    write_replay = ['--write-replay', write_replay] if write_replay else []
 
     cmd = [get_python_process(), '-m', 'pelita.scripts.pelita_main',
            team1, team2,
            '--reply-to', reply_addr,
-           *seed,
-           *dump,
-           *filter,
            *rounds,
-           *viewer]
+           *filter,
+           *viewer,
+           *seed,
+           *write_replay]
 
     # We need to run a process in the background in order to await the zmq events
     # stdout and stderr are written to temporary files in order to be more portable

--- a/pelita/libpelita.py
+++ b/pelita/libpelita.py
@@ -225,7 +225,7 @@ def run_and_terminate_process(args, **kwargs):
                     p.kill()
 
 
-def call_pelita(team_specs, *, rounds, filter, viewer, seed, write_replay=False):
+def call_pelita(team_specs, *, rounds, filter, viewer, seed, write_replay=False, store_output=False):
     """ Starts a new process with the given command line arguments and waits until finished.
 
     Returns
@@ -252,6 +252,7 @@ def call_pelita(team_specs, *, rounds, filter, viewer, seed, write_replay=False)
     viewer = ['--' + viewer] if viewer else []
     seed = ['--seed', seed] if seed else []
     write_replay = ['--write-replay', write_replay] if write_replay else []
+    store_output = ['--store-output', store_output] if store_output else []
 
     cmd = [get_python_process(), '-m', 'pelita.scripts.pelita_main',
            team1, team2,
@@ -260,7 +261,8 @@ def call_pelita(team_specs, *, rounds, filter, viewer, seed, write_replay=False)
            *filter,
            *viewer,
            *seed,
-           *write_replay]
+           *write_replay,
+           *store_output]
 
     # We need to run a process in the background in order to await the zmq events
     # stdout and stderr are written to temporary files in order to be more portable

--- a/pelita/player/team.py
+++ b/pelita/player/team.py
@@ -325,9 +325,13 @@ class RemoteTeam:
             _logger.info("Remote Player %r is already dead during exit. Ignoring.", self)
 
     def __del__(self):
-        self._exit()
-        if self.proc:
-            self.proc[0].terminate()
+        try:
+            self._exit()
+            if self.proc:
+                self.proc[0].terminate()
+        except AttributeError:
+            # in case we exit before self.proc or self.zmqconnection have been set
+            pass
 
     def __repr__(self):
         team_name = f" ({self._team_name})" if self._team_name else ""

--- a/pelita/scripts/pelita_main.py
+++ b/pelita/scripts/pelita_main.py
@@ -58,7 +58,7 @@ parser.add_argument('--write-replay', help=long_help('Print game dumps to file (
                     metavar='REPLAYFILE', const='pelita.dump', nargs='?')
 parser.add_argument('--replay', help=long_help('Replay a dumped game'),
                     metavar='REPLAYFILE', dest='replayfile', const='pelita.dump', nargs='?')
-parser.add_argument('--store-output', help=long_help('Write all stdout/stderr to the given folder'),
+parser.add_argument('--store-output', help=long_help('Write all player’s stdout/stderr to the given folder (must exist)'),
                     metavar='FOLDER')
 parser.add_argument('--list-layouts', action='store_true',
                     help='List all available layouts.')

--- a/pelita/scripts/pelita_main.py
+++ b/pelita/scripts/pelita_main.py
@@ -58,6 +58,8 @@ parser.add_argument('--write-replay', help=long_help('Print game dumps to file (
                     metavar='REPLAYFILE', const='pelita.dump', nargs='?')
 parser.add_argument('--replay', help=long_help('Replay a dumped game'),
                     metavar='REPLAYFILE', dest='replayfile', const='pelita.dump', nargs='?')
+parser.add_argument('--store-output', help=long_help('Write all stdout/stderr to the given folder'),
+                    metavar='FOLDER')
 parser.add_argument('--list-layouts', action='store_true',
                     help='List all available layouts.')
 parser.add_argument('--check-team', action="store_true",
@@ -263,7 +265,8 @@ def main():
     layout_dict = layout.parse_layout(layout_string)
     game.run_game(team_specs=team_specs, max_rounds=args.rounds, layout_dict=layout_dict, layout_name=layout_name, seed=args.seed,
                   timeout_length=args.timeout_length, max_team_errors=args.max_timeouts,
-                  viewers=viewers, viewer_options=viewer_options)
+                  viewers=viewers, viewer_options=viewer_options,
+                  store_output=args.store_output)
 
 if __name__ == '__main__':
     main()

--- a/pelita/scripts/pelita_main.py
+++ b/pelita/scripts/pelita_main.py
@@ -54,10 +54,10 @@ parser.add_argument('--version', help='Show the version number and exit.',
 parser.add_argument('--log', help='Print debugging log information to'
                     ' LOGFILE (default \'stderr\').',
                     metavar='LOGFILE', const='-', nargs='?')
-parser.add_argument('--dump', help=long_help('Print game dumps to file (will be overwritten)'),
-                    metavar='DUMPFILE', const='pelita.dump', nargs='?')
+parser.add_argument('--write-replay', help=long_help('Print game dumps to file (will be overwritten)'),
+                    metavar='REPLAYFILE', const='pelita.dump', nargs='?')
 parser.add_argument('--replay', help=long_help('Replay a dumped game'),
-                    metavar='DUMPFILE', dest='replayfile', const='pelita.dump', nargs='?')
+                    metavar='REPLAYFILE', dest='replayfile', const='pelita.dump', nargs='?')
 parser.add_argument('--list-layouts', action='store_true',
                     help='List all available layouts.')
 parser.add_argument('--check-team', action="store_true",
@@ -206,8 +206,8 @@ def main():
 
     if args.reply_to:
         viewers.append(('reply-to', args.reply_to))
-    if args.dump:
-        viewers.append(('dump-to', args.dump))
+    if args.write_replay:
+        viewers.append(('write-replay-to', args.write_replay))
     
     if args.replayfile:
         viewer_state = game.setup_viewers(viewers, options=viewer_options)
@@ -262,7 +262,7 @@ def main():
 
     layout_dict = layout.parse_layout(layout_string)
     game.run_game(team_specs=team_specs, max_rounds=args.rounds, layout_dict=layout_dict, layout_name=layout_name, seed=args.seed,
-                  timeout_length=args.timeout_length, max_team_errors=args.max_timeouts, dump=args.dump,
+                  timeout_length=args.timeout_length, max_team_errors=args.max_timeouts,
                   viewers=viewers, viewer_options=viewer_options)
 
 if __name__ == '__main__':

--- a/pelita/scripts/pelita_player.py
+++ b/pelita/scripts/pelita_player.py
@@ -132,6 +132,11 @@ def player_handle_request(socket, team):
         elif action == "team_name":
             retval = team.team_name
         elif action == "exit":
+            # quit and don’t return anything
+            message_obj = {
+                "__uuid__": msg_id,
+                "__return__": None
+            }
             return False
         else:
             _logger.warning(f"Player received unknown action {action}.")

--- a/pelita/tournament/tournament.py
+++ b/pelita/tournament/tournament.py
@@ -4,7 +4,6 @@
 import builtins
 import io
 import json
-import os
 from pathlib import Path
 import random
 import re
@@ -248,10 +247,16 @@ def play_game_with_config(config, teams):
     team1, team2 = teams
 
     if config.tournament_log_folder:
-        dumpfile = os.path.join(config.tournament_log_folder, "dump-{time}".format(time=time.strftime('%Y%m%d-%H%M%S')))
-        dump = dumpfile
+        log_folder = config.tournament_log_folder / f"match-{time.strftime('%Y%m%d-%H%M%S')}"
+        log_folder.mkdir()
+        replay_file = log_folder / 'replay'
+        log_kwargs = {
+            'write_replay': str(replay_file),
+            'store_output': str(log_folder)
+        }
     else:
-        dump = None
+        log_folder = None
+        log_kwargs = {}
 
     seed = str(random.randint(0, sys.maxsize))
 
@@ -259,13 +264,13 @@ def play_game_with_config(config, teams):
                                 rounds=config.rounds,
                                 filter=config.filter,
                                 viewer=config.viewer,
-                                dump=dump,
-                                seed=seed)
+                                seed=seed,
+                                **log_kwargs)
 
-    if dump:
+    if log_folder:
         (_final_state, stdout, stderr) = res
-        Path(dump + '.out').write_text(stdout)
-        Path(dump + '.err').write_text(stderr)
+        (log_folder / 'main.out').write_text(stdout)
+        (log_folder / 'main.err').write_text(stderr)
 
     return res
 

--- a/pelita/viewer.py
+++ b/pelita/viewer.py
@@ -107,7 +107,7 @@ class ReplyToViewer:
         self._send(game_state)
 
 
-class DumpingViewer:
+class ReplayWriter:
     """ A viewer which dumps to a given stream.
     """
     def __init__(self, stream):

--- a/test/test_libpelita.py
+++ b/test/test_libpelita.py
@@ -1,6 +1,8 @@
 import pytest
 
+import subprocess
 import sys
+import tempfile
 
 from pelita.simplesetup import ZMQClientError
 from pelita import libpelita
@@ -15,28 +17,27 @@ class TestLibpelitaUtils:
         assert libpelita.firstNN(None, None, None) == None
         assert libpelita.firstNN() == None
 
-class TestCallPelita:
-    def test_call_pelita(self):
-        rounds = 200
-        viewer = 'ascii'
-        filter = 'small'
+def test_call_pelita():
+    rounds = 200
+    viewer = 'ascii'
+    filter = 'small'
 
-        teams = ["pelita/player/StoppingPlayer", "pelita/player/StoppingPlayer"]
-        (state, stdout, stderr) = libpelita.call_pelita(teams, rounds=rounds, viewer='null', filter=filter, dump=None, seed=None)
-        assert state['gameover'] is True
-        assert state['whowins'] == 2
-        # Quick assert that there is text in stdout
-        assert len(stdout.split('\n')) == 6
+    teams = ["pelita/player/StoppingPlayer", "pelita/player/StoppingPlayer"]
+    (state, stdout, stderr) = libpelita.call_pelita(teams, rounds=rounds, viewer='null', filter=filter, seed=None)
+    assert state['gameover'] is True
+    assert state['whowins'] == 2
+    # Quick assert that there is text in stdout
+    assert len(stdout.split('\n')) == 6
 
-        teams = ["pelita/player/SmartEatingPlayer", "pelita/player/StoppingPlayer"]
-        (state, stdout, stderr) = libpelita.call_pelita(teams, rounds=rounds, viewer=viewer, filter=filter, dump=None, seed=None)
-        assert state['gameover'] is True
-        assert state['whowins'] == 0
+    teams = ["pelita/player/SmartEatingPlayer", "pelita/player/StoppingPlayer"]
+    (state, stdout, stderr) = libpelita.call_pelita(teams, rounds=rounds, viewer=viewer, filter=filter, seed=None)
+    assert state['gameover'] is True
+    assert state['whowins'] == 0
 
-        teams = ["pelita/player/StoppingPlayer", "pelita/player/SmartEatingPlayer"]
-        (state, stdout, stderr) = libpelita.call_pelita(teams, rounds=rounds, viewer=viewer, filter=filter, dump=None, seed=None)
-        assert state['gameover'] is True
-        assert state['whowins'] == 1
+    teams = ["pelita/player/StoppingPlayer", "pelita/player/SmartEatingPlayer"]
+    (state, stdout, stderr) = libpelita.call_pelita(teams, rounds=rounds, viewer=viewer, filter=filter, seed=None)
+    assert state['gameover'] is True
+    assert state['whowins'] == 1
 
 
 def test_check_team_external():
@@ -50,3 +51,37 @@ def test_check_team_internal():
     def move(b, s):
         return b.position, s
     assert libpelita.check_team(move) == "local-team (move)"
+
+
+def test_write_replay_is_idempotent():
+    # TODO: The replay functionality could be added to call_pelita
+    # so we don’t have to run the subprocess ourselves
+    with tempfile.NamedTemporaryFile() as f:
+        with tempfile.NamedTemporaryFile() as g:
+            # run a quick game and save the game states to f
+
+            cmd = [libpelita.get_python_process(), '-m', 'pelita.scripts.pelita_main',
+                    '--write-replay', f.name,
+                    '--filter', 'small',
+                    '--null']
+
+            subprocess.check_output(cmd)
+
+            f.seek(0)
+            first_run = f.read()
+            # check that we received something
+            assert len(first_run) > 0
+
+            # run a replay of f and store in g
+            cmd = [libpelita.get_python_process(), '-m', 'pelita.scripts.pelita_main',
+                    '--write-replay', g.name,
+                    '--replay', f.name,
+                    '--null']
+
+            subprocess.check_output(cmd)
+
+            g.seek(0)
+            second_run = g.read()
+            # check that f and g have the same content
+            assert first_run == second_run
+

--- a/test/test_remote_game.py
+++ b/test/test_remote_game.py
@@ -31,10 +31,12 @@ def remote_teams():
 
 
 def test_remote_call_pelita(remote_teams):
-    res, stdout, stderr = libpelita.call_pelita(remote_teams, rounds=30, filter='small', viewer='null', dump=None, seed=None)
+    res, stdout, stderr = libpelita.call_pelita(remote_teams, rounds=30, filter='small', viewer='null', seed=None)
     assert res['whowins'] == 1
     assert res['fatal_errors'] == [[], []]
-    assert res['errors'] == [{}, {}]
+    # errors for call_pelita only contains the last thrown error, hence None
+    # TODO: should be alligned so that call_pelita and run_game return the same thing
+    assert res['errors'] == [None, None]
 
 
 def test_remote_run_game(remote_teams):


### PR DESCRIPTION
`--dump` is now called `--write-replay`

`--store-output` will write the player’s stdout and stderr into the specified folder. Note that this needs to be done unbuffered or else we will lose the most important messages (the reason why a bot crashed).
