### PR TITLE
BF: Disable randomized hash seeds to avoid introducing non-predictability.

### DIFF
--- a/pelita/player/team.py
+++ b/pelita/player/team.py
@@ -250,10 +250,12 @@ class RemoteTeam:
             # We must run in unbuffered mode to enforce flushing of stdout/stderr,
             # otherwise we may lose some of what is printed
             proc = subprocess.Popen(external_call, stdout=stdout, stderr=stderr,
-                                    env=dict(os.environ, PYTHONUNBUFFERED='x'))
+                                    env=dict(os.environ,
+                                             PYTHONUNBUFFERED='x',
+                                             PYTHONHASHSEED='0'))
             return (proc, stdout, stderr)
         else:
-            return (subprocess.Popen(external_call), None, None)
+            return (subprocess.Popen(external_call, env=dict(os.environ, PYTHONHASHSEED='0')), None, None)
 
     @property
     def team_name(self):


### PR DESCRIPTION
Randomized hash seeds (the default in recent Python versions) make the
game non-reproducible, as different Python runs will have a different
results for code such as list(set(x)), which is independent of the
manually seeded rng.

We now disable randomized seeds completely by setting an environment
variable PYTHONHASHSEED='0' before calling the Pelita players. (A future
version could manually set different seeds for the individual players,
dependent on the global seed value.)

Caveat: This only solves the problem for _external_ players that are
started by the main Pelita executable. Internal players will have a
different set ordering each time the main program is run.

Closes #689.