### PR TITLE
BLD: Drop official support for Python 3.6

### DIFF
--- a/pelita/layout.py
+++ b/pelita/layout.py
@@ -1,10 +1,5 @@
-try:
-    import importlib.resources as importlib_resources
-except ImportError:
-    # Python 3.6
-    import importlib_resources
+import importlib.resources as importlib_resources
 import io
-from pathlib import Path
 import random
 
 # bot to index conversion

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,12 +12,13 @@ classifiers =
     Intended Audience :: Education
     Topic :: Scientific/Engineering :: Artificial Intelligence
     License :: OSI Approved :: BSD License
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
 [options]
 zip_safe = true
-python_requires = >= 3.6
+python_requires = >= 3.7
 packages = find:
 install_requires =
     pyzmq
@@ -25,7 +26,6 @@ install_requires =
     numpy
     networkx
     pytest>=4
-    importlib_resources; python_version<"3.7"
 include_package_data = True
 setup_requires =
     pytest-runner


### PR DESCRIPTION
This means that we *might* make `gamestate` a `@dataclass` in the future.