### PR TITLE
Add enemy character handling to parse_layout

### DIFF
--- a/pelita/layout.py
+++ b/pelita/layout.py
@@ -440,6 +440,28 @@ def layout_as_str(*, walls, food=None, bots=None, enemy=None):
     return out.getvalue()
 
 
+def layout_for_team(layout, is_blue=True):
+    """ Converts a layout dict with 4 bots to a layout
+    from the view of the specified team.
+    """
+    if "enemy" in layout:
+        raise ValueError("Layout is already in team-style.")
+
+    if is_blue:
+        bots = layout['bots'][0::2]
+        enemy = layout['bots'][1::2]
+    else:
+        bots = layout['bots'][1::2]
+        enemy = layout['bots'][0::2]
+
+    return {
+        'walls': layout['walls'][:],
+        'food': layout['food'][:],
+        'bots': bots,
+        'enemy': enemy,
+    }
+
+
 def wall_dimensions(walls):
     """ Given a list of walls, returns a tuple of (width, height)."""
     width = max(walls)[0] + 1

--- a/pelita/layout.py
+++ b/pelita/layout.py
@@ -9,12 +9,6 @@ except SyntaxError as err:
     print("Invalid syntax in __layouts module. Pelita will not be able to use built-in layouts.")
     print(err)
 
