### PR TITLE
Put max_team_errors in game state

### DIFF
--- a/pelita/game.py
+++ b/pelita/game.py
@@ -901,8 +901,11 @@ def check_gameover(game_state, detect_final_move=False):
 
     # If any team has reached more than max_team_errors errors, this team loses.
     # If both teams have reached more than max_team_errors errors, it’s a draw.
+    # If max_team_errors is < 0, the game will go on without checking.
     num_errors = [len(f) for f in game_state['errors']]
-    if num_errors[0] <= game_state['max_team_errors'] and num_errors[1] <= game_state['max_team_errors']:
+    if game_state['max_team_errors'] < 0:
+        pass
+    elif num_errors[0] <= game_state['max_team_errors'] and num_errors[1] <= game_state['max_team_errors']:
         # no one has exceeded the max number of errors
         pass
     elif num_errors[0] > game_state['max_team_errors'] and num_errors[1] > game_state['max_team_errors']:

--- a/pelita/game.py
+++ b/pelita/game.py
@@ -28,9 +28,6 @@ _mswindows = (sys.platform == "win32")
 #: The points a team gets for killing another bot
 KILL_POINTS = 5
 
-#: Maximum number of errors before a team loses
-MAX_ALLOWED_ERRORS = 4
-
 #: The maximum distance between two bots before noise is applied
 SIGHT_DISTANCE = 5
 
