### PR TITLE
RF: Change max_team_errors to error_limit (and shift logic by one).

### DIFF
--- a/pelita/scripts/pelita_main.py
+++ b/pelita/scripts/pelita_main.py
@@ -91,8 +91,8 @@ timeout_opt.add_argument('--timeout', type=float, metavar="SEC",
                          dest='timeout_length', help='Time before timeout is triggered (default: 3 seconds).')
 timeout_opt.add_argument('--no-timeout', const=None, action='store_const',
                          dest='timeout_length', help='Run game without timeouts.')
-game_settings.add_argument('--max-errors', type=int, default=4,
-                           dest='max_team_errors', help='Maximum number of team errors allowed (default: 4).')
+game_settings.add_argument('--error-limit', type=int, default=5,
+                           dest='error_limit', help='Error limit. Reaching this limit disqualifies a team (default: 5).')
 parser.set_defaults(timeout_length=3)
 game_settings.add_argument('--stop-at', dest='stop_at', type=int, metavar="N",
                            help='Stop before playing round N.')
@@ -276,7 +276,7 @@ def main():
 
     layout_dict = layout.parse_layout(layout_string)
     game.run_game(team_specs=team_specs, max_rounds=args.rounds, layout_dict=layout_dict, layout_name=layout_name, seed=seed,
-                  timeout_length=args.timeout_length, max_team_errors=args.max_team_errors,
+                  timeout_length=args.timeout_length, error_limit=args.error_limit,
                   viewers=viewers, viewer_options=viewer_options,
                   store_output=args.store_output)
 

--- a/test/test_game.py
+++ b/test/test_game.py
@@ -738,7 +738,7 @@ def test_play_turn_move():
         "whowins": None,
         "team_say": "bla",
         "score": 0,
-        "max_team_errors": 4,
+        "error_limit": 5,
         "kills":[0]*4,
         "deaths": [0]*4,
         "bot_was_killed": [False]*4,
@@ -870,7 +870,7 @@ def test_last_round_check():
             'max_rounds': max_rounds,
             'round': current_round,
             'turn': current_turn,
-            'max_team_errors': 4,
+            'error_limit': 5,
             'fatal_errors': [[],[]],
             'errors': [[],[]],
             'gameover': False,
@@ -909,7 +909,7 @@ def test_error_finishes_game(team_errors, team_wins):
     (fatal_0, errors_0), (fatal_1, errors_1) = team_errors
     # just faking a bunch of errors in our game state
     state = {
-        "max_team_errors": 4,
+        "error_limit": 5,
         "fatal_errors": [[None] * fatal_0, [None] * fatal_1],
         "errors": [[None] * errors_0, [None] * errors_1]
     }


### PR DESCRIPTION
Setting the error_limit to zero will disable error counting. As discussed in #709 we can still settle on a different name.