-class Layout:
-    pass
-
-class LayoutEncodingException(Exception):
-    """ Signifies a problem with the encoding of a layout. """
-    pass
 
 def get_random_layout(filter=''):
     """ Return a random layout string from the available ones.

--- a/pelita/layout.py
+++ b/pelita/layout.py
@@ -172,7 +172,10 @@ def parse_layout(layout_str):
         # add the bots
         for bot_idx, bot_pos in enumerate(items['bots']):
             if bot_pos:
-                # this bot position is not None, overwrite whatever we had before
+                # this bot position is not None, overwrite whatever we had before, unless
+                # it already holds a different coordinate
+                if out['bots'][bot_idx] and out['bots'][bot_idx] != bot_pos:
+                    raise ValueError(f"Cannot set bot {bot_idx} to position {bot_pos} (already at {out['bots'][bot_idx]}).")
                 out['bots'][bot_idx] = bot_pos
 
     return out
@@ -255,6 +258,11 @@ def parse_single_layout(layout_str):
                         raise ValueError
                 except ValueError:
                     raise ValueError(f"Unknown character {char} in maze!")
+
+                # bot_idx is a valid character.
+                if bots[bot_idx]:
+                    # bot_idx has already been set before
+                    raise ValueError(f"Cannot set bot {bot_idx} to position {coord} (already at {bots[bot_idx]}).")
                 bots[bot_idx] = coord
     walls.sort()
     food.sort()

--- a/pelita/layout.py
+++ b/pelita/layout.py
@@ -226,7 +226,9 @@ def parse_layout(layout_str, allow_enemy_chars=False):
     }
 
     if allow_enemy_chars:
-        out['enemy'] = sorted(enemy)
+        # sort the enemy characters
+        # be careful, since it may contain None
+        out['enemy'] = sorted(enemy, key=lambda x: () if x is None else x)
 
     return out
 

--- a/pelita/layout.py
+++ b/pelita/layout.py
@@ -163,7 +163,7 @@ def parse_layout(layout_str):
     # initialize walls, food and bots from the first layout
     out = parse_single_layout(layout_list.pop(0))
     for layout in layout_list:
-        items = parse_layout(layout)
+        items = parse_single_layout(layout)
         # walls should always be the same
         if items['walls'] != out['walls']:
             raise ValueError('Walls are not equal in all layouts!')

--- a/pelita/player/team.py
+++ b/pelita/player/team.py
@@ -702,8 +702,8 @@ def create_layout(*layout_strings, food=None, bots=None, enemy=None):
 
     # override bots if given and not None
     if bots is not None:
-        if not len(bots) == 2:
-            raise ValueError(f"bots must be a list of 2 ({bots})!")
+        if len(bots) > 2:
+            raise ValueError(f"bots must not be more than 2 ({bots})!")
         for idx, pos in enumerate(bots):
             if pos is not None:
                 _check_valid_pos(pos, "bot")

--- a/pelita/player/team.py
+++ b/pelita/player/team.py
@@ -688,7 +688,6 @@ def create_layout(*layout_strings, food=None, bots=None, enemy=None):
     width, height = wall_dimensions(parsed_layout['walls'])
 
     def _check_valid_pos(pos, item):
-        print(pos, width, height)
         if pos in parsed_layout['walls']:
             raise ValueError(f"{item} must not be on wall (given: {pos})!")
         if not ((0 <= pos[0] < width) and (0 <= pos[1] < height)):

--- a/pelita/utils/__init__.py
+++ b/pelita/utils/__init__.py
@@ -3,11 +3,10 @@ import random
 from ..player.team import create_layout, make_bots
 from ..graph import Graph
 
-def split_food(layout):
-    width = max(layout.walls)[0] + 1
 
+def split_food(width, food):
     team_food = [set(), set()]
-    for pos in layout.food:
+    for pos in food:
         idx = pos[0] // (width // 2)
         team_food[idx].add(pos)
     return team_food
@@ -26,7 +25,9 @@ def setup_test_game(*, layout, game=None, is_blue=True, round=None, score=None, 
         score = [0, 0]
 
     layout = create_layout(layout, food=food, bots=bots, enemy=enemy)
-    food = split_food(layout)
+    width = max(layout['walls'])[0] + 1
+
+    food = split_food(width, layout['food'])
 
     if is_blue:
         team_index = 0
@@ -38,7 +39,7 @@ def setup_test_game(*, layout, game=None, is_blue=True, round=None, score=None, 
     rng = random.Random(seed)
 
     team = {
-        'bot_positions': layout.bots[:],
+        'bot_positions': layout['bots'][:],
         'team_index': team_index,
         'score': score[team_index],
         'kills': [0]*2,
@@ -49,7 +50,7 @@ def setup_test_game(*, layout, game=None, is_blue=True, round=None, score=None, 
         'name': "blue" if is_blue else "red"
     }
     enemy = {
-        'bot_positions': layout.enemy[:],
+        'bot_positions': layout['enemy'][:],
         'team_index': enemy_index,
         'score': score[enemy_index],
         'kills': [0]*2,
@@ -57,11 +58,11 @@ def setup_test_game(*, layout, game=None, is_blue=True, round=None, score=None, 
         'bot_eaten': [False]*2,
         'error_count': 0,
         'food': food[enemy_index],
-        'is_noisy': [False] * len(layout.enemy),
+        'is_noisy': [False] * len(layout['enemy']),
         'name': "red" if is_blue else "blue"
     }
 
-    bot = make_bots(walls=layout.walls[:],
+    bot = make_bots(walls=layout['walls'][:],
                     team=team,
                     enemy=enemy,
                     round=round,

--- a/test/test_layout.py
+++ b/test/test_layout.py
@@ -138,6 +138,41 @@ def test_combined_layouts_empty_lines():
     from_single = parse_single_layout(layouts)
     assert from_combined == from_single
 
+def test_duplicate_bots_forbidden():
+    layouts = """
+                 ####
+                 #11#
+                 ####
+                 """
+    with pytest.raises(ValueError):
+        parse_layout(layouts)
+
+def test_duplicate_bots_forbidden_multiple():
+    layouts = """
+                 ####
+                 # 1#
+                 ####
+
+                 ####
+                 #1 #
+                 ####
+                 """
+    with pytest.raises(ValueError):
+        parse_layout(layouts)
+
+def test_duplicate_bots_allowed():
+    layouts = """
+                 ####
+                 # 1#
+                 ####
+
+                 ####
+                 # 1#
+                 ####
+                 """
+    parsed_layout = parse_layout(layouts)
+    assert parsed_layout['bots'][1] == (2, 1)
+
 def test_combined_layouts_broken_lines():
     layouts = """
                  ####

--- a/test/test_layout.py
+++ b/test/test_layout.py
@@ -326,3 +326,77 @@ def test_legal_positions_fail(pos):
     parsed = parse_layout(test_layout)
     with pytest.raises(ValueError):
         get_legal_positions(parsed['walls'], pos)
