### PR TITLE
Add line of sight and intention arrows

### DIFF
--- a/pelita/ui/tk_canvas.py
+++ b/pelita/ui/tk_canvas.py
@@ -424,8 +424,8 @@ class TkApplication:
         self.mesh_graph.num_y = game_state['shape'][1]
 
         self.draw_grid()
-        self.draw_line_of_sight(game_state)
         self.draw_selected(game_state)
+        self.draw_line_of_sight(game_state)
         self.draw_background()
         self.draw_maze(game_state)
         self.draw_food(game_state)
@@ -489,7 +489,12 @@ class TkApplication:
             for dy in range(- sight_distance, sight_distance + 1)
             if abs(dx) + abs(dy) == sight_distance
         )
-        print(border_cells_relative)
+
+        def in_maze(x, y):
+            return 0 <= x < game_state['shape'][0] and  0 <= y < game_state['shape'][1]
+
+        def on_edge(x, y):
+            return x == 0 or x == game_state['shape'][0] - 1 or y == 0 or y == game_state['shape'][1] - 1
 
 
         def draw_line(pos, color, loc):
@@ -516,8 +521,12 @@ class TkApplication:
                     continue
 
                 pos = (old_pos[0] + dx, old_pos[1] + dy)
+                if not in_maze(pos[0], pos[1]):
+                    continue
+
                 draw_box(pos, fill=LIGHT_BLUE if bot % 2 == 0 else LIGHT_RED)
 
+                # add edge around cells at the line of sight max
                 if (dx, dy) in border_cells_relative:
                     if dx >= 0:
                         draw_line(pos, loc=(1, 1, 1, -1), color=team_col)
@@ -528,11 +537,19 @@ class TkApplication:
                     if dy <= 0:
                         draw_line(pos, loc=(1, -1, -1, -1), color=team_col)
 
+                # add edge around cells at the edge of the maze
+                if on_edge(pos[0], pos[1]):
+                    if pos[0] == game_state['shape'][0] - 1:
+                        draw_line(pos, loc=(1, 1, 1, -1), color=team_col)
+                    if pos[0] == 0:
+                        draw_line(pos, loc=(-1, 1, -1, -1), color=team_col)
+                    if pos[1] == game_state['shape'][1] - 1:
+                        draw_line(pos, loc=(1, 1, -1, 1), color=team_col)
+                    if pos[1] == 0:
+                        draw_line(pos, loc=(1, -1, -1, -1), color=team_col)
 
         self.ui.game_canvas.tag_lower("area_of_sight")
         self.ui.game_canvas.tag_raise("wall")
-        print(game_state)
-
 
 
     def toggle_grid(self):

--- a/pelita/ui/tk_canvas.py
+++ b/pelita/ui/tk_canvas.py
@@ -434,6 +434,8 @@ class TkApplication:
         self.draw_shadow_bots(game_state)
         self.draw_bots(game_state)
 
+        self.draw_moves(game_state)
+
         self.draw_status_info(game_state)
 
     def draw_grid(self):
@@ -791,6 +793,29 @@ class TkApplication:
             idx: BotSprite(self.mesh_graph, team=idx % 2, bot_id=idx, position=None, shadow=True)
             for idx, bot in enumerate(bot_positions)
         }
+
+    def draw_moves(self, game_state):
+        if game_state['turn'] is None:
+            return
+
+        self.ui.game_canvas.delete("arrow")
+        # we keep all arrow items stored in a list
+        # some versions of Python seem to forget about drawing
+        # them otherwise
+        self.arrow_items = []
+
+        bot = game_state['turn']
+        old_pos = tuple(game_state['requested_moves'][bot]['previous_position'])
+        req_pos = tuple(game_state['requested_moves'][bot]['requested_position'])
+        print(game_state['bots'][bot], game_state['requested_moves'][bot])
+        arrow_item = Arrow(self.mesh_graph,
+                           position=old_pos,
+                           req_pos=game_state['bots'][bot],
+                           success=game_state['requested_moves'][bot]['success'])
+        arrow_item.draw(self.ui.game_canvas)
+        self.arrow_items.append(arrow_item)
+        print(game_state["bots"][bot], old_pos, req_pos)
+
 
     def draw_bots(self, game_state):
         if game_state:

