### PR TITLE
make walls a tuple of tuples on the client's side

### DIFF
--- a/pelita/layout.py
+++ b/pelita/layout.py
@@ -243,7 +243,7 @@ def parse_layout(layout_str, food=None, bots=None):
 
     # build parsed layout, ensuring walls and food are sorted
     parsed_layout = {
-        'walls': lwalls,
+        'walls': tuple(sorted(lwalls)),
         'food': sorted(lfood),
         'bots': lbots,
         'shape': (width, height)

--- a/pelita/team.py
+++ b/pelita/team.py
@@ -26,6 +26,10 @@ def _ensure_set_tuples(set):
     """ Ensures that an iterable is a set of position tuples. """
     return {tuple(item) for item in set}
 
+def _ensure_tuple_tuples(set):
+    """ Ensures that an iterable is a tuple of position tuples. """
+    return tuple(sorted(tuple(item) for item in set))
+
 
 def create_homezones(shape):
     width, height = shape
@@ -95,7 +99,7 @@ class Team:
         self._bot_track = [[], []]
 
         # Store the walls, which are only transmitted once
-        self._walls = _ensure_set_tuples(game_state['walls'])
+        self._walls = _ensure_tuple_tuples(game_state['walls'])
 
         # Store the shape, which is only transmitted once
         self._shape = tuple(game_state['shape'])
@@ -643,7 +647,7 @@ class Bot:
         with StringIO() as out:
             out.write(header)
 
-            layout = layout_as_str(walls=bot.walls.copy(),
+            layout = layout_as_str(walls=bot.walls,
                                    food=bot.food + bot.enemy[0].food,
                                    bots=bot_positions,
                                    shape=bot.shape)

--- a/pelita/utils.py
+++ b/pelita/utils.py
@@ -295,7 +295,7 @@ def setup_test_game(*, layout, is_blue=True, round=None, score=None, seed=None,
         'name': "red" if is_blue else "blue"
     }
 
-    bot = make_bots(walls=layout['walls'].copy(),
+    bot = make_bots(walls=layout['walls'],
                     shape=layout['shape'],
                     initial_positions=initial_positions(layout['walls'], layout['shape']),
                     homezone=create_homezones(layout['shape']),

--- a/test/test_layout.py
+++ b/test/test_layout.py
@@ -64,7 +64,7 @@ def test_legal_layout():
     ewalls.update([(3, 2),(2, 3)])
     efood = sorted([(2, 1), (1, 2), (4, 3), (3, 4)])
     ebots = [(1, 3), (4, 2), (1, 4), (4, 1)]
-    assert parsed_layout['walls'] == ewalls
+    assert parsed_layout['walls'] == tuple(sorted(ewalls))
     assert parsed_layout['food'] == efood
     assert parsed_layout['bots'] == ebots
     assert parsed_layout['shape'] == (6, 6)
@@ -90,7 +90,7 @@ def test_legal_layout_with_added_items():
     ewalls.update([(3, 2),(2, 3)])
     efood = sorted([(2, 1), (1, 2), (4, 3), (3, 4)]+added_food)
     ebots = [(1, 3), (4, 2), (1, 4), (4, 1)]
-    assert parsed_layout['walls'] == ewalls
+    assert parsed_layout['walls'] == tuple(sorted(ewalls))
     assert parsed_layout['food'] == efood
     assert parsed_layout['bots'] == ebots
     assert parsed_layout['shape'] == (6, 6)


### PR DESCRIPTION
This makes the usage of walls for client code more predictable and allow for fully reproducible games. Given that bot.walls is actually cached, I don't think there are any relevant implication with respect to speed (see #708).

Fixes: #760 