+
+def test_enemy_raises():
+    layouts = """
+        ####
+        #E1#
+        ####
+
+        ####
+        #1 #
+        ####
+        """
+    with pytest.raises(ValueError):
+        parse_layout(layouts)
+
+@pytest.mark.parametrize('layout,enemy_pos', [
+    ("""
+        ####
+        #E #
+        ####
+        """, [(1, 1), (1, 1)]), # one enemy sets both coordinates
+    ("""
+        ####
+        #EE#
+        ####
+        """, [(1, 1), (2, 1)]), # two enemies
+    ("""
+        ####
+        #E #
+        ####
+        ####
+        #E #
+        ####
+        """, [(1, 1), (1, 1)]), # two enemies two layouts on the same spot
+    ("""
+        ####
+        #E #
+        ####
+        ####
+        # E#
+        ####
+        """, [(1, 1), (2, 1)]), # two enemies in two layouts
+    ("""
+        ####
+        # E#
+        ####
+        ####
+        #E #
+        ####
+        """, [(1, 1), (2, 1)]), # two enemies in two layouts (list is sorted)
+    ("""
+        ####
+        # E#
+        ####
+        ####
+        #EE#
+        ####
+        """, [(1, 1), (2, 1)]), # two enemies in two layouts with duplication
+    ("""
+        #######
+        #E E E#
+        #######
+        """, None), # this will raise ValueError
+    ("""
+        ####
+        #  #
+        ####
+        """, [None, None]), # this will set both to None
+])
+def test_enemy_positions(layout, enemy_pos):
+    if enemy_pos is None:
+        with pytest.raises(ValueError):
+            parse_layout(layout, allow_enemy_chars=True)
+    else:
+        assert parse_layout(layout, allow_enemy_chars=True)['enemy'] == enemy_pos

--- a/test/test_layout.py
+++ b/test/test_layout.py
@@ -400,3 +400,39 @@ def test_enemy_positions(layout, enemy_pos):
             parse_layout(layout, allow_enemy_chars=True)
     else:
         assert parse_layout(layout, allow_enemy_chars=True)['enemy'] == enemy_pos
+
+def test_layout_for_team():
+    # test that we can convert a layout to team-style
+    l1 = """
+    ####
+    #01#
+    #32#
+    #..#
+    ####
+    """
+    blue1 = layout_as_str(**layout_for_team(parse_layout(l1), is_blue=True))
+    red1 = layout_as_str(**layout_for_team(parse_layout(l1), is_blue=False))
+
+    assert blue1 == """\
+####
+#0E#
+#E1#
+#..#
+####
+"""
+
+    assert red1 == """\
+####
+#E0#
+#1E#
+#..#
+####
+"""
+
+
+    # cannot convert layout that is already in team-style
+    with pytest.raises(ValueError):
+        layout_for_team(parse_layout(blue1))
+
+    with pytest.raises(ValueError):
+        layout_for_team(parse_layout(red1))

--- a/test/test_team.py
+++ b/test/test_team.py
@@ -1,8 +1,8 @@
 import pytest
 
-from pelita.layout import parse_layout, get_random_layout, initial_positions
+from pelita.layout import parse_layout, get_random_layout, initial_positions, layout_as_str
 from pelita.game import run_game, setup_game, play_turn
-from pelita.player.team import Team, split_layout_str, create_layout
+from pelita.player.team import Team, create_layout
 from pelita.utils import setup_test_game
 
 def stopping(bot, state):
@@ -12,166 +12,154 @@ def randomBot(bot, state):
     legal = bot.legal_positions[:]
     return bot.random.choice(legal), state
 
