### PR TITLE
ENH/UI: Add option to pelita to add additional information in the UI …

### DIFF
--- a/pelita/game.py
+++ b/pelita/game.py
@@ -78,8 +78,8 @@ def controller_exit(state, await_action='play_step'):
 
 def run_game(team_specs, *, layout_dict, layout_name="", max_rounds=300, seed=None,
              error_limit=5, timeout_length=3, viewers=None, viewer_options=None,
-             store_output=False, team_names=(None, None), allow_exceptions=False,
-             print_result=True):
+             store_output=False, team_names=(None, None), team_infos=(None, None),
+             allow_exceptions=False, print_result=True):
     """ Run a pelita match.
 
     Parameters
@@ -139,6 +139,9 @@ def run_game(team_specs, *, layout_dict, layout_name="", max_rounds=300, seed=No
               a tuple containing the team names. If not given, names will be taken
               from the team module TEAM_NAME variable or from the function name.
 
+    team_info : tuple(team_info_0, team_info_1)
+              a tuple containing additional team info.
+
     allow_exceptions : bool
                     when True, allow teams to raise Exceptions. This is especially
                     useful when running local games, where you typically want to
@@ -180,7 +183,8 @@ def run_game(team_specs, *, layout_dict, layout_name="", max_rounds=300, seed=No
     state = setup_game(team_specs, layout_dict=layout_dict, layout_name=layout_name, max_rounds=max_rounds,
                        error_limit=error_limit, timeout_length=timeout_length, seed=seed,
                        viewers=viewers, viewer_options=viewer_options,
-                       store_output=store_output, team_names=team_names, print_result=print_result)
+                       store_output=store_output, team_names=team_names, team_infos=team_infos,
+                       print_result=print_result)
 
     # Play the game until it is gameover.
     while not state.get('gameover'):
@@ -251,8 +255,8 @@ def setup_viewers(viewers=None, options=None, print_result=True):
 
 def setup_game(team_specs, *, layout_dict, max_rounds=300, layout_name="", seed=None,
                error_limit=5, timeout_length=3, viewers=None, viewer_options=None,
-               store_output=False, team_names=(None, None), allow_exceptions=False,
-               print_result=True):
+               store_output=False, team_names=(None, None), team_infos=(None, None),
+               allow_exceptions=False, print_result=True):
     """ Generates a game state for the given teams and layout with otherwise default values. """
 
     # check that two teams have been given
@@ -354,6 +358,9 @@ def setup_game(team_specs, *, layout_dict, max_rounds=300, layout_name="", seed=
 
         #: Name of the teams. Tuple of str
         team_names=team_names,
+
+        #: Additional team info. Tuple of str|None
+        team_infos=team_infos,
 
         #: Time each team needed, list of float
         team_time=[0, 0],

--- a/pelita/scripts/pelita_main.py
+++ b/pelita/scripts/pelita_main.py
@@ -63,6 +63,10 @@ parser.add_argument('--list-layouts', action='store_true',
                     help='List all available built-in layouts.')
 parser.add_argument('--check-team', action="store_true",
                     help=long_help('Check that the team is valid (on first sight) and print its name.'))
+parser.add_argument('--append-blue', type=str, metavar='INFO', default=None,
+                    help=long_help('Append info about the blue team (such as group id).'))
+parser.add_argument('--append-red', type=str, metavar='INFO', default=None,
+                    help=long_help('Append info about the red team (such as group id).'))
 
 game_settings = parser.add_argument_group('Game settings')
 game_settings.add_argument('--rounds', type=int, default=300,
@@ -272,7 +276,8 @@ def main():
     pelita.game.run_game(team_specs=team_specs, max_rounds=args.rounds, layout_dict=layout_dict, layout_name=layout_name, seed=seed,
                          timeout_length=args.timeout_length, error_limit=args.error_limit,
                          viewers=viewers, viewer_options=viewer_options,
-                         store_output=args.store_output)
+                         store_output=args.store_output,
+                         team_infos=(args.append_blue, args.append_red))
 
 if __name__ == '__main__':
     main()

--- a/pelita/tournament/__init__.py
+++ b/pelita/tournament/__init__.py
@@ -94,7 +94,7 @@ def run_and_terminate_process(args, **kwargs):
                     p.kill()
 
 
-def call_pelita(team_specs, *, rounds, size, viewer, seed, write_replay=False, store_output=False):
+def call_pelita(team_specs, *, rounds, size, viewer, seed, team_infos=None, write_replay=False, store_output=False):
     """ Starts a new process with the given command line arguments and waits until finished.
 
     Returns
