### PR TITLE
ENH: Only transmit the walls during set_initial phase

### DIFF
--- a/pelita/game.py
+++ b/pelita/game.py
@@ -391,7 +391,9 @@ def prepare_bot_state(game_state, idx=None):
 
     """
 
-    if game_state.get('turn') is None and idx is not None:
+    bot_initialization = game_state.get('turn') is None and idx is not None
+
+    if bot_initialization:
         # We assume that we are in get_initial phase
         turn = idx
         bot_turn = None
@@ -438,14 +440,18 @@ def prepare_bot_state(game_state, idx=None):
     }
 
     bot_state = {
-        'walls': game_state['walls'], # only in initial round
-        'seed': seed, # only used in set_initial phase
         'team': team_state,
         'enemy': enemy_state,
         'round': game_state['round'],
         'bot_turn': bot_turn,
         'timeout_length': game_state['timeout_length']
     }
+
+    if bot_initialization:
+        bot_state.update({
+            'walls': game_state['walls'], # only in initial round
+            'seed': seed # only used in set_initial phase
+        })
 
     return bot_state
 

--- a/pelita/player/team.py
+++ b/pelita/player/team.py
@@ -77,6 +77,9 @@ class Team:
         # Reset the bot tracks
         self._bot_track = [[], []]
 
+        # Store the walls, which are only transmitted once
+        self._walls = game_state['walls']
+
         return self.team_name
 
     def get_move(self, game_state):
@@ -94,7 +97,7 @@ class Team:
         -------
         move : dict
         """
-        me = make_bots(walls=game_state['walls'],
+        me = make_bots(walls=self._walls,
                        team=game_state['team'],
                        enemy=game_state['enemy'],
                        round=game_state['round'],


### PR DESCRIPTION
Closes #485.

The speed increase is not super big (10–20% faster), so I am not 100% sure, if we really do need it. However, compared to pelita from September 2018, we are almost three times slower, when running a game with stopping players on a big layout… At some point we should see, if profiling helps (or cache the height/width of the layout, which I am almost sure is a factor).