-class TestLayout:
-    layout="""
-    ########
-    # ###E0#
-    #1E    #
-    ########
-    """
-    layout2="""
-    ########
-    # ###  #
-    # . ...#
-    ########
-    """
-
-    def test_split_layout(self):
-        layout = split_layout_str(self.layout)
-        assert len(layout) == 1
-        assert layout[0].strip() != ""
-
-        mini = """####
-                  #  #
-                  ####"""
-        layout = split_layout_str(mini)
-        assert len(layout) == 1
-        assert layout[0].strip() != ""
-
-    def test_load(self):
-        layout = create_layout(self.layout, self.layout2)
-        assert layout.bots == [(6, 1), (1, 2)]
-        assert layout.enemy == [(5, 1), (2, 2)]
-
-    def test_concat(self):
-        layout = create_layout(self.layout + self.layout2)
-        assert layout.bots == [(6, 1), (1, 2)]
-        assert layout.enemy == [(5, 1), (2, 2)]
-
-    def test_load1(self):
-        layout = create_layout(self.layout)
-        assert layout.bots == [(6, 1), (1, 2)]
-        assert layout.enemy == [(5, 1), (2, 2)]
-
-    def test_equal_positions(self):
-        layout_str = """
-            ########
-            #0###  #
-            # . ...#
-            ########
-
-            ########
-            #1###  #
-            # . ...#
-            ########
-
-            ########
-            #E###  #
-            # . ...#
-            ########
-
-            ########
-            #E###  #
-            # . ...#
-            ########
-        """
-        layout = create_layout(layout_str)
-        assert layout.bots == [(1, 1), (1, 1)]
-        assert layout.enemy ==  [(1, 1), (1, 1)]
-        setup_test_game(layout=layout_str)
-
-    def test_define_after(self):
-        layout = create_layout(self.layout, food=[(1, 1)], bots=[None, None], enemy=None)
-        assert layout.bots == [(6, 1), (1, 2)]
-        assert layout.enemy == [(5, 1), (2, 2)]
-        layout = create_layout(self.layout, food=[(1, 1)], bots=[None, (1, 2)], enemy=None)
-        assert layout.bots == [(6, 1), (1, 2)]
-        assert layout.enemy == [(5, 1), (2, 2)]
-
-        layout = create_layout(self.layout, food=[(1, 1)], bots=[None, (1, 2)], enemy=[(5, 1)])
-        assert layout.enemy == [(2, 2), (5, 1)]
-
-        layout = create_layout(self.layout2, food=[(1, 1)], bots=[None, (1, 2)], enemy=[(5, 1), (2, 2)])
-        assert layout.bots == [None, (1, 2)]
-        assert layout.enemy == [(5, 1), (2, 2)]
-
-        with pytest.raises(ValueError):
-            # placed bot on walls
-            layout = create_layout(self.layout2, food=[(1, 1)], bots=[(0, 1), (1, 2)], enemy=[(5, 1), (2, 2)])
-
-        with pytest.raises(ValueError):
-            # placed bot outside maze
-            layout = create_layout(self.layout2, food=[(1, 1)], bots=[(1, 40), (1, 2)], enemy=[(5, 1), (2, 2)])
-
-        with pytest.raises(ValueError):
-            # too many bots
-            layout = create_layout(self.layout2, food=[(1, 1)], bots=[(1, 1), (1, 2), (2, 2)], enemy=[(5, 1), (2, 2)])
-
-    def test_repr(self):
-        layout = create_layout(self.layout, food=[(1, 1)], bots=[None, None], enemy=None)
-        assert layout._repr_html_()
-        str1 = str(create_layout(self.layout, food=[(1, 1)], bots=[None, None], enemy=None))
-        assert str1 == """
-########
-#.###  #
-#      #
-########
-
+layout1="""
 ########
 # ###E0#
 #1E    #
 ########
