### PR TITLE
Fix error in SmartRandomPlayers that would make enemies invincible.

### DIFF
--- a/pelita/player/FoodEatingPlayer.py
+++ b/pelita/player/FoodEatingPlayer.py
@@ -16,8 +16,9 @@ def food_eating_player(bot, state):
         or state[bot.turn]['next_food'] not in bot.enemy[0].food):
         if not bot.enemy[0].food:
             # all food has been eaten? ok. I’ll stop
+            # NB: We should never land here; the game will be over instead
             next_pos = bot.position
-            return next_pos, state
+            return next_pos
 
         state[bot.turn]['next_food'] = bot.random.choice(bot.enemy[0].food)
 

--- a/pelita/player/SmartEatingPlayer.py
+++ b/pelita/player/SmartEatingPlayer.py
@@ -1,28 +1,14 @@
 import networkx
 
 from pelita.utils import walls_to_graph
-
+from . import food_eating_player
 
 def smart_eating_player(bot, state):
-    if 'graph' not in state:
-        # first turn, first round
-        state['graph'] = walls_to_graph(bot.walls)
-
-    if bot.turn not in state:
-        state[bot.turn] = { 'next_food': None }
-
-    # check, if food is still present
-    if (state[bot.turn]['next_food'] is None
-            or state[bot.turn]['next_food'] not in bot.enemy[0].food):
-        if not bot.enemy[0].food:
-            # all food has been eaten? ok. i’ll stop
-            return bot.position, state
-        state[bot.turn]['next_food'] = bot.random.choice(bot.enemy[0].food)
+    # food eating player but won’t do kamikaze (although a sufficently smart
+    # enemy will be able to kill the bot in its next turn as it doesn’t flee)
+    next_pos = food_eating_player(bot, state)
 
     dangerous_enemy_pos = [enemy.position for enemy in bot.enemy if enemy.position in enemy.homezone]
-
-    # the first position in the shortest path is always bot.position
-    next_pos = networkx.shortest_path(state['graph'], bot.position, state[bot.turn]['next_food'])[1]
 
     # check, if the next_pos has an enemy on it
     if next_pos in dangerous_enemy_pos:

--- a/pelita/player/SmartEatingPlayer.py
+++ b/pelita/player/SmartEatingPlayer.py
@@ -1,7 +1,6 @@
 import networkx
 
-from pelita.utils import walls_to_graph
-from . import food_eating_player
+from pelita.player import food_eating_player
 
 def smart_eating_player(bot, state):
     # food eating player but won’t do kamikaze (although a sufficently smart

--- a/pelita/player/SmartRandomPlayer.py
+++ b/pelita/player/SmartRandomPlayer.py
@@ -1,9 +1,9 @@
 
 def smart_random_player(bot, state):
     dangerous_enemy_pos = [enemy.position
-        for enemy in bot.enemy if enemy in enemy.homezone]
+        for enemy in bot.enemy if enemy.position in enemy.homezone]
     killable_enemy_pos = [enemy.position
-        for enemy in bot.enemy if enemy not in enemy.homezone]
+        for enemy in bot.enemy if enemy.position not in enemy.homezone]
 
     smart_positions = []
     for new_pos in bot.legal_positions[:]:

--- a/test/test_players.py
+++ b/test/test_players.py
@@ -2,7 +2,7 @@ import pytest
 
 from pelita.game import run_game
 from pelita.layout import parse_layout
-from pelita.player import nq_random_player, SANE_PLAYERS, smart_random_player, food_eating_player
+from pelita.player import nq_random_player, SANE_PLAYERS, smart_random_player, food_eating_player, smart_eating_player
 from pelita.utils import setup_test_game
 
 
@@ -145,6 +145,82 @@ class TestFoodEatingPlayer():
         next_pos = food_eating_player(bot, {0: {'next_food': (5, 1)}})
         assert next_pos == (5, 2)
 
