### PR TITLE
RF: Improve matchplan in round robin-tournament

### DIFF
--- a/pelita/tournament/__init__.py
+++ b/pelita/tournament/__init__.py
@@ -376,7 +376,7 @@ class State:
             self.state = {
                 "round1": {
                     "played": [],
-                    "unplayed": roundrobin.initial_state(config.team_ids)
+                    "unplayed": roundrobin.create_matchplan(config.team_ids)
                 },
                 "round2": {}
             }

--- a/pelita/tournament/roundrobin.py
+++ b/pelita/tournament/roundrobin.py
@@ -64,10 +64,10 @@ def matchplan_five_teams():
     # [{0, 1}, {2, 3}, {0, 4}, {1, 2}, {3, 4}, {0, 2}, {1, 3}, {2, 4}, {0, 3}, {1, 4}]
     # [{0, 1}, {2, 3}, {0, 4}, {1, 2}, {3, 4}, {0, 2}, {1, 4}, {0, 3}, {2, 4}, {1, 3}]
 
-    if random.randrange(2):
-        matchplan = [(0, 1), (2, 3), (0, 4), (1, 2), (3, 4), (0, 2), (1, 3), (2, 4), (0, 3), (1, 4)]
-    else:
-        matchplan = [(0, 1), (2, 3), (0, 4), (1, 2), (3, 4), (0, 2), (1, 4), (0, 3), (2, 4), (1, 3)]
+    matchplan = random.choice([
+        [(0, 1), (2, 3), (0, 4), (1, 2), (3, 4), (0, 2), (1, 3), (2, 4), (0, 3), (1, 4)],
+        [(0, 1), (2, 3), (0, 4), (1, 2), (3, 4), (0, 2), (1, 4), (0, 3), (2, 4), (1, 3)]
+    ])
 
     # collect all matchplans that have an equal distribution of blue/red matches
     # TODO: It should be possible to reduce the possible combinations for this in advance.

--- a/pelita/tournament/roundrobin.py
+++ b/pelita/tournament/roundrobin.py
@@ -1,13 +1,156 @@
+from collections import Counter
 import itertools
 import random
 
+def create_matchplan(teams: list[str]) -> list[tuple[str, str]]:
+    """ Takes a list of team ids and returns a list of tuples of team ids with
+    the matchplan."""
 