@@ -102,6 +102,9 @@ def call_pelita(team_specs, *, rounds, size, viewer, seed, write_replay=False, s
     tuple of (game_state, stdout, stderr)
     """
     team1, team2 = team_specs
+
+    if team_infos is None:
+        team_infos = [None, None]
 
     if seed is not None:
         if isinstance(seed, int):
@@ -129,10 +132,14 @@ def call_pelita(team_specs, *, rounds, size, viewer, seed, write_replay=False, s
     seed = ['--seed', seed] if seed else []
     write_replay = ['--write-replay', write_replay] if write_replay else []
     store_output = ['--store-output', store_output] if store_output else []
+    append_blue = ['--append-blue', team_infos[0]] if team_infos[0] else []
+    append_red = ['--append-red', team_infos[1]] if team_infos[1] else []
 
     cmd = [sys.executable, '-m', 'pelita.scripts.pelita_main',
            team1, team2,
            '--reply-to', reply_addr,
+           *append_blue,
+           *append_red,
            *rounds,
            *size,
            *viewer,
@@ -454,11 +461,13 @@ def play_game_with_config(config, teams, *, match_id=None):
         log_kwargs = {}
 
     seed = str(random.randint(0, sys.maxsize))
+    team_infos = [config.team_group(team1), config.team_group(team2)]
 
     res = call_pelita([config.team_spec(team1), config.team_spec(team2)],
                                 rounds=config.rounds,
                                 size=config.size,
                                 viewer=config.viewer,
+                                team_infos=team_infos,
                                 seed=seed,
                                 **log_kwargs)
 

--- a/pelita/ui/tk_canvas.py
+++ b/pelita/ui/tk_canvas.py
@@ -608,8 +608,21 @@ class TkApplication:
         except (KeyError, TypeError):
             team_time = [0, 0]
 
-        left_team = "%s %d " % (game_state["team_names"][0], game_state["score"][0])
-        right_team = " %d %s" % (game_state["score"][1], game_state["team_names"][1])
+        left_name = game_state["team_names"][0]
+        right_name = game_state["team_names"][1]
+
+        left_score = game_state["score"][0]
+        right_score = game_state["score"][1]
+
+        left_info = game_state["team_infos"][0]
+        right_info = game_state["team_infos"][1]
+
+        left_info = f"({left_info})" if left_info else ""
+        right_info = f"({right_info})" if right_info else ""
+
+        left_team = f"{left_info} {left_name} {left_score} "
+        right_team = f" {right_score} {right_name} {right_info}"
+
         font_size = guess_size(left_team + ' : ' + right_team,
                                self.ui.header_canvas.winfo_width(),
                                30,

--- a/test/test_tournament.py
+++ b/test/test_tournament.py
@@ -173,6 +173,7 @@ class TestSingleMatch:
         config = MagicMock()
         config.rounds = 200
         config.team_spec = lambda x: x
+        config.team_group = lambda x: x
         config.viewer = 'ascii'
         config.size = 'small'
         config.tournament_log_folder = None
@@ -212,6 +213,7 @@ class TestSingleMatch:
         config.rounds = 300
         config.team_spec = lambda x: teams[x]
         config.team_name = lambda x: teams[x]
+        config.team_group = lambda x: x
         config.viewer = 'ascii'
         config.size = 'small'
         config.print = mock_print
@@ -249,6 +251,7 @@ class TestSingleMatch:
         config.teams = teams
         config.team_spec = lambda x: teams[x]
         config.team_name = lambda x: teams[x]
+        config.team_group = lambda x: x
         config.viewer = 'ascii'
         config.size = 'small'
         config.print = mock_print


### PR DESCRIPTION
Closes #737. Needs review. 

Adds an additional command line option to pelita to pass info on the blue and red teams.
This info will be shown in the UI and the tournament uses it to show the group numbers.