### PR TITLE
Run games in headless mode and replay them later

### DIFF
--- a/pelita/game.py
+++ b/pelita/game.py
@@ -621,19 +621,18 @@ def apply_move(gamestate, bot_position):
     """
     # TODO is a timeout counted as an error?
     # define local variables
-    bots = gamestate["bots"]
+    bots = gamestate["bots"][:]
     turn = gamestate["turn"]
     team = turn % 2
     enemy_idx = (1, 3) if team == 0 else (0, 2)
     gameover = gamestate["gameover"]
-    score = gamestate["score"]
-    food = gamestate["food"]
+    score = gamestate["score"][:]
+    food = gamestate["food"][:]
     walls = gamestate["walls"]
-    food = gamestate["food"]
     n_round = gamestate["round"]
-    kills = gamestate["kills"]
-    deaths = gamestate["deaths"]
-    bot_was_killed = gamestate["bot_was_killed"]
+    kills = gamestate["kills"][:]
+    deaths = gamestate["deaths"][:]
+    bot_was_killed = gamestate["bot_was_killed"][:]
     fatal_error = True if gamestate["fatal_errors"][team] else False
     #TODO how are fatal errors passed to us? dict with same structure as regular errors?
     #TODO do we need to communicate that fatal error was the reason for game over in any other way?

--- a/test/test_game.py
+++ b/test/test_game.py
@@ -879,7 +879,7 @@ def test_play_turn_move():
         "gameover": False,
         "whowins": None,
         "team_say": "bla",
-        "score": 0,
+        "score": [0, 0],
         "kills":[0]*4,
         "deaths": [0]*4,
         "bot_was_killed": [False]*4,

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -50,27 +50,3 @@ def test_setup_test_game(is_blue):
     assert test_game.enemy[1].is_noisy is True
 
 
-def test_load_builtin_layout():
-    layout = utils.load_builtin_layout("small_001")
-    assert layout.strip() == dedent("""
-################
-# ..       .. E#
-#. ######..  #E#
-#  .  .   .  # #
-# #  .   .  .  #
-#0#  ..###### .#
-#1 ..       .. #
-################
-    """).strip()
-
-    layout = utils.load_builtin_layout("small_001", is_blue=False)
-    assert layout.strip() == dedent("""
-################
-# ..       .. 1#
-#. ######..  #0#
-#  .  .   .  # #
-# #  .   .  .  #
-#E#  ..###### .#
-#E ..       .. #
-################
-    """).strip()


### PR DESCRIPTION
Users can play a game in headless mode, store its result and additionally the history of game states during the game, which is useful, if they want to know what went wrong during a game.

    from pelita.utils import run_background_game, replay_background_game

    result, replay = run_background_game('0', '1')
    
    replay_background_game(replay)
    # opens Tk viewer

    replay_background_game(replay, viewer='ascii')


Still needs a bunch of tests and utils suffers from circular imports.