-def initial_state(teams):
-    rr = []
-    for pair in itertools.combinations(teams, 2):
-        match = list(pair)
-        random.shuffle(match)
-        rr.append(tuple(match))
-    # shuffle the matches for more fun
-    random.shuffle(rr)
-    return rr
+    # We want to optimise the matchplan in multiple ways:
+    # a) At any point each team should have a similar number of played games
+    # b) No team should play two games directly after another;
+    # both of these points should make the tournament more interesting to
+    # follow.
+    # Finally, in the interest of fairness:
+    # c) Blue and red teams (ie. who starts the match) should be assigned evenly.
+    #
+    # For an even number of teams (> 4), these points can be fulfilled with the
+    # circle method; for an odd number of teams, however, it should be noted
+    # that the circle method is not the most optimal algorithm. [1]
+    #
+    # As having five teams is the usual case during ASPP student tournaments,
+    # we will special-case this one and implement the circle method in all
+    # other cases. (Arguably, round-robin tournaments with more than 6 teams
+    # will tend to become rather lengthy and should probably be executed
+    # differently anyway.)
+    #
+    # Further reading
+    # [1]: Scheduling Asynchronous Round-Robin Tournaments, W. Suksompong, arXiv:1804.04504 [math.CO]
+
+
+    if len(teams) == 3:
+        matchplan_indexes = matchplan_three_teams()
+    elif len(teams) == 5:
+        matchplan_indexes = matchplan_five_teams()
+    else:
+        matchplan_indexes = circle_method(len(teams))
+
+    shuffled_teams = list(teams)
+    random.shuffle(shuffled_teams)
+
+    matchplan = []
+    for match in matchplan_indexes:
+        idx_a, idx_b = match
+        a = shuffled_teams[idx_a]
+        b = shuffled_teams[idx_b]
+        matchplan.append((a, b))
+
+    return matchplan
+
+def matchplan_three_teams():
+    # Without loss of generality, there should be exactly two possible matchplans with evenly distributed blue/red
+    matchplans = [
+        [(0, 1), (1, 2), (2, 0)],
+        [(0, 1), (2, 0), (1, 2)]
+    ]
+    return random.choice(matchplans)
+
+def matchplan_five_teams():
+    # Without loss of generality, there are two possible matchplans for five teams (with the starting order undefined)
+    # that don’t have the same team play two consecutive matches. (Assuming the teams are assigned randomly.)
+    # (Source: pen&paper + brute force analysis)
+    #
+    # [{0, 1}, {2, 3}, {0, 4}, {1, 2}, {3, 4}, {0, 2}, {1, 3}, {2, 4}, {0, 3}, {1, 4}]
+    # [{0, 1}, {2, 3}, {0, 4}, {1, 2}, {3, 4}, {0, 2}, {1, 4}, {0, 3}, {2, 4}, {1, 3}]
+
+    if random.randrange(2):
+        matchplan = [(0, 1), (2, 3), (0, 4), (1, 2), (3, 4), (0, 2), (1, 3), (2, 4), (0, 3), (1, 4)]
+    else:
+        matchplan = [(0, 1), (2, 3), (0, 4), (1, 2), (3, 4), (0, 2), (1, 4), (0, 3), (2, 4), (1, 3)]
+
+    # collect all matchplans that have an equal distribution of blue/red matches
+    # TODO: It should be possible to reduce the possible combinations for this in advance.
+    valid_matchplans = []
+    for shuffle in itertools.product([0, 1], repeat=len(matchplan)):
+        # for each possible order, make a histogram of each team playing blue
+        # as we have five teams, we know that each team should play blue exactly twice
+        if set(Counter(match[idx] for match, idx in zip(matchplan, shuffle)).values()) == {2}:
+            valid_mp = [(match[idx], match[1 - idx]) for match, idx in zip(matchplan, shuffle)]
+            valid_matchplans.append(valid_mp)
+
+    return random.choice(valid_matchplans)
+
+def circle_method(num_teams):
+    return list(circle_method_gen(num_teams))
+
+def circle_method_gen(num_teams):
+    """ For the given number of teams, create a matchplan for a round-robin tournament using the circle method. """
+
+    FILLER_TEAM = object()
+
+    teams = list(range(num_teams))
+
+    # add a dummy team if we have an odd number of teams
+    # the matches will later be discarded
+    if len(teams) % 2 != 0:
+        teams.append(FILLER_TEAM)
+
+    # choose an index that we keep fixed (must be in first or last column)
+    #
+    # entries are aligned clockwise
+    #
+    #  +---+---+---+---+
+    #  | 0 | 1 | 2 | 3 |
+    #  +---+---+---+---+
+    #  | 4 | 5 | 6 | 7 |
+    #  +---+---+---+---+
+    #
+    #  keep 0 fixed and rotate
+    #
+    #  +---+---+---+---+
+    #  | 0 | 2 | 3 | 4 |
+    #  +---+---+---+---+
+    #  | 5 | 6 | 7 | 1 |
+    #  +---+---+---+---+
+    #
+    # This gives us the starting matches: 04, 14, 26, 37, 50, 26, 37, 41, ...
+    # Note that all matches of the fixed team need to be reversed in every second round
+
+    # corner indexes
+    if num_teams % 2 == 0:
+        fixed_index = random.choice([0, len(teams) // 2 - 1, len(teams) // 2, len(teams) - 1])
+    else:
+        # for an odd number of teams, only select the column with the filler team
+        fixed_index = random.choice([0, len(teams) - 1])
+
+    flip_fixed = False
+    for _iter in range(len(teams) - 1):
+        teams = rotate_with_fixed(teams, fixed_index)
+
+        # pair the matches
+        for match_idx in range(len(teams) // 2):
+            # pair a team from the top of the list with a team from the bottom
+            top_index = match_idx
+            bottom_index = len(teams) - match_idx - 1
+            match = teams[top_index], teams[bottom_index]
+
+            # the pairing with the fixed team needs to be flipped every other time
+            if fixed_index in [top_index, bottom_index]:
+                if flip_fixed:
+                    match = teams[bottom_index], teams[top_index]
+                flip_fixed = not flip_fixed
+
+            if FILLER_TEAM in match:
+                continue
+            yield match
+
+def rotate_with_fixed(lst: list, index: int) -> list:
+    lst = list(lst)
+
+    # remove index
+    removed_team = lst.pop(index)
+    # rotate
+    lst = lst[1:] + lst[:1]
+    # insert again
+    lst.insert(index, removed_team)
+    return lst

--- a/pelita/tournament/roundrobin.py
+++ b/pelita/tournament/roundrobin.py
@@ -1,8 +1,9 @@
 from collections import Counter
 import itertools
 import random
+from typing import List, Tuple
 
-def create_matchplan(teams: list[str]) -> list[tuple[str, str]]:
+def create_matchplan(teams: List[str]) -> List[Tuple[str, str]]:
     """ Takes a list of team ids and returns a list of tuples of team ids with
     the matchplan."""
 
@@ -144,7 +145,7 @@ def circle_method_gen(num_teams):
                 continue
             yield match
 
-def rotate_with_fixed(lst: list, index: int) -> list:
+def rotate_with_fixed(lst: List, index: int) -> List:
     lst = list(lst)
 
     # remove index


### PR DESCRIPTION
This commit optimises the matchplan in the round-robin tournament, making it fairer and (hopefully) more fun:

  a) At any point each team should have a similar number of played games
  b) No team should play two games directly after another;

both of these points should make the tournament more interesting to follow.

Finally, in the interest of fairness:
  c) Blue and red teams (ie. who starts the match) should be assigned evenly.
    
