### PR TITLE
BF: Allow team names that include the string ‘error’.

### DIFF
--- a/pelita/scripts/pelita_player.py
+++ b/pelita/scripts/pelita_player.py
@@ -146,7 +146,12 @@ def player_handle_request(socket, team):
             "__return__": retval
         }
 
-        if "error" in retval:
+        # retval can be a string with a team name,
+        # a dict with a move and optionally additional data,
+        # or a dict with error key and message, if something
+        # went wrong
+
+        if isinstance(retval, dict) and 'error' in retval:
             # The team class has flagged an error.
             # We return the result (in the finally clause)
             # but return false to exit the process.


### PR DESCRIPTION
A team with `TEAM_NAME="error"` would be detected as returning an error dict (Team returns `{'error': (error_type, error_msg)}` when it has detected an exception in the client), as it would return the team name string after `set_initial`.

In a future revision, we should have `set_initial` return a dict as well (and probably change the return dict in case of error to `{'error': error_type, 'error_msg': error_msg}, too).

Needs a test of some sort. This is an error of the kind that will pop up again eventually.
