### PR TITLE
Better walls for TK UI

### DIFF
--- a/pelita/ui/tk_sprites.py
+++ b/pelita/ui/tk_sprites.py
@@ -221,7 +221,7 @@ class Wall(TkSprite):
 
 
     def draw(self, canvas, game_state=None):
-        scale = (self.mesh.half_scale_x + self.mesh.half_scale_y) * 0.5
+        scale = (self.mesh.half_scale_x + self.mesh.half_scale_y) * 0.6
         if not ((0, 1) in self.wall_neighbors or
                 (1, 0) in self.wall_neighbors or
                 (0, -1) in self.wall_neighbors or
@@ -230,7 +230,7 @@ class Wall(TkSprite):
             # draw only a small dot.
             # TODO add diagonal lines
             canvas.create_line(self.screen((-0.3, 0)), self.screen((+0.3, 0)), fill=BROWN,
-                               width=0.8 * scale, tag=(self.tag, "wall"), capstyle="round")
+                               width=scale, tag=(self.tag, "wall"), capstyle="round")
         else:
             neighbours = [(-1, -1), (0, -1), (1, -1), (1, 0), (1, 1), (0, 1), (-1, 1), (-1, 0)]
             for dx in [-1, 0, 1]:
@@ -246,7 +246,8 @@ class Wall(TkSprite):
                             pass
                         else:
                             canvas.create_line(self.screen((0, 0)), self.screen((2*dx, 2*dy)), fill=BROWN,
-                                               width=0.8 * scale, tag=(self.tag, "wall"), capstyle="round")
+                                               width=scale, tag=(self.tag, "wall"), capstyle="round")
+
 
 class Food(TkSprite):
     @classmethod

--- a/pelita/ui/tk_sprites.py
+++ b/pelita/ui/tk_sprites.py
@@ -248,6 +248,13 @@ class Wall(TkSprite):
                             canvas.create_line(self.screen((0, 0)), self.screen((2*dx, 2*dy)), fill=BROWN,
                                                width=scale, tag=(self.tag, "wall"), capstyle="round")
 
+            # if we are drawing a closed square, fill in the internal part
+            # detect the square when we are on the bottom-left vertex of it
+            square_neighbors = {(0,0), (0,-1), (1,0),(1,-1)}
+            if square_neighbors <= set(self.wall_neighbors):
+                canvas.create_line(self.screen((1,0)), self.screen((1,-2)), fill=BROWN,
+                                   width=scale, tag=(self.tag, "wall"))
+
 
 class Food(TkSprite):
     @classmethod


### PR DESCRIPTION
This PR increases the thickness of all walls in the TK UI. This way it is easier to see how many squares are there between wall tunnels, for example. 
Also, fill in squares of walls. Until now there is empty space within a square of walls, and it seems it would be reachable. If we go for this thickness, then maybe the color of the walls could be made a little lighter.

Two screenshots on two different layouts to appreciate the change.

Master branch (example 1):
![master_branch1](https://user-images.githubusercontent.com/347147/62812600-c15ff500-bb06-11e9-938b-35a4cc2f0e78.png)

This PR (example 1):
![this_branch1](https://user-images.githubusercontent.com/347147/62812615-d0df3e00-bb06-11e9-9f3a-06b97630473a.png)


Master branch (example 2):
![master_branch2](https://user-images.githubusercontent.com/347147/62812625-db013c80-bb06-11e9-8e35-0d31f5f7318f.png)

This PR (example 2):
![this_branch2](https://user-images.githubusercontent.com/347147/62812634-e8b6c200-bb06-11e9-9da1-be34e11f15ff.png)

