### PR TITLE
Do not return state from move()

### DIFF
--- a/pelita/game.py
+++ b/pelita/game.py
@@ -92,10 +92,10 @@ def run_game(team_specs, *, layout_dict, layout_name="", max_rounds=300, seed=No
     team_specs : list[team0, team1]
               a list specifying the two teams to play the match with. The list
               items team0 and team1 must be either
-               - a function with signature move(bot, state) -> (x, y), state
-                 the function takes a bot object and a state and returns the next
-                 position (x, y) of bot and state.
-                 state can be an arbitrary Python object, None by default
+               - a function with signature move(bot, state) -> (x, y)
+                 The function takes a bot object and a state and returns the next
+                 position (x, y) of the bot.
+
                - the path to a Python module that defines at least a function
                  called 'move' (specified as above) and a string TEAM_NAME.
 

--- a/pelita/player/FoodEatingPlayer.py
+++ b/pelita/player/FoodEatingPlayer.py
@@ -4,16 +4,12 @@ from pelita.utils import walls_to_graph
 
 
 def food_eating_player(bot, state):
-    if state is None:
+    if 'graph' not in state:
         # first turn, first round
-        state = {
-            'graph': walls_to_graph(bot.walls)
-        }
+        state['graph'] = walls_to_graph(bot.walls)
 
-    if not bot.turn in state:
-        state[bot.turn] = {
-            'next_food': None
-        }
+    if bot.turn not in state:
+        state[bot.turn] = { 'next_food': None }
 
     # check if food is still there for us to eat
     if (state[bot.turn]['next_food'] is None
@@ -28,7 +24,7 @@ def food_eating_player(bot, state):
     # the first position in the shortest path is always bot.position
     next_pos = networkx.shortest_path(state['graph'], bot.position, state[bot.turn]['next_food'])[1]
 
-    return next_pos, state
+    return next_pos
 
 
 TEAM_NAME = "Food Eating Players"

--- a/pelita/player/RandomExplorerPlayer.py
+++ b/pelita/player/RandomExplorerPlayer.py
@@ -2,15 +2,9 @@
 def random_explorer_player(bot, state):
     """ Least visited random player. Will prefer moving to a position it’s never seen before. """
 
-    if state is None:
-        # first turn, first round
-        state = {}
-
     if not bot.turn in state:
         # initialize bot
-        state[bot.turn] = {
-            'visited': []
-        }
+        state[bot.turn] = { 'visited': [] }
 
     if bot.position in state[bot.turn]['visited']:
         state[bot.turn]['visited'].remove(bot.position)
@@ -23,14 +17,14 @@ def random_explorer_player(bot, state):
     for pos in state[bot.turn]['visited']:
         if len(positions) == 1:
             # only one position left, we’ll take it
-            return positions[0], state
+            return positions[0]
         if len(positions) == 0:
-            return bot.position, state
+            return bot.position
         if pos in positions:
             positions.remove(pos)
 
     # more than one move left
-    return bot.random.choice(positions), state
+    return bot.random.choice(positions)
 
 
 TEAM_NAME = "Random Explorer Players"

--- a/pelita/player/RandomPlayers.py
+++ b/pelita/player/RandomPlayers.py
@@ -1,5 +1,5 @@
 def random_player(bot, state):
-    return bot.random.choice(bot.legal_positions), state
+    return bot.random.choice(bot.legal_positions)
 
 def nq_random_player(bot, state):
     """ Not-Quite-RandomPlayer that will move randomly but not stop or reverse. """
@@ -22,9 +22,9 @@ def nq_random_player(bot, state):
                 pass
     # just in case, there is really no way to go to:
     if not legal_positions:
-        return bot.position, state
+        return bot.position
     # and select a move at random
-    return bot.random.choice(legal_positions), state
+    return bot.random.choice(legal_positions)
 
 
 TEAM_NAME = "Random Players"

--- a/pelita/player/SmartEatingPlayer.py
+++ b/pelita/player/SmartEatingPlayer.py
@@ -4,16 +4,12 @@ from pelita.utils import walls_to_graph
 
 
 def smart_eating_player(bot, state):
-    if state is None:
+    if 'graph' not in state:
         # first turn, first round
-        state = {
-            'graph': walls_to_graph(bot.walls)
-        }
+        state['graph'] = walls_to_graph(bot.walls)
 
-    if not bot.turn in state:
-        state[bot.turn] = {
-            'next_food': None
-        }
+    if bot.turn not in state:
+        state[bot.turn] = { 'next_food': None }
 
     # check, if food is still present
     if (state[bot.turn]['next_food'] is None
@@ -32,9 +28,9 @@ def smart_eating_player(bot, state):
     if next_pos in dangerous_enemy_pos:
         # whoops, better wait this round and take another food next time
         state[bot.turn]['next_food'] = None
-        return bot.position, state
+        return bot.position
 
-    return next_pos, state
+    return next_pos
 
 
 TEAM_NAME = "Smart Eating Players"

--- a/pelita/player/SmartRandomPlayer.py
+++ b/pelita/player/SmartRandomPlayer.py
@@ -12,15 +12,15 @@ def smart_random_player(bot, state):
             continue # bad idea
         elif (new_pos in killable_enemy_pos or
               new_pos in bot.enemy[0].food):
-            return new_pos, state # get it
+            return new_pos # get it
         else:
             smart_positions.append(new_pos)
 
     if smart_positions:
-        return bot.random.choice(smart_positions), state
+        return bot.random.choice(smart_positions)
     else:
         # we ran out of smart moves
-        return bot.position, state
+        return bot.position
 
 
 TEAM_NAME = "Smart Random Players"

--- a/pelita/player/StoppingPlayer.py
+++ b/pelita/player/StoppingPlayer.py
@@ -1,6 +1,6 @@
 def stopping_player(bot, state):
     """ A Player that just stands still. """
-    return bot.position, state
+    return bot.position
 
 TEAM_NAME = "Stopping Players"
 move = stopping_player

--- a/pelita/player/base.py
+++ b/pelita/player/base.py
@@ -8,7 +8,7 @@ def speaking_player(bot, state):
     """ A player that makes moves at random and tells us about it. """
     move = bot.random.choice(bot.legal_positions)
     bot.say(f"Going {move}.")
-    return move, state
+    return move
 
 
 def stepping_player(*bot_moves):
@@ -47,7 +47,7 @@ def stepping_player(*bot_moves):
         moves_iter = iterators[bot.turn]
         try:
             next_move = next(moves_iter)
-            return (bot.position[0] + next_move[0], bot.position[1] + next_move[1]), state
+            return (bot.position[0] + next_move[0], bot.position[1] + next_move[1])
         except StopIteration:
             raise ValueError()
     return move
@@ -65,9 +65,9 @@ def round_based_player(*bot_moves):
     def move(bot, state):
         try:
             next_move = bot_moves[bot.turn][bot.round]
-            return (bot.position[0] + next_move[0], bot.position[1] + next_move[1]), state
+            return (bot.position[0] + next_move[0], bot.position[1] + next_move[1])
         except (IndexError, KeyError):
-            return bot.position, state
+            return bot.position
     return move
 
 
@@ -84,4 +84,4 @@ def debuggable_player(bot, state):
     """
     position = bot.position
     pdb.set_trace()
-    return position, state
+    return position

--- a/pelita/player/team.py
+++ b/pelita/player/team.py
@@ -41,7 +41,7 @@ class Team:
         self.team_name = team_name
 
         #: Storage for the team state
-        self._state = None
+        self._state = {}
 
         #: The team’s random number generator
         self._random = None
@@ -68,7 +68,7 @@ class Team:
 
         """
         # Reset the team state
-        self._state = None
+        self._state.clear()
 
         # Initialize the random number generator
         # with the seed that we received from game
@@ -125,14 +125,9 @@ class Team:
 
         try:
             # request a move from the current bot
-            res = self._team_move(team[me._bot_turn], self._state)
-            # check that the returned value # is a tuple of (position, state)
-            try:
-                if len(res) != 2:
-                    raise ValueError(f"Function move did not return move and state: got {res} instead.")
-            except TypeError:
-                raise ValueError(f"Function move did not return move and state: got {res} instead.")
-            move, state = res
+            move = self._team_move(team[me._bot_turn], self._state)
+
+            # check that the returned value is a position tuple
             try:
                 if len(move) != 2:
                     raise ValueError(f"Function move did not return a valid position: got {move} instead.")
@@ -147,9 +142,6 @@ class Team:
             return {
                 "error": (type(e).__name__, str(e)),
             }
-
-        # save the returned team state for the next turn
-        self._state = state
 
         return {
             "move": move,

--- a/pelita/utils.py
+++ b/pelita/utils.py
@@ -145,10 +145,9 @@ def run_background_game(*, blue_move, red_move, layout=None, max_rounds=300, see
     Notes
     -----
     - Move functions:
-        A move function is a function with signature move(bot, state) -> (x, y), state
-        the function takes a bot object and a state and returns the next position of
-        the current bot as a tuple (x, y) and state. `state` can be an arbitrary
-        Python object, None by default
+        A move function is a function with signature move(bot, state) -> (x, y).
+        The function takes a bot object and a state and returns the next position of
+        the current bot as a tuple (x, y). `state` is initially an empty dictionary.
 
     - Timeouts:
         As opposed to standard pelita matches, timeouts are not considered.

--- a/test/demo01_stopping.py
+++ b/test/demo01_stopping.py
@@ -4,5 +4,4 @@ TEAM_NAME = 'StoppingBots'
 
 def move(bot, state):
     # do not move at all
-    next_move = bot.position
-    return next_move, state
+    return bot.position

--- a/test/demo02_random.py
+++ b/test/demo02_random.py
@@ -6,5 +6,4 @@ TEAM_NAME = 'RandomBots'
 def move(bot, state):
     # make a reference to our bot with a shorter name
     # mostly useful for longer code, of course
-    next_move = bot.random.choice(bot.legal_positions)
-    return next_move, state
+    return bot.random.choice(bot.legal_positions)

--- a/test/test_game.py
+++ b/test/test_game.py
@@ -486,8 +486,8 @@ def test_cascade_kill():
     ]
     def move(bot, state):
         if not bot.is_blue and bot.turn == 1 and bot.round == 1:
-            return (6, 1), state
-        return bot.position, state
+            return (6, 1)
+        return bot.position
     layouts = [layout.parse_layout(l) for l in cascade]
     state = setup_game([move, move], max_rounds=5, layout_dict=layout.parse_layout(cascade[0]))
     assert state['bots'] == layouts[0]['bots']
@@ -547,8 +547,8 @@ def test_cascade_kill_2():
     ]
     def move(bot, state):
         if bot.is_blue and bot.turn == 0 and bot.round == 1:
-            return (1, 1), state
-        return bot.position, state
+            return (1, 1)
+        return bot.position
     layouts = [layout.parse_layout(l) for l in cascade]
     state = setup_game([move, move], max_rounds=5, layout_dict=layout.parse_layout(cascade[0]))
     assert state['bots'] == layouts[0]['bots']
@@ -600,10 +600,10 @@ def test_cascade_kill_rescue_1():
     ]
     def move(bot, state):
         if bot.is_blue and bot.turn == 0 and bot.round == 1:
-            return (1, 1), state
+            return (1, 1)
         if bot.is_blue and bot.turn == 1 and bot.round == 1:
-            return (5, 1), state
-        return bot.position, state
+            return (5, 1)
+        return bot.position
     layouts = [layout.parse_layout(l) for l in cascade]
     state = setup_game([move, move], max_rounds=5, layout_dict=layout.parse_layout(cascade[0]))
     assert state['bots'] == layouts[0]['bots']
@@ -649,10 +649,10 @@ def test_cascade_kill_rescue_2():
     ]
     def move(bot, state):
         if bot.is_blue and bot.turn == 0 and bot.round == 1:
-            return (1, 2), state
+            return (1, 2)
         if not bot.is_blue and bot.turn == 0 and bot.round == 1:
-            return (5, 2), state
-        return bot.position, state
+            return (5, 2)
+        return bot.position
     layouts = [layout.parse_layout(l) for l in cascade]
     state = setup_game([move, move], max_rounds=5, layout_dict=layout.parse_layout(cascade[0]))
     assert state['bots'] == layouts[0]['bots']
@@ -701,8 +701,8 @@ def test_cascade_suicide():
     ]
     def move(bot, state):
         if bot.is_blue and bot.turn == 0 and bot.round == 1:
