### PR TITLE
BF: Let a remote player lose when it cannot connect in time.

### DIFF
--- a/pelita/game.py
+++ b/pelita/game.py
@@ -11,7 +11,7 @@ import typing
 from warnings import warn
 
 from . import layout
-from .exceptions import FatalException, NonFatalException, NoFoodWarning
+from .exceptions import FatalException, NonFatalException, NoFoodWarning, PlayerTimeout
 from .gamestate_filters import noiser
 from .layout import initial_positions, get_legal_positions
 from .network import bind_socket, setup_controller, ZMQPublisher
@@ -450,7 +450,9 @@ def setup_teams(team_specs, game_state, store_output=False, allow_exceptions=Fal
     for idx, team in enumerate(teams):
         try:
             team_name = team.set_initial(idx, prepare_bot_state(game_state, idx))
-        except FatalException as e:
+        except (FatalException, PlayerTimeout) as e:
+            # TODO: Not sure if PlayerTimeout should let the other payer win.
+            # It could simply be a network problem.
             if allow_exceptions: raise
             exception_event = {
                 'type': e.__class__.__name__,

--- a/pelita/player/team.py
+++ b/pelita/player/team.py
@@ -236,6 +236,7 @@ class RemoteTeam:
             self.bound_to_address = address
 
             socket = zmq_context.socket(zmq.DEALER)
+            socket.setsockopt(zmq.LINGER, 0)
             socket.connect(send_addr)
             _logger.info("Connecting zmq.DEALER to remote player at {}.".format(send_addr))
             socket.send_json({"REQUEST": address})


### PR DESCRIPTION
This ends the game when it is stared like as follows

    pelita my_player/ remote:tcp://remote.server:8087

but when there is no remote player running on remote.server:8087 (which would have to be started as `pelita-player --remote tcp://remote.server:8087` but isn’t). We now catch the PlayerTimeout and count a win for the team that has successfully connected. Previously, Pelita would raise the `PlayerTimeout` exception and exit.

This might fix a similar situation that was discussed #269, which I am also closing now.

I had to introduce an additional `socket.setsockopt(zmq.LINGER, 0)`, otherwise Pelita would never exit as the zmq Context was never destroyed. In a follow-up issue I’ll detail what needs to be done some point in the future to fix this once and for all.