### PR TITLE
BLD: v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Pelita changelog
 
-  * v2.2.0 (???)
+  * v2.2.0 (08. Sep 2022)
 
     - Do not have a team play two matches in a row during round-robin mode
     - Show the tournament group names in the UI and on the CLI

--- a/pelita/__init__.py
+++ b/pelita/__init__.py
@@ -3,4 +3,4 @@ from . import (game,
                network,
                viewer)
 
-__version__ = '2.2.0-rc1'
+__version__ = '2.2.0'


### PR DESCRIPTION
Release Pelita v2.2.0, the Bilbao edition. Closes #744