-            return (6, 1), state
-        return bot.position, state
+            return (6, 1)
+        return bot.position
     layouts = [layout.parse_layout(l) for l in cascade]
     state = setup_game([move, move], max_rounds=5, layout_dict=layout.parse_layout(cascade[0]))
     assert state['bots'] == layouts[0]['bots']
@@ -940,7 +940,7 @@ def test_max_rounds():
         # all bots move to the south
         if bot.round == 1:
             # go one step to the right
-            return (bot.position[0], bot.position[1] + 1), s
+            return (bot.position[0], bot.position[1] + 1)
         else:
             # There should not be more then one round in this test
             raise RuntimeError("We should not be here in this test")
@@ -1075,12 +1075,12 @@ def test_finished_when_no_food(bot_to_move):
     team_to_move = bot_to_move % 2
     def move(bot, s):
         if team_to_move == 0 and bot.is_blue and bot_turn == bot._bot_turn:
-            return (4, 1), s
+            return (4, 1)
             # eat the food between 0 and 2
         if team_to_move == 1 and (not bot.is_blue) and bot_turn == bot._bot_turn:
             # eat the food between 3 and 1
-            return (3, 2), s
-        return bot.position, s
+            return (3, 2)
+        return bot.position
 
     l = layout.parse_layout(l)
     final_state = run_game([move, move], layout_dict=l, max_rounds=20)
