### PR TITLE
error reporting on importing teams sometimes shows wrong/unclear text

### DIFF
--- a/test/test_pelita_player.py
+++ b/test/test_pelita_player.py
@@ -21,6 +21,15 @@ def noteam():
     return None
 """
 
+MODULE_IMPORT_ERROR = """
+import broken
+
+TEAM_NAME = "noteam"
+
+def move(bot, state):
+    return bot.position
+"""
+
 # TODO: The modules should be unloaded after use
 
 class TestLoadFactory:
@@ -59,6 +68,22 @@ class TestLoadFactory:
 
             spec = str(module)
             with pytest.raises(AttributeError):
+                load_team_from_module(spec)
+
+    def test_failing_import_importerror(self):
+        modules_before = list(sys.modules.keys())
+        with tempfile.TemporaryDirectory() as d:
+            module = Path(d) / "teamy"
+            module.mkdir()
+            initfile = module / "__init__.py"
+            with initfile.open(mode='w') as f:
+                f.write(SIMPLE_FAILING_MODULE)
+            broken_module = module / "broken.py"
+            with broken_module.open(mode='w') as f:
+                f.write('this is a syntax error\n')
+
+            spec = str(module)
+            with pytest.raises(SyntaxError):
                 load_team_from_module(spec)
 
     def test_import_of_pyc(self):


### PR DESCRIPTION
this is a failing test that reproduces an issue we observed in Mexico City:

Running the code wiht the pelita CLI shows the right error:

```
Could not load test_broken.py: invalid syntax (doesnotexistbelieveme.py, line 1)): SyntaxError ...
[and then a nice traceback with the pointer to the file and the line with the SyntaxError]

```
In the test we get instead a different thing:

`AttributeError: module 'teamy' has no attribute 'move'
`

--> we have observed this "wrong" error reporting also with the CLI, but we can't reproduce it right now. My guess is that we have to go through the whole error-catching on import logic and fix it/streamline it.