As having five teams is the usual case during ASPP student tournaments, we special-case this one and implement the circle method in all other cases.


### Further motivation:

There are 10 games to be played in a single round-robin tournament with 5 teams, which means that there are 10! = 3628800 possible arrangements (ignoring blue/red difference). Some of then are obviously pathologically bad, such as for example, permutation number 766415:

    [(0, 3), (0, 2), (0, 1), (0, 4), (1, 4), (2, 4), (3, 4), (2, 3), (1, 3), (1, 2)]

This game won’t be much fun for teams 0, 4 and 3, and we should probably strive to distribute the teams more evenly across the plan.

Out of these 3628800 permutations, there are only 240 match plans left that don’t have a team play two matches back-to-back [*]:

    [(0, 1), (2, 3), (0, 4), (1, 2), (3, 4), (0, 2), (1, 3), (2, 4), (0, 3), (1, 4)]
    [(0, 1), (2, 3), (0, 4), (1, 2), (3, 4), (0, 2), (1, 4), (0, 3), (2, 4), (1, 3)]
    [(0, 1), (2, 3), (0, 4), (1, 3), (2, 4), (0, 3), (1, 2), (3, 4), (0, 2), (1, 4)]
    [(0, 1), (2, 3), (0, 4), (1, 3), (2, 4), (0, 3), (1, 4), (0, 2), (3, 4), (1, 2)]
    [(0, 1), (2, 3), (1, 4), (0, 2), (3, 4), (1, 2), (0, 3), (2, 4), (1, 3), (0, 4)]
    [(0, 1), (2, 3), (1, 4), (0, 2), (3, 4), (1, 2), (0, 4), (1, 3), (2, 4), (0, 3)]
    [(0, 1), (2, 3), (1, 4), (0, 3), (2, 4), (1, 3), (0, 2), (3, 4), (1, 2), (0, 4)]
    ...

If we allow ourselves to randomly assign the teams to these match plans, then only two arrangements remain:

    [{0, 1}, {2, 3}, {0, 4}, {1, 2}, {3, 4}, {0, 2}, {1, 3}, {2, 4}, {0, 3}, {1, 4}]
    [{0, 1}, {2, 3}, {0, 4}, {1, 2}, {3, 4}, {0, 2}, {1, 4}, {0, 3}, {2, 4}, {1, 3}]

These are now taken as the basis for the tournament. (I couldn’t find an algorithm that generates these so they are hard-coded for now.)


[*]: As an aside: all these match plans have one team play in both the first and the final match, meaning it is impossible to have this feature when playing multiple rounds with five teams without reassigning the teams to new positions each round.

Closes: #736