@@ -1090,7 +1090,7 @@ def test_finished_when_no_food(bot_to_move):
 
 def test_minimal_game():
     def move(b, s):
-        return b.position, s
+        return b.position
 
     layout_name, layout_string = layout.get_random_layout()
     l = layout.parse_layout(layout_string)
@@ -1103,11 +1103,11 @@ def test_minimal_losing_game_has_one_error():
     def move0(b, s):
         if b.round == 1 and b._bot_index == 0:
             # trigger a bad move in the first round
-            return (0, 0), s
+            return (0, 0)
         else:
-            return b.position, s
+            return b.position
     def move1(b, s):
-        return b.position, s
+        return b.position
 
     layout_name, layout_string = layout.get_random_layout()
     l = layout.parse_layout(layout_string)
@@ -1121,7 +1121,7 @@ def test_minimal_losing_game_has_one_error():
 
 def test_minimal_remote_game():
     def move(b, s):
-        return b.position, s
+        return b.position
 
     layout_name, layout_string = layout.get_random_layout()
     l = layout.parse_layout(layout_string)
@@ -1149,12 +1149,12 @@ def test_remote_errors(tmp_path):
     # we change to the tmp dir, to make our paths simpler
     syntax_error = dedent("""
     def move(b, state)
-        return b.position, state
+        return b.position
     """)
     import_error = dedent("""
     import does_not_exist
     def move(b, state):
-        return b.position, state
+        return b.position
     """)
 
     layout_name, layout_string = layout.get_random_layout()