@@ -179,7 +176,8 @@ def run_game(team_specs, *, layout_dict, layout_name="", max_rounds=300, seed=No
     # in background games
 
     # we create the initial game state
-    state = setup_game(team_specs, layout_dict=layout_dict, layout_name=layout_name, max_rounds=max_rounds, timeout_length=timeout_length, seed=seed,
+    state = setup_game(team_specs, layout_dict=layout_dict, layout_name=layout_name, max_rounds=max_rounds,
+                       max_team_errors=max_team_errors, timeout_length=timeout_length, seed=seed,
                        viewers=viewers, viewer_options=viewer_options,
                        store_output=store_output, team_names=team_names, print_result=print_result)
 
@@ -383,6 +381,9 @@ def setup_game(team_specs, *, layout_dict, max_rounds=300, layout_name="", seed=
 
         #: Timeout length, int, None
         timeout_length=timeout_length,
+
+        #: Maximum number of errors before a team loses, int
+        max_team_errors=max_team_errors,
 
         #: Viewers, list
         viewers=viewer_state['viewers'],
@@ -898,19 +899,19 @@ def check_gameover(game_state, detect_final_move=False):
             if num_fatals[team] > 0:
                 return { 'whowins' : 1 - team, 'gameover' : True}
 
-    # If any team has more than MAX_ALLOWED_ERRORS errors, this team loses.
-    # If both teams have more than MAX_ALLOWED_ERRORS errors, it’s a draw.
+    # If any team has reached more than max_team_errors errors, this team loses.
+    # If both teams have reached more than max_team_errors errors, it’s a draw.
     num_errors = [len(f) for f in game_state['errors']]
-    if num_errors[0] <= MAX_ALLOWED_ERRORS and num_errors[1] <= MAX_ALLOWED_ERRORS:
+    if num_errors[0] <= game_state['max_team_errors'] and num_errors[1] <= game_state['max_team_errors']:
         # no one has exceeded the max number of errors
         pass
-    elif num_errors[0] > MAX_ALLOWED_ERRORS and num_errors[1] > MAX_ALLOWED_ERRORS:
+    elif num_errors[0] > game_state['max_team_errors'] and num_errors[1] > game_state['max_team_errors']:
         # both teams have exceeded the max number of errors
         return { 'whowins' : 2, 'gameover' : True}
     else:
         # some one has exceeded the max number of errors
         for team in (0, 1):
-            if num_errors[team] > MAX_ALLOWED_ERRORS:
+            if num_errors[team] > game_state['max_team_errors']:
                 return { 'whowins' : 1 - team, 'gameover' : True}
 
     if detect_final_move:

--- a/pelita/game.py
+++ b/pelita/game.py
@@ -79,7 +79,7 @@ def controller_exit(state, await_action='play_step'):
             return False
 
 def run_game(team_specs, *, layout_dict, layout_name="", max_rounds=300, seed=None,
-             max_team_errors=5, timeout_length=3, viewers=None, viewer_options=None,
+             max_team_errors=4, timeout_length=3, viewers=None, viewer_options=None,
              store_output=False, team_names=(None, None), allow_exceptions=False,
              print_result=True):
     """ Run a pelita match.
@@ -116,7 +116,7 @@ def run_game(team_specs, *, layout_dict, layout_name="", max_rounds=300, seed=No
                    The maximum number of non fatal errors for a team before the
                    game is over and the team is disqualified. Non fatal errors are
                    timeouts and returning an illegal move. Fatal errors are raising
-                   Exceptions. Default: 5.
+                   Exceptions. Default: 4.
 
     timeout_length : int or float
                   Time in seconds to wait for the move function (or for the remote
@@ -249,7 +249,7 @@ def setup_viewers(viewers=None, options=None, print_result=True):
 
 
 def setup_game(team_specs, *, layout_dict, max_rounds=300, layout_name="", seed=None,
-               max_team_errors=5, timeout_length=3, viewers=None, viewer_options=None,
+               max_team_errors=4, timeout_length=3, viewers=None, viewer_options=None,
                store_output=False, team_names=(None, None), allow_exceptions=False,
                print_result=True):
     """ Generates a game state for the given teams and layout with otherwise default values. """
@@ -703,7 +703,7 @@ def play_turn(game_state, allow_exceptions=False):
 
 def apply_move(gamestate, bot_position):
     """Plays a single step of a bot by applying the game rules to the game state. The rules are:
-    - if the playing team has an error count of >5 or a fatal error they lose
+    - if the playing team has an error count of >4 or a fatal error they lose
     - a legal step must not be on a wall, else the error count is increased by 1 and a random move is chosen for the bot
     - if a bot lands on an enemy food pellet, it eats it. It cannot eat its own teams’ food
     - if a bot lands on an enemy bot in its own homezone, it kills the enemy

--- a/pelita/scripts/pelita_main.py
+++ b/pelita/scripts/pelita_main.py
@@ -91,8 +91,8 @@ timeout_opt.add_argument('--timeout', type=float, metavar="SEC",
                          dest='timeout_length', help='Time before timeout is triggered (default: 3 seconds).')
 timeout_opt.add_argument('--no-timeout', const=None, action='store_const',
                          dest='timeout_length', help='Run game without timeouts.')
-game_settings.add_argument('--max-timeouts', type=int, default=5,
-                           dest='max_timeouts', help='Maximum number of timeouts allowed (default: 5).')
+game_settings.add_argument('--max-errors', type=int, default=4,
+                           dest='max_team_errors', help='Maximum number of team errors allowed (default: 4).')
 parser.set_defaults(timeout_length=3)
 game_settings.add_argument('--stop-at', dest='stop_at', type=int, metavar="N",
                            help='Stop before playing round N.')
@@ -276,7 +276,7 @@ def main():
 
     layout_dict = layout.parse_layout(layout_string)
     game.run_game(team_specs=team_specs, max_rounds=args.rounds, layout_dict=layout_dict, layout_name=layout_name, seed=seed,
-                  timeout_length=args.timeout_length, max_team_errors=args.max_timeouts,
+                  timeout_length=args.timeout_length, max_team_errors=args.max_team_errors,
                   viewers=viewers, viewer_options=viewer_options,
                   store_output=args.store_output)
 

--- a/test/test_game.py
+++ b/test/test_game.py
@@ -738,6 +738,7 @@ def test_play_turn_move():
         "whowins": None,
         "team_say": "bla",
         "score": 0,
+        "max_team_errors": 4,
         "kills":[0]*4,
         "deaths": [0]*4,
         "bot_was_killed": [False]*4,
@@ -869,6 +870,7 @@ def test_last_round_check():
             'max_rounds': max_rounds,
             'round': current_round,
             'turn': current_turn,
+            'max_team_errors': 4,
             'fatal_errors': [[],[]],
             'errors': [[],[]],
             'gameover': False,
@@ -903,11 +905,11 @@ def test_error_finishes_game(team_errors, team_wins):
     # the mapping is as follows:
     # [(num_fatal_0, num_errors_0), (num_fatal_1, num_errors_1), result_flag]
     # the result flag: 0/1: team 0/1 wins, 2: draw, False: no winner yet
-    assert game.MAX_ALLOWED_ERRORS == 4, "Test assumes MAX_ALLOWED_ERRORS is 4"
 
     (fatal_0, errors_0), (fatal_1, errors_1) = team_errors
     # just faking a bunch of errors in our game state
     state = {
+        "max_team_errors": 4,
         "fatal_errors": [[None] * fatal_0, [None] * fatal_1],
         "errors": [[None] * errors_0, [None] * errors_1]
     }


### PR DESCRIPTION
Previously, this was only a global variable `MAX_ALLOWED_ERRORS ` in `game.py`, even though we did have an empty, non-used API slot (with a default) in `def run_game` and `def setup_game` and an argument in the command line interface `--max-timeouts` that was not functional either.

I have rewired everything to make use of the flag and renamed the CLI to `--max-errors`, which is hopefully more clear. Note that I also changed the defaults to 4, as in my opinion the name `--max-errors` implies the maximum number of errors that are still allowed and our rule is ‘(minimum) five timeouts and you’re out’ (open for suggestions to change the wording and default to be 5 again, but `--num-errors-to-die` does not sound much nicer).

For running games without error checking (might be useful for testing), I’ve added a branch that disables the error check when a negative number is passes. We don’t need to have this but I find it a little nicer than having to invent arbitrarily big numbers (and probably not important enough to include a flag `--no-max-errors` – or would this be better?).