### PR TITLE
WIP: Adding support for zeroconf

### DIFF
--- a/pelita/scripts/pelita_main.py
+++ b/pelita/scripts/pelita_main.py
@@ -41,7 +41,7 @@ def scan(team_spec):
             if info:
                 addresses = ["%s:%d" % (addr, info.port) for addr in info.parsed_scoped_addresses()]
 
-                addr = f"remote:tcp://{addresses[0]}"
+                addr = f"tcp://{addresses[0]}"
                 team_name = info.properties[b"team_name"].decode()
                 q.put((addr, team_name), timeout=5)
 
@@ -61,8 +61,8 @@ def scan(team_spec):
                 (addr, team_name) = q.get(timeout=5)
                 #  if not players:
                     #console.print("[bold]Found players:")
-                console.print(f"  [blue]{len(players)})[/] {team_name} \[{addr}]")
-                players.append(addr)
+                console.print(f"  [blue]{len(players)})[/] {team_name} \[[blue]{addr}[/]]", highlight=False)
+                players.append(f"remote:{addr}")
         except Empty:
             pass
         except KeyboardInterrupt:
@@ -70,7 +70,7 @@ def scan(team_spec):
         finally:
             zeroconf.close()
     if players:
-        console.print(f"  [blue]0)[/] Random team")
+        console.print(f"  [blue]r)[/] Random team")
         console.print(f"  [blue]x)[/] Exit")
         console.print()
         console.print(f"Found {len(players)} player{'s' if len(players) == 1 else ''}s.")
@@ -85,7 +85,7 @@ def scan(team_spec):
             console.print("Choosing random player.")
             return random.choice(players)
         elif answer in choices.keys():
-            console.print(f"Choosing {choices[answer]}")
+            console.print(f"Choosing [blue]{choices[answer]}[/]", highlight=False)
             return choices[answer]
         else:
             return None

--- a/pelita/scripts/pelita_main.py
+++ b/pelita/scripts/pelita_main.py
@@ -73,7 +73,7 @@ def scan(team_spec):
         console.print(f"  [blue]r)[/] Random team")
         console.print(f"  [blue]x)[/] Exit")
         console.print()
-        console.print(f"Found {len(players)} player{'s' if len(players) == 1 else ''}s.")
+        console.print(f"Found {len(players)} player{'s' if len(players) != 1 else ''}.")
 
         choices = {str(i): player for i, player in enumerate(players)}
 

--- a/pelita/scripts/pelita_main.py
+++ b/pelita/scripts/pelita_main.py
@@ -55,6 +55,8 @@ def scan(team_spec):
             browser = ServiceBrowser(zeroconf, services, handlers=[on_service_state_change])
             players = []
             import time
+            import select
+            import sys
             start = time.time()
             while start + 5 > time.time():
                 time.sleep(0.2)

--- a/pelita/scripts/pelita_player.py
+++ b/pelita/scripts/pelita_player.py
@@ -421,7 +421,7 @@ def main():
                         metavar='LOGFILE', default=argparse.SUPPRESS, nargs='?')
     parser.add_argument('--remote', help='bind to a zmq.ROUTER socket at the given address which forks subprocesses on demand',
                         action='store_const', const=True)
-    parser.add_argument('--advertise', help='advertize player on zeroconf',
+    parser.add_argument('--advertise', help='advertise player on zeroconf',
                         action='store_const', const=True)
     parser.add_argument('--color', help='which color your team will have in the game', default=None)
     parser.add_argument('team')

--- a/pelita/scripts/pelita_player.py
+++ b/pelita/scripts/pelita_player.py
@@ -22,6 +22,9 @@ from .script_utils import start_logging
 _logger = logging.getLogger(__name__)
 
 
+zeroconf.log.setLevel(logging.DEBUG)
+zeroconf.log.addHandler(_logger)
+
 @contextlib.contextmanager
 def with_sys_path(dirname):
     sys.path.insert(0, dirname)
@@ -323,6 +326,7 @@ def zeroconf_advertise(address, team_spec):
         "_pelita-player._tcp.local.",
         f"{name}._pelita-player._tcp.local.",
         parsed_addresses=[parsed_url.hostname],
+        server='mynewserver.local',
         port=parsed_url.port,
         properties=desc,
     )

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,8 @@ install_requires =
     numpy
     networkx
     pytest>=4
+    zeroconf
+    rich
 include_package_data = True
 setup_requires =
     pytest-runner

--- a/test/test_game.py
+++ b/test/test_game.py
@@ -8,12 +8,14 @@ import os
 from pathlib import Path
 import random
 from textwrap import dedent
-import time
+import sys
 
 from pelita import game, layout
 from pelita.exceptions import NoFoodWarning
 from pelita.game import initial_positions, get_legal_positions, apply_move, run_game, setup_game, play_turn
 from pelita.player import stepping_player, stopping_player
+
+_mswindows = (sys.platform == "win32")
 
 
 @contextmanager
@@ -1051,6 +1053,8 @@ def test_non_existing_file():
         'type': 'PlayerDisconnected'
     }
 
+# TODO: Get it working again on Windows
+@pytest.mark.skipif(_mswindows, reason="Test fails on some Python versions.")
 def test_remote_errors(tmp_path):
     # TODO: Change error messages to be more meaningful
     # we change to the tmp dir, to make our paths simpler


### PR DESCRIPTION
This commit adds basic support for zeroconf-based networking.

Instead of a player location, pelita now understands the keyword `SCAN`
to search for remote players that advertise themselves via zeroconf:

    pelita ./own_player SCAN

A zeroconf-based remote player can be started with the argument
`--advertise` like so:

    pelita-player --advertise --remote ./some_bot.py tcp://192.168.1.23:10027

Demo:

https://user-images.githubusercontent.com/216179/168391205-0d130500-2295-47e0-92bb-9b4883e43d95.mov

Commit needs https://github.com/jstasiak/python-zeroconf and https://github.com/Textualize/rich (eye-candy) to run.

Not sure if we can call our service `_pelita-player._tcp`. For IANA correctness, we might want to create a uuid.
