### PR TITLE
Promote pytest and networkx to dependencies for pelita

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,11 +23,11 @@ install_requires =
     pyzmq
     PyYAML
     numpy
+    networkx
+    pytest>=4
 include_package_data = True
 setup_requires =
     pytest-runner
-tests_require = 
-    pytest>=4
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
pytest is needed for the tests also in pelita_template, so it makes
sense if it gets installed unconditionally together with pelita.

networkx is not strictly a dependency, but it makes sense to use it
in pelita_template, and it is indeed used already in some demos, so
let's have it also for pelita, given that pelita_template will come
back to the main repo at some point.