-
+"""
+layout2="""
+########
+# ###  #
+# . ...#
+########
 """
 
-        layout_merge = create_layout(self.layout, food=[(1, 1)], bots=[(1, 2), (1, 2)], enemy=[(1, 1), (1, 1)])
-        str2 = str(layout_merge)
-        assert str2 == """
+
+def test_load():
+    layout = create_layout(layout1, layout2)
+    assert layout['bots'] == [(6, 1), (1, 2)]
+    assert layout['enemy'] == [(2, 2), (5, 1)]
+
+def test_concat():
+    layout = create_layout(layout1 + layout2)
+    assert layout['bots'] == [(6, 1), (1, 2)]
+    assert layout['enemy'] == [(2, 2), (5, 1)]
+
+def test_load1():
+    layout = create_layout(layout1)
+    assert layout['bots'] == [(6, 1), (1, 2)]
+    assert layout['enemy'] == [(2, 2), (5, 1)]
+
+def test_equal_positions():
+    layout_str = """
+        ########
+        #0###  #
+        # . ...#
+        ########
+
+        ########
+        #1###  #
+        # . ...#
+        ########
+
+        ########
+        #E###  #
+        # . ...#
+        ########
+
+        ########
+        #E###  #
+        # . ...#
+        ########
+    """
+    layout = create_layout(layout_str)
+    assert layout['bots'] == [(1, 1), (1, 1)]
+    assert layout['enemy'] ==  [(1, 1), (1, 1)]
+    setup_test_game(layout=layout_str)
+
+def test_define_after():
+    layout = create_layout(layout1, food=[(1, 1)], bots=[None, None], enemy=None)
+    assert layout['bots'] == [(6, 1), (1, 2)]
+    assert layout['enemy'] == [(2, 2), (5, 1)]
+    layout = create_layout(layout1, food=[(1, 1)], bots=[None, (1, 1)], enemy=None)
+    assert layout['bots'] == [(6, 1), (1, 1)]
+    assert layout['enemy'] == [(2, 2), (5, 1)]
+
+    with pytest.raises(ValueError):
+        # must define all enemies
+        layout = create_layout(layout1, food=[(1, 1)], bots=[None, (1, 2)], enemy=[(5, 1)])
+
+    layout = create_layout(layout2, food=[(1, 1)], bots=[None, (1, 2)], enemy=[(5, 1), (2, 2)])
+    assert layout['bots'] == [None, (1, 2)]
+    assert layout['enemy'] == [(5, 1), (2, 2)]
+
+    with pytest.raises(ValueError):
+        # placed bot on walls
+        layout = create_layout(layout2, food=[(1, 1)], bots=[(0, 1), (1, 2)], enemy=[(5, 1), (2, 2)])
+
+    with pytest.raises(ValueError):
+        # placed bot outside maze
+        layout = create_layout(layout2, food=[(1, 1)], bots=[(1, 40), (1, 2)], enemy=[(5, 1), (2, 2)])
+
+    with pytest.raises(ValueError):
+        # placed bot outside maze
+        layout = create_layout(layout2, food=[(1, 1)], bots=[(40, 40), (1, 2)], enemy=[(5, 1), (2, 2)])
+
+    with pytest.raises(ValueError):
+        # placed bot outside maze
+        layout = create_layout(layout2, food=[(1, 1)], bots=[(-40, 4), (1, 2)], enemy=[(5, 1), (2, 2)])
+
+    with pytest.raises(ValueError):
+        # too many bots
+        layout = create_layout(layout2, food=[(1, 1)], bots=[(1, 1), (1, 2), (2, 2)], enemy=[(5, 1), (2, 2)])
+
+def test_repr():
+    layout = create_layout(layout1, food=[(1, 1)], bots=[None, None], enemy=None)
+    str1 = layout_as_str(**layout)
+    assert str1 == """\
+########
+#.###E0#
+#1E    #
+########
+"""
+
+    layout_merge = create_layout(layout1, food=[(1, 1)], bots=[(1, 2), (1, 2)], enemy=[(1, 1), (1, 1)])
+    str2 = layout_as_str(**layout_merge)
+    assert str2 == """\
 ########
 #.###  #
 #      #
 ########
-
 ########
 #E###  #
 #0     #
 ########
-
 ########
 #E###  #
 #1     #
 ########
-
 """
-        # load again
-        assert create_layout(str2) == layout_merge
+    # load again
+    assert create_layout(str2) == layout_merge
 
-    def test_solo_bot(self):
-        l = """
-        ########
-        #.###  #
-        #      #
-        ########
+def test_two_enemies():
+    # single E evaluates to two enemies
+    l = """
+    ########
+    #.###  #
+    #      #
+    ########
 
-        ########
-        # ###  #
-        #0E    #
-        ########
-        """
-        layout = create_layout(l, food=[(1, 1)], bots=[None, None], enemy=None)
-        assert layout._repr_html_()
-        str1 = str(create_layout(l, food=[(1, 1)], bots=[None, None], enemy=None))
-        assert str1 == """
+    ########
+    # ###  #
+    #0E    #
+    ########
+    """
+    str1 = layout_as_str(**create_layout(l, food=[(1, 1)], bots=[None, None], enemy=None))
+    assert str1 == """\
 ########
 #.###  #
 #      #
 ########
-
 ########
 # ###  #
 #0E    #
 ########
-
+########
+# ###  #
+# E    #
+########
 """
 
 


### PR DESCRIPTION
Adds a new functionality to `parse_layout` that accepts the layouts that are accepted in `setup_test_game`

    layout = """
    ########
    #01..EE#
    ########
    """
    parse_layout(layout, allow_enemy_chars=True)['enemy'] == [(5, 1), (6, 1)]

Additionally, it fixes #617 

Still work in progress while I rewrite `pelita.utils.create_layout` to use this function instead of it’s own class-based representation.

The main problem I have with the API is that now we have two types of layout. First, the 4 bot based one that we use in all our provided layouts, and then the team-centric one with 2 bots, 2 enemies. They are both dicts and their only difference is that the latter one has a key `"enemy"` and the list of bots has only a length of 2. I fear this will be very confusing at some point or even lead to weird bugs (the team-centric layout could easily be passed to a function that expects the other style and go unnoticed since it will just ignore the `"enemy"` key).

Any ideas?

Closes #615 
