### PR TITLE
Use importlib.resources instead of pkg_resources

### DIFF
--- a/pelita/layout.py
+++ b/pelita/layout.py
@@ -1,4 +1,8 @@
-import importlib.resources as importlib_resources
+try:
+    import importlib.resources as importlib_resources
+except ImportError:
+    # Python 3.6
+    import importlib_resources
 import io
 from pathlib import Path
 import random

--- a/pelita/layout.py
+++ b/pelita/layout.py
@@ -1,6 +1,6 @@
+import importlib.resources as importlib_resources
 import io
 from pathlib import Path
-import pkg_resources
 import random
 
 def get_random_layout(filter=''):
@@ -50,7 +50,7 @@ def get_available_layouts(filter=''):
 
     """
     # loop in layouts directory and look for layout files
-    return [item[:-(len('.layout'))] for item in pkg_resources.resource_listdir('pelita', '_layouts')
+    return [item[:-(len('.layout'))] for item in importlib_resources.contents('pelita._layouts')
                  if item.endswith('.layout') and filter in item]
 
 def get_layout_by_name(layout_name):
@@ -76,7 +76,7 @@ def get_layout_by_name(layout_name):
     get_available_layouts
     """
     try:
-        return pkg_resources.resource_string('pelita', '_layouts/' + layout_name + '.layout').decode()
+        return importlib_resources.read_text('pelita._layouts', layout_name + '.layout')
     except FileNotFoundError:
         # This happens if layout_name is not found in the layouts directory
         # reraise as ValueError with appropriate error message.

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ install_requires =
     numpy
     networkx
     pytest>=4
+    importlib_resources; python_version<"3.7"
 include_package_data = True
 setup_requires =
     pytest-runner


### PR DESCRIPTION
New in Python 3.7 (but backported for earlier versions). Comes with a nicer API, too.