@@ -1199,13 +1199,11 @@ def test_bad_move_function(team_to_test):
     appends a FatalException. """
 
     def stopping(b, state):
-        return b.position, state
+        return b.position
     def move0(b, state):
         return None
     def move1(b, state):
         return 0
-    def move2(b, state):
-        return 0, 0
     def move3(b, state):
         return 0, 0, 0
     def move4(b): # TypeError: move4() takes 1 positional argument but 2 were given
@@ -1228,15 +1226,9 @@ def test_bad_move_function(team_to_test):
     assert res['gameover']
     assert res['whowins'] == other
     assert res['fatal_errors'][team_to_test][0]['type'] == 'FatalException'
-    assert res['fatal_errors'][team_to_test][0]['description'] == 'Exception in client (ValueError): Function move did not return move and state: got None instead.'
+    assert res['fatal_errors'][team_to_test][0]['description'] == 'Exception in client (ValueError): Function move did not return a valid position: got None instead.'
 
     res = test_run_game(move1)
-    assert res['gameover']
-    assert res['whowins'] == other
-    assert res['fatal_errors'][team_to_test][0]['type'] == 'FatalException'
-    assert res['fatal_errors'][team_to_test][0]['description'] == 'Exception in client (ValueError): Function move did not return move and state: got 0 instead.'
-
-    res = test_run_game(move2)
     assert res['gameover']
     assert res['whowins'] == other
     assert res['fatal_errors'][team_to_test][0]['type'] == 'FatalException'
@@ -1246,7 +1238,7 @@ def test_bad_move_function(team_to_test):
     assert res['gameover']
     assert res['whowins'] == other
     assert res['fatal_errors'][team_to_test][0]['type'] == 'FatalException'
-    assert res['fatal_errors'][team_to_test][0]['description'] == 'Exception in client (ValueError): Function move did not return move and state: got (0, 0, 0) instead.'
+    assert res['fatal_errors'][team_to_test][0]['description'] == 'Exception in client (ValueError): Function move did not return a valid position: got (0, 0, 0) instead.'
 
     res = test_run_game(move4)
     assert res['gameover']

--- a/test/test_network.py
+++ b/test/test_network.py
@@ -49,7 +49,7 @@ def test_simpleclient(zmq_context):
         print(bot)
         res.append(True)
         print(res)
-        return bot.position, state
+        return bot.position
 
     sock = zmq_context.socket(zmq.PAIR)
     port = sock.bind_to_random_port('tcp://127.0.0.1')

--- a/test/test_remote_game.py
+++ b/test/test_remote_game.py
@@ -77,9 +77,9 @@ def test_remote_timeout():
     TEAM_NAME = "500ms timeout"
     def move(b, s):
         if b.round == 1 and b.turn == 1:
-            return (-2, 0), s
+            return (-2, 0)
         time.sleep(0.5)
-        return b.position, s
+        return b.position
     """
     with tempfile.NamedTemporaryFile('w+', suffix='.py') as f:
         print(dedent(tp), file=f, flush=True)
