### PR TITLE
Fix a long standing bug where we assume sorted filenames

### DIFF
--- a/pelita/layout.py
+++ b/pelita/layout.py
@@ -7,7 +7,9 @@ import io
 from pathlib import Path
 import random
 
-def get_random_layout(size='normal'):
+RNG = random.Random()
+
+def get_random_layout(size='normal', seed=None):
     """ Return a random layout string from the available ones.
 
     Parameters
@@ -27,8 +29,10 @@ def get_random_layout(size='normal'):
         the name of the layout, a random layout string
 
     """
+    if seed is not None:
+        RNG.seed(seed)
     layouts_names = get_available_layouts(size=size)
-    layout_choice = random.choice(layouts_names)
+    layout_choice = RNG.choice(layouts_names)
     return layout_choice, get_layout_by_name(layout_choice)
 
 def get_available_layouts(size='normal'):

--- a/pelita/layout.py
+++ b/pelita/layout.py
@@ -62,8 +62,12 @@ def get_available_layouts(size='normal'):
         raise ValueError(f"Invalid layout size ('{size}' given). Valid: {valid}")
     if size == 'all':
         size = ''
-    return [item[:-(len('.layout'))] for item in importlib_resources.contents('pelita._layouts')
-                 if item.endswith('.layout') and size in item]
+    av_layouts = []
+    for item in importlib_resources.contents('pelita._layouts'):
+        if item.endswith('.layout') and size in item:
+            av_layouts.append(item[:-(len('.layout'))])
+
+    return sorted(av_layouts)
 
 def get_layout_by_name(layout_name):
     """Get a built-in layout by name

--- a/pelita/scripts/pelita_main.py
+++ b/pelita/scripts/pelita_main.py
@@ -249,11 +249,11 @@ def main():
 
     if args.seed is None:
         seed = random.randint(0, sys.maxsize)
-        args.seed = seed
         print("Replay this game with --seed {seed}".format(seed=seed))
     else:
-        pass
-    random.seed(args.seed)
+        seed = args.seed
+
+    random.seed(seed)
 
     if args.layout:
         # first check if the given layout is a file
@@ -275,7 +275,7 @@ def main():
     print("Using layout '%s'" % layout_name)
 
     layout_dict = layout.parse_layout(layout_string)
-    game.run_game(team_specs=team_specs, max_rounds=args.rounds, layout_dict=layout_dict, layout_name=layout_name, seed=args.seed,
+    game.run_game(team_specs=team_specs, max_rounds=args.rounds, layout_dict=layout_dict, layout_name=layout_name, seed=seed,
                   timeout_length=args.timeout_length, max_team_errors=args.max_timeouts,
                   viewers=viewers, viewer_options=viewer_options,
                   store_output=args.store_output)

--- a/pelita/scripts/pelita_main.py
+++ b/pelita/scripts/pelita_main.py
@@ -270,7 +270,7 @@ def main():
             layout_name = args.layout
             layout_string = pelita.layout.get_layout_by_name(args.layout)
     else:
-        layout_name, layout_string = pelita.layout.get_random_layout(args.size)
+        layout_name, layout_string = pelita.layout.get_random_layout(args.size, seed=seed)
 
     print("Using layout '%s'" % layout_name)
 

--- a/pelita/utils.py
+++ b/pelita/utils.py
@@ -4,6 +4,8 @@ import networkx
 
 from .player.team import make_bots
 
+RNG = random.Random()
+
 def walls_to_graph(walls):
     """Return a networkx Graph object given the walls of a maze.
 
@@ -46,13 +48,13 @@ def walls_to_graph(walls):
     return graph
 
 def _parse_layout_arg(*, layout=None, food=None, bots=None, enemy=None,
-                         is_noisy=None, is_blue=True, agnostic=True):
+                         is_noisy=None, is_blue=True, agnostic=True, seed=None):
     from .layout import (get_random_layout, get_layout_by_name, get_available_layouts,
                          parse_layout, layout_for_team, layout_agnostic)
 
     # prepare layout argument to be passed to pelita.game.run_game
     if layout is None:
-        layout_name, layout_str = get_random_layout(size='normal')
+        layout_name, layout_str = get_random_layout(size='normal', seed=seed)
         layout_dict = parse_layout(layout_str, allow_enemy_chars=False)
         if not agnostic:
             layout_dict = layout_for_team(layout_dict, is_blue=is_blue)
@@ -157,10 +159,10 @@ def run_background_game(*, blue_move, red_move, layout=None, max_rounds=300, see
 
     # if the seed is not set explicitly, set it here
     if seed is None:
-        seed = random.randint(1, 2**31)
-        random.seed(seed)
+        seed = RNG.randint(1, 2**31)
+        RNG.seed(seed)
 
-    layout_dict, layout_name = _parse_layout_arg(layout=layout, agnostic=True)
+    layout_dict, layout_name = _parse_layout_arg(layout=layout, agnostic=True, seed=seed)
 
     game_state = run_game((blue_move, red_move), layout_dict=layout_dict,
                           layout_name=layout_name, max_rounds=max_rounds, seed=seed,

--- a/test/test_layout.py
+++ b/test/test_layout.py
@@ -52,6 +52,10 @@ def test_get_random_layout_returns_correct_layout():
     layout2 = get_layout_by_name(name)
     assert layout == layout2
 
+def test_get_random_layout_random_seed():
+    name, layout = get_random_layout(size='small', seed=1)
+    assert name == 'small_007'
+
 def test_not_enclosed_by_walls():
     illegals = ("""# ###
                    #   #
@@ -458,7 +462,7 @@ def test_layout_for_team():
 def test_layout_agnostic():
     """
     Test if team-style layout can be converted to server-style layout.
-    
+
     Uses this layout:
 
     ####

--- a/test/test_layout.py
+++ b/test/test_layout.py
@@ -54,7 +54,7 @@ def test_get_random_layout_returns_correct_layout():
 
 def test_get_random_layout_random_seed():
     name, layout = get_random_layout(size='small', seed=1)
-    assert name == 'small_007'
+    assert name == 'small_018'
 
 def test_not_enclosed_by_walls():
     illegals = ("""# ###


### PR DESCRIPTION
We also had our own private instance of the glob.glob('*') (non-)sorting mistake, where we assumed that that listing a directory returns the filenames sorted, when it actually does not. The global instance of this mistake made the headlines:

https://arstechnica.com/information-technology/2019/10/chemists-discover-cross-platform-python-scripts-not-so-cross-platform/