--- a/pelita/ui/tk_canvas.py
+++ b/pelita/ui/tk_canvas.py
@@ -9,9 +9,8 @@ import tkinter.font
 
 from ..game import next_round_turn
 from ..player.team import _ensure_list_tuples
-from .tk_sprites import BotSprite, Food, Wall, col
+from .tk_sprites import BotSprite, Food, Wall, Arrow, RED, BLUE, YELLOW, GREY, BROWN, LIGHT_BLUE, LIGHT_RED, STRONG_BLUE, STRONG_RED
 from .tk_utils import wm_delete_window_handler
-from .tk_sprites import BotSprite, Food, Wall, RED, BLUE, YELLOW, GREY, BROWN
 from .. import layout
 
 _logger = logging.getLogger(__name__)
@@ -425,6 +424,7 @@ class TkApplication:
         self.mesh_graph.num_y = game_state['shape'][1]
 
         self.draw_grid()
+        self.draw_line_of_sight(game_state)
         self.draw_selected(game_state)
         self.draw_background()
         self.draw_maze(game_state)
@@ -460,6 +460,80 @@ class TkApplication:
 
         for y in range(self.mesh_graph.mesh_height + 1):
             draw_line(-0.5, y - 0.5, self.mesh_graph.mesh_width - 0.5, y - 0.5)
+
+    def draw_line_of_sight(self, game_state):
+        self.ui.game_canvas.delete("line_of_sight")
+        if not self._grid_enabled:
+            return
+
+        scale = self.mesh_graph.half_scale_x * 0.1
+
+        def draw_box(pos):
+            ul = self.mesh_graph.mesh_to_screen(pos, (-1, -1))
+            ur = self.mesh_graph.mesh_to_screen(pos, (1, -1))
+            ll = self.mesh_graph.mesh_to_screen(pos, (-1, 1))
+            lr = self.mesh_graph.mesh_to_screen(pos, (1, 1))
+
+            self.ui.game_canvas.create_rectangle(*ul, *lr, width=2, outline='#111', tag=("line_of_sight",))
+
+        bot = game_state['turn']
+        old_pos = tuple(game_state['requested_moves'][bot]['previous_position'])
+        draw_box(old_pos)
+
+        sight_distance = game_state["sight_distance"]
+        # starting from old_pos, iterate over all positions that are up to sight_distance
+        # steps away and put a border around the fields.
+        border_cells_relative = set(
+            (dx, dy)
+            for dx in range(- sight_distance, sight_distance + 1)
+            for dy in range(- sight_distance, sight_distance + 1)
+            if abs(dx) + abs(dy) == sight_distance
+        )
+        print(border_cells_relative)
+
+
+        def draw_line(pos, color, loc):
+            x0_ = self.mesh_graph.mesh_to_screen_x(pos[0], loc[0])
+            y0_ = self.mesh_graph.mesh_to_screen_y(pos[1], loc[1])
+            x1_ = self.mesh_graph.mesh_to_screen_x(pos[0], loc[2])
+            y1_ = self.mesh_graph.mesh_to_screen_y(pos[1], loc[3])
+            self.ui.game_canvas.create_line(x0_, y0_, x1_, y1_, width=2, fill=color, tag=("line_of_sight"))
+
+        team_col = STRONG_BLUE if bot % 2 == 0 else STRONG_RED
+
+
+        def draw_box(pos, fill):
+            ul = self.mesh_graph.mesh_to_screen(pos, (-1, -1))
+            ur = self.mesh_graph.mesh_to_screen(pos, (1, -1))
+            ll = self.mesh_graph.mesh_to_screen(pos, (-1, 1))
+            lr = self.mesh_graph.mesh_to_screen(pos, (1, 1))
+
+            self.ui.game_canvas.create_rectangle(*ul, *lr, width=0, fill=fill, tag=("line_of_sight", "area_of_sight"))
+
+        for dx in range(- sight_distance, sight_distance + 1):
+            for dy in range(- sight_distance, sight_distance + 1):
+                if abs(dx) + abs(dy) > sight_distance:
+                    continue
+
+                pos = (old_pos[0] + dx, old_pos[1] + dy)
+                draw_box(pos, fill=LIGHT_BLUE if bot % 2 == 0 else LIGHT_RED)
+
+                if (dx, dy) in border_cells_relative:
+                    if dx >= 0:
+                        draw_line(pos, loc=(1, 1, 1, -1), color=team_col)
+                    if dx <= 0:
+                        draw_line(pos, loc=(-1, 1, -1, -1), color=team_col)
+                    if dy >= 0:
+                        draw_line(pos, loc=(1, 1, -1, 1), color=team_col)
+                    if dy <= 0:
+                        draw_line(pos, loc=(1, -1, -1, -1), color=team_col)
+
+
+        self.ui.game_canvas.tag_lower("area_of_sight")
+        self.ui.game_canvas.tag_raise("wall")
+        print(game_state)
+
+
 
     def toggle_grid(self):
         self._grid_enabled = not self._grid_enabled

