### PR TITLE
BF: rect_width/rect_height should never return negative values.

### DIFF
--- a/pelita/ui/tk_canvas.py
+++ b/pelita/ui/tk_canvas.py
@@ -46,14 +46,24 @@ class MeshGraph:
         """ The width of a single field.
         """
         # we have to adjust by one pixel for the border
-        return float(self.screen_width - 1 - 2 * self.padding) / self.mesh_width
+        width = float(self.screen_width - 1 - 2 * self.padding) / self.mesh_width
+        # if the UI is not initialized yet (or just really really small) this may
+        # result in a negative value. Ensure that it is always positive or zero.
+        if width < 0:
+            width = 0.0
+        return width
 
     @property
     def rect_height(self):
         """ The height of a single field.
         """
         # we have to adjust by one pixel for the border
-        return float(self.screen_height - 1 - 2 * self.padding) / self.mesh_height
+        height = float(self.screen_height - 1 - 2 * self.padding) / self.mesh_height
+        # if the UI is not initialized yet (or just really really small) this may
+        # result in a negative value. Ensure that it is always positive or zero.
+        if height < 0:
+            height = 0.0
+        return height
 
     @property
     def half_scale_x(self):


### PR DESCRIPTION
On some systems (and consistently on the new macOS) tk would try to draw the game’s background before the `screen_width` (coming from `canvas.winfo_width()`) was properly initialised. The default value for the width could therefore be 1. Together with our August sprint addition that introduced padding for the canvas (#640) with the following formula

    def rect_width(self):
        """ The width of a single field.
        """
        # we have to adjust by one pixel for the border
        return float(self.screen_width - 1 - 2 * self.padding) / self.mesh_width

this meant that in some circumstances the `rect_width` would become negative, which in turn would be used to calculate the line width of the maze. Drawing a line with a negative width would then crash Tk with the error given in #693:

    _tkinter.TclError: bad screen distance "-0.0625"

This fix just returns 0 for the `rect_with`/`rect_height` when this would happen. It is not the best solution but seems to work.

Closes #693 