### PR TITLE
BF: Use FullLoader for yaml.

### DIFF
--- a/pelita/scripts/pelita_tournament.py
+++ b/pelita/scripts/pelita_tournament.py
@@ -228,7 +228,7 @@ def main():
 
     try:
         with open(args.config) as f:
-            config_data = yaml.load(f)
+            config_data = yaml.load(f, Loader=yaml.FullLoader)
             config_data['viewer'] = args.viewer or config_data.get('viewer', 'tk')
             config_data['interactive'] = firstNN(args.interactive, config_data.get('interactive'), True)
             config_data['statefile'] = args.state

--- a/pelita/tournament/__init__.py
+++ b/pelita/tournament/__init__.py
@@ -400,7 +400,7 @@ class State:
     def load(cls, config, filename):
         if filename:
             with open(filename) as f:
-                return cls(config=config, state=yaml.load(f))
+                return cls(config=config, state=yaml.load(f, Loader=yaml.FullLoader))
 
 
 def present_teams(config):


### PR DESCRIPTION
Using yaml.load without Loader argument has been deprecated.
While we use the FullLoader for now as a quick fix, we might
want to change this again in the future.