--- a/pelita/ui/tk_sprites.py
+++ b/pelita/ui/tk_sprites.py
@@ -9,7 +9,14 @@ def col(red, green, blue):
 
 RED = col(235, 90, 90)
 BLUE = col(94, 158, 217)
+
+LIGHT_BLUE = '#B9D9F6'
+STRONG_BLUE = '#1E6BB1'
+LIGHT_RED = '#FFB0B0'
+STRONG_RED = '#A91919'
+
 YELLOW = col(242, 255, 83)
+YELLOW = '#FFE38B'
 GREY = col(80, 80, 80)
 BROWN = col(48, 26, 22)
 

--- a/pelita/ui/tk_sprites.py
+++ b/pelita/ui/tk_sprites.py
@@ -200,7 +200,7 @@ class BotSprite(TkSprite):
 
         # ghost head
         canvas.create_arc((box_ll, box_tr), start=0, extent=180, style="pieslice" if not self.shadow else "arc",
-                          width=0, outline=self.outline_col, fill=self.col, tag=self.tag)
+                          width=1, outline=self.outline_col, fill=self.col, tag=self.tag)
 
         # ghost body
         box_ll = box_ll[0], box_ll[1] + (box_tr[1]-box_ll[1])/2.

--- a/pelita/ui/tk_sprites.py
+++ b/pelita/ui/tk_sprites.py
@@ -1,6 +1,7 @@
 import cmath
 import math
 from .. import layout
+from ..gamestate_filters import manhattan_dist
 
 
 def col(red, green, blue):
@@ -303,3 +304,75 @@ class Food(TkSprite):
         else:
             fill = RED
         canvas.create_oval(self.bounding_box(0.4), fill=fill, width=0, tag=(self.tag, self.food_pos_tag(self.position), "food"))
