### PR TITLE
ENH: Increase the chance that call_pelita flushes correctly to stdout.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
 script:
 - >
     python -c "import zmq; print('Using pyzmq {} and zmq {}.'.format(zmq.pyzmq_version(), zmq.zmq_version()))" &&
-    echo "Sarting tests..." && python -m pytest test/ && echo "Tests finished." && echo "Starting pelita CLI as a module..." &&
+    echo "Starting tests..." && python -m pytest test/ && echo "Tests finished." && echo "Starting pelita CLI as a module..." &&
     python -m pelita.scripts.pelita_main --null && echo "Pelita CLI as a module finished." && echo "Starting pelita CLI as a script..." &&
     pelita --null --rounds 100 --size small $player && echo "Pelita CLI as a script finished."
 - >

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
 script:
 - >
     python -c "import zmq; print('Using pyzmq {} and zmq {}.'.format(zmq.pyzmq_version(), zmq.zmq_version()))" &&
-    python -m pytest --cov=pelita test/ &&
+    python -m pytest test/ &&
     python -m pelita.scripts.pelita_main --progress &&
     pelita --null --rounds 100 --size small $player 2>&1
 - >

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,18 +20,19 @@ install:
 script:
 - >
     python -c "import zmq; print('Using pyzmq {} and zmq {}.'.format(zmq.pyzmq_version(), zmq.zmq_version()))" &&
-    python -m pytest test/ &&
-    python -m pelita.scripts.pelita_main --progress &&
-    pelita --null --rounds 100 --size small $player 2>&1
+    echo "Sarting tests..." && python -m pytest test/ && echo "Tests finished." && echo "Starting pelita CLI as a module..." &&
+    python -m pelita.scripts.pelita_main --null && echo "Pelita CLI as a module finished." && echo "Starting pelita CLI as a script..." &&
+    pelita --null --rounds 100 --size small $player && echo "Pelita CLI as a script finished."
 - >
     if [[ $TRAVIS_PYTHON_VERSION == 3.6 || $TRAVIS_PYTHON_VERSION == 3.7 ]] ; then
-      pelita-tournament --non-interactive --viewer null
+      echo "Starting tournament..." && pelita-tournament --non-interactive --viewer null && echo "Tournament finished."
     fi
 - >
     if [[ $TRAVIS_PYTHON_VERSION == 3.6 || $TRAVIS_PYTHON_VERSION == 3.7 ]] ; then
     # We must clone pelita_template to a location outside of the pelita repo
     # Otherwise pelita’s own setup.cfg will be used for test configuration
-      (cd .. && git clone https://github.com/ASPP/pelita_template) && ( cd ../pelita_template/ && python -m pytest . )
+      (cd .. && echo "Test pelita_template..." && git clone https://github.com/ASPP/pelita_template) && ( cd ../pelita_template/ && python -m pytest . &&
+      echo "Finished testing pelita_template.")
     fi
 
 # push coverage

--- a/pelita/tournament/tournament.py
+++ b/pelita/tournament/tournament.py
@@ -119,7 +119,7 @@ def call_pelita(team_specs, *, rounds, size, viewer, seed, write_replay=False, s
     rounds = ['--rounds', str(rounds)] if rounds else []
     size = ['--size', size] if size else []
     viewer = ['--' + viewer] if viewer else []
-    seed = ['--seed', seed] if seed else []
+    seed = ['--seed', str(seed)] if seed else []
     write_replay = ['--write-replay', write_replay] if write_replay else []
     store_output = ['--store-output', store_output] if store_output else []
 

--- a/pelita/tournament/tournament.py
+++ b/pelita/tournament/tournament.py
@@ -157,6 +157,17 @@ def call_pelita(team_specs, *, rounds, size, viewer, seed, write_replay=False, s
                         whowins = game_state.get("whowins", None)
                         if finished:
                             final_game_state = game_state
+                            # The game in the subprocess has finished but the process
+                            # may still be running.
+                            # Give it a little time to finish writing everything.
+                            # Once we exit the `with` statement, the subprocess will
+                            # be terminated.
+                            try:
+                                proc.wait(1)
+                            except subprocess.TimeoutExpired:
+                                # It didn’t terminate in time by itself.
+                                # We exit anyway.
+                                pass
                             break
                     except ValueError:  # JSONDecodeError
                         pass

--- a/pelita/tournament/tournament.py
+++ b/pelita/tournament/tournament.py
@@ -67,6 +67,11 @@ def run_and_terminate_process(args, **kwargs):
         else:
             p = subprocess.Popen(args, **kwargs, preexec_fn=os.setsid)
         yield p
+        p.poll()
+        if p.returncode is not None:
+            _logger.debug(f"Subprocess exited with {p.returncode}.")
+        else:
+            _logger.debug(f"Subprocess has not exited yet.")
     finally:
         if _mswindows:
             _logger.debug("Sending CTRL_BREAK_EVENT to {proc} with pid {pid}.".format(proc=p, pid=p.pid))

--- a/test/test_remote_game.py
+++ b/test/test_remote_game.py
@@ -32,7 +32,7 @@ def remote_teams():
 
 
 def test_remote_call_pelita(remote_teams):
-    res, stdout, stderr = call_pelita(remote_teams, rounds=30, size='small', viewer='null', seed=None)
+    res, stdout, stderr = call_pelita(remote_teams, rounds=30, size='small', viewer='null', seed=1)
     assert res['whowins'] == 1
     assert res['fatal_errors'] == [[], []]
     # errors for call_pelita only contains the last thrown error, hence None


### PR DESCRIPTION
I think I have found our problem with the flushing. (Running `call_pelita` does not always return the last line in the game. Ie. ‘Finished’ is never printed.)

The problem is probably not flushing (we do in fact flush in `ResultPrinter` which prints the final line). The problem is that before we print the last line, we already tell `call_pelita` via zmq that the game is over. Therefore, `call_pelita` decides that it can as well exit and tries terminating out main pelita process. In most cases all is well and the main pelita process has already printed and exited. Sometimes it will be forcefully terminated before it can print.

This fix adds a small `wait(1)` after the `call_pelita` loop has received the message that the game has ended, which should be enough time for pelita to finish all its remaining jobs.

We might also just ensure that the zmq message is executed as the final thing before pelita exits but then again, this might also run us into bad situations when zmq is cleaned up while sending the message, so we will try it with the simple `wait(1)` for now.

Closes #652 