### PR TITLE
NF: Add utils function to load a builtin layout for a team

### DIFF
--- a/pelita/utils.py
+++ b/pelita/utils.py
@@ -1,8 +1,9 @@
 import logging
 import random
 
-from .player.team import create_layout, make_bots
 from .graph import Graph
+from .layout import get_layout_by_name, layout_as_str, layout_for_team, parse_layout
+from .player.team import create_layout, make_bots
 
 
 def start_logging(filename, module='pelita'):
@@ -24,6 +25,12 @@ def split_food(width, food):
         idx = pos[0] // (width // 2)
         team_food[idx].add(pos)
     return team_food
+
+
+def load_builtin_layout(layout_name, *, is_blue=True):
+    """ Loads a builtin layout with the given `layout_name` and returns a layout string.
+    """
+    return layout_as_str(**layout_for_team(parse_layout(get_layout_by_name(layout_name)), is_blue=is_blue))
 
 
 def setup_test_game(*, layout, game=None, is_blue=True, round=None, score=None, seed=None,


### PR DESCRIPTION
Adds a new helper function to `pelita.utils` that can be used to load a builtin layout in a way that it can be passed to `setup_test_game`:

    layout = load_builtin_layout("small_without_dead_ends_001", is_blue=True)
    setup_test_game(layout=layout, is_blue=True)

If this is the proper way to do it is still up for discussion.