+
+
+class Arrow(TkSprite):
+    def __init__(self, mesh, req_pos, success, **kwargs):
+        self.req_pos = req_pos
+        self.success = success
+
+        super(Arrow, self).__init__(mesh, **kwargs)
+
+    def draw(self, canvas, game_state=None):
+        scale = (self.mesh.half_scale_x + self.mesh.half_scale_y) * 0.07
+
+        if not self.success:
+            points = [
+                self.screen((-0.3, 0.3)),
+                self.screen((0.3, -0.3))
+            ]
+            canvas.create_line(points,
+                            fill=BROWN, width=scale, tag=(self.tag, "arrow"), capstyle="round")
+
+            points = [
+                self.screen((-0.3, -0.3)),
+                self.screen(( 0.3, 0.3))
+            ]
+            canvas.create_line(points,
+                            fill=BROWN, width=scale, tag=(self.tag, "arrow"), capstyle="round")
+
+        dist = manhattan_dist(self.req_pos, self.position)
+        if dist == 0:
+            canvas.create_arc(self.bounding_box(0.6), start=110, extent=320, style="arc", outline=BROWN,
+                                                width=scale, tag=(self.tag, "arrow"))
+            # arrow head
+            head = cmath.rect(0.6, -110 * cmath.pi / 180)
+            head_rotation = (-110 + 90) * cmath.pi / 180
+            head_left = head - cmath.rect(0.3, head_rotation - cmath.pi/4)
+            head_right = head - cmath.rect(0.3, head_rotation + cmath.pi/4)
+            #vector = dx + dy * 1j
+            #phase = cmath.phase(vector)
+            #head = vector + cmath.rect(0.1, phase)
+            #head_left = vector - cmath.rect(1, phase) + cmath.rect(0.9, phase - cmath.pi/4)
+            #head_right = vector - cmath.rect(1, phase) + cmath.rect(0.9, phase + cmath.pi/4)
+
+            points = [
+                self.screen((head_left.real, head_left.imag)),
+                self.screen((head.real, head.imag)),
+                self.screen((head_right.real, head_right.imag))
+            ]
+            canvas.create_line(points,
+                            fill=BROWN, width=scale, tag=(self.tag, "arrow"), capstyle="round")
+
+        else:
+            # dx, dy has to be duplicated because the self.screen coordinates go from -1 to 1
+            # for the current cell
+            dx = (self.req_pos[0] - self.position[0]) * 2
+            dy = (self.req_pos[1] - self.position[1]) * 2
+            canvas.create_line(self.screen((0, 0)), self.screen((dx, dy)), fill=BROWN,
+                                                width=scale, tag=(self.tag, "arrow"), capstyle="round")
+            # arrow head
+            vector = dx + dy * 1j
+            phase = cmath.phase(vector)
+            head = vector + cmath.rect(0.1, phase)
+            head_left = vector - cmath.rect(1, phase) + cmath.rect(0.9, phase - cmath.pi/4)
+            head_right = vector - cmath.rect(1, phase) + cmath.rect(0.9, phase + cmath.pi/4)
+
+            points = [
+                self.screen((head_left.real, head_left.imag)),
+                self.screen((head.real, head.imag)),
+                self.screen((head_right.real, head_right.imag))
+            ]
+            canvas.create_line(points,
+                            fill=BROWN, width=scale, tag=(self.tag, "arrow"), capstyle="round")
+


### PR DESCRIPTION
(Work in progress. Will be rebased and become more refined eventually.)

This adds a bot’s line of sight in debug mode. Any enemy bot within the line of sight will appear at its exact position (and therefore will not have a ghost bot appear).

Note that the line of sight is drawn from a bot’s position *before* a move, while the UI will show it’s position *after* a move. To make this more clear, we show a border around the initial cell (or maybe we should colour the cell; will still experiment with this) and put an arrow in the direction of the move that was requested.

<img width="799" alt="image" src="https://user-images.githubusercontent.com/216179/123250219-1eda7080-d4ea-11eb-92bc-b17bef9a908c.png">

When a move was invalid and a random move is executed instead, we show an X on the original cell (design need to be refined).

<img width="799" alt="image" src="https://user-images.githubusercontent.com/216179/123250273-2a2d9c00-d4ea-11eb-8cfb-79e0772bfab0.png">

How should we show that a move was a stopping move? Perhaps with this circular arrow? (This version comes with an X as it was also a random move because of an error.)

<img width="799" alt="image" src="https://user-images.githubusercontent.com/216179/123250298-2f8ae680-d4ea-11eb-8401-f2eb7c45d34e.png">

Even better would be, if we could animate the bots in Tk. This would, however, require a medium-sized rewrite of the Tk code.

**Technical details**

This is implemented with a new informational attribute in the game state `'requested_moves'` (needs tests), which informs the UI of the previous position and the position that has been requested (which can be different from the final position, as a bot can of course be eaten when moving – this might need a different kind of array, too).