+    def test_will_do_kamikaze(self):
+        # check that we eat the last food when adjacent
+        layout="""
+        ########
+        #x  a.##
+        # .  b #
+        ########
+        """
+        bot = setup_test_game(layout=layout, is_blue=True, bots={'y': (5, 1)})
+        next_pos = food_eating_player(bot, {})
+        assert next_pos == (5,1)
+
+class TestSmartEatingPlayer():
+    def test_legalmoves(self):
+        # check that the only two valid moves are returned
+        layout="""
+        ########
+        #a######
+        #b. .xy#
+        ########
+        """
+        bot = setup_test_game(layout=layout, is_blue=True)
+        next_pos = smart_eating_player(bot, {})
+        assert next_pos in ((1,2), (1,1))
+
+    def test_eat_food(self):
+        # check that we eat the last food when adjacent
+        layout="""
+        ########
+        #x  a.##
+        # .  by#
+        ########
+        """
+        bot = setup_test_game(layout=layout, is_blue=True)
+        next_pos = smart_eating_player(bot, {})
+        assert next_pos == (5,1)
+
+    def test_move_towards_food(self):
+        # check that we move closer to the food
+        layout="""
+        ########
+        #y a .##
+        #b.x   #
+        ########
+        """
+        bot = setup_test_game(layout=layout, is_blue=True)
+        next_pos = smart_eating_player(bot, {})
+        assert next_pos == (4,1)
+
+    def test_move_towards_next_food(self):
+        # check that we move closer to the food in the next_food key,
+        # even though another food is closer
+        layout="""
+        ########
+        #y   .##
+        #      #
+        # .. a #
+        #x   . #
+        # .b   #
+        ########
+        """
+        bot = setup_test_game(layout=layout, is_blue=True)
+        next_pos = smart_eating_player(bot, {0: {'next_food': (5, 1)}})
+        assert next_pos == (5, 2)
+
+    def test_will_not_do_kamikaze(self):
+        # check that we eat the last food when adjacent
+        layout="""
+        ########
+        #x  a.##
+        # .  b #
+        ########
+        """
+        bot = setup_test_game(layout=layout, is_blue=True, bots={'y': (5, 1)})
+        next_pos = smart_eating_player(bot, {})
+        assert next_pos == (4,1)
 
 @pytest.mark.parametrize('player', SANE_PLAYERS)
 def test_players(player):

--- a/test/test_players.py
+++ b/test/test_players.py
@@ -2,7 +2,7 @@ import pytest
 
 from pelita.game import run_game
 from pelita.layout import parse_layout
-from pelita.player import nq_random_player, SANE_PLAYERS, smart_random_player
+from pelita.player import nq_random_player, SANE_PLAYERS, smart_random_player, food_eating_player
 from pelita.utils import setup_test_game
 
 
@@ -92,6 +92,59 @@ class TestSmartRandomPlayer():
         assert next_pos == (5, 2)
 
 
+class TestFoodEatingPlayer():
+    def test_legalmoves(self):
+        # check that the only two valid moves are returned
+        layout="""
+        ########
+        #a######
+        #b. .xy#
+        ########
+        """
+        bot = setup_test_game(layout=layout, is_blue=True)
+        next_pos = food_eating_player(bot, {})
+        assert next_pos in ((1,2), (1,1))
+
+    def test_eat_food(self):
+        # check that we eat the last food when adjacent
+        layout="""
+        ########
+        #x  a.##
+        # .  by#
+        ########
+        """
+        bot = setup_test_game(layout=layout, is_blue=True)
+        next_pos = food_eating_player(bot, {})
+        assert next_pos == (5,1)
+
+    def test_move_towards_food(self):
+        # check that we move closer to the food
+        layout="""
+        ########
+        #y a .##
+        #b.x   #
+        ########
+        """
+        bot = setup_test_game(layout=layout, is_blue=True)
+        next_pos = food_eating_player(bot, {})
+        assert next_pos == (4,1)
+
+    def test_move_towards_next_food(self):
+        # check that we move closer to the food in the next_food key,
+        # even though another food is closer
+        layout="""
+        ########
+        #y   .##
+        #      #
+        # .. a #
+        #x   . #
+        # .b   #
+        ########
+        """
+        bot = setup_test_game(layout=layout, is_blue=True)
+        next_pos = food_eating_player(bot, {0: {'next_food': (5, 1)}})
+        assert next_pos == (5, 2)
+
 
 @pytest.mark.parametrize('player', SANE_PLAYERS)
 def test_players(player):
@@ -105,7 +158,7 @@ def test_players(player):
         #    #  # ##
         #a#.   .  x#
         ############ """)
-    
+
     teams = [
         player,
         nq_random_player


### PR DESCRIPTION
That one’s for the best-of-fails collection in the Pelita bug hall of fame.

What’s the problem with the following assignments and how does this make you feel about Python being an untyped language?

```python
def smart_random_player(bot, state):
    dangerous_enemy_pos = [enemy.position
        for enemy in bot.enemy if enemy in enemy.homezone]
    killable_enemy_pos = [enemy.position
        for enemy in bot.enemy if enemy not in enemy.homezone]
```

Of course, `enemy.homezone` is a `Set[(int, int)]`, so the check `enemy in enemy.homezone` is always `False`, rendering all enemies instantly non-dangerous and killable. Perhaps `enemy.homezone` should raise a `ValueError` when the types are incompatible.

(Tests copied over from the pelita_template code.)