@@ -114,7 +114,7 @@ def test_remote_dumps_are_written():
     def move(b, s):
         print(f"{b.round} {b.turn} p1", file=sys.stdout)
         print(f"p1err", file=sys.stderr)
-        return b.position, s
+        return b.position
     """)
 
     p2 = dedent("""
@@ -123,7 +123,7 @@ def test_remote_dumps_are_written():
     def move(b, s):
         print(f"{b.round} {b.turn} p2", file=sys.stdout)
         print("p2err", file=sys.stderr)
-        return b.position, s
+        return b.position
     """)
     out_folder = tempfile.TemporaryDirectory()
 
@@ -170,13 +170,13 @@ def test_remote_dumps_with_failure(failing_team):
         if b.round == 2 and b.turn == 0:
             # introduce an error
             0 / 0
-        return b.position, s
+        return b.position
     """)
 
     good_player = dedent("""
     TEAM_NAME="good"
     def move(b, s):
-        return b.position, s
+        return b.position
     """)
     out_folder = tempfile.TemporaryDirectory()
 

--- a/test/test_team.py
+++ b/test/test_team.py
@@ -6,11 +6,11 @@ from pelita.player.team import Team
 from pelita.utils import setup_test_game
 
 def stopping(bot, state):
-    return bot.position, state
+    return bot.position
 
 def randomBot(bot, state):
     legal = bot.legal_positions[:]
-    return bot.random.choice(legal), state
+    return bot.random.choice(legal)
 
 layout1="""
 ########
@@ -164,12 +164,10 @@ class TestStoppingTeam:
         storage_copy = {}
         def inner(bot, state):
             print(state)
-            if state is None:
-                state = {}
             state[bot.turn] = state.get(bot.turn, 0) + 1
             storage_copy['rounds'] = state[bot.turn]
             print(state)
-            return bot.position, state
+            return bot.position
         inner._storage = storage_copy
         return inner
 
@@ -213,9 +211,9 @@ def test_track_and_kill_count():
         other = bot.other
 
         # first move. get the state from the global cache
-        if state is None:
+        if state == {}:
             team_idx = 0 if bot.is_blue else 1
-            state = bot_states[team_idx]
+            state.update(enumerate(bot_states[team_idx]))
 
         if bot.round == 1 and turn == 0:
             assert bot.track[0] == bot.position
@@ -383,7 +381,7 @@ def test_eaten_flag_kill(bot_to_move):
                 assert bot.other.was_killed is False
 
         # otherwise return current position
-        return new_pos, state
+        return new_pos
     state = run_game([move, move], max_rounds=3, layout_dict=parse_layout(layout), allow_exceptions=True)
     # assertions might have been caught in run_game
     # check that all is good
@@ -465,7 +463,7 @@ def test_eaten_flag_suicide(bot_to_move):
                 assert bot.other.was_killed is False
 
         # otherwise return current position
-        return new_pos, state
+        return new_pos
     state = run_game([move, move], max_rounds=3, layout_dict=parse_layout(layout), allow_exceptions=True)
     # assertions might have been caught in run_game
     # check that all is good
@@ -542,7 +540,7 @@ def test_bot_attributes():
         else:
             assert set(bot.homezone) == set(homezones[1])
             assert set(bot.enemy[0].homezone) == set(homezones[0])
-        return bot.position, state
+        return bot.position
 
     state = run_game([asserting_team, asserting_team], max_rounds=1, layout_dict=parsed)
     # assertions might have been caught in run_game


### PR DESCRIPTION
Things are simpler if we always initialize the state to be an empty
dictionary, and simply pass the same mutable object always to the move
function. In cases where the player does not actually use the state to
store anything, it can ignore the variable completely. The object also
has always the same type (dict), so there is less chance of trying to
a TypeError.