### PR TITLE
On (at least) Debian, tkinter is not installed by default

### DIFF
--- a/pelita/ui/tk_canvas.py
+++ b/pelita/ui/tk_canvas.py
@@ -3,7 +3,19 @@ import time
 
 import zmq
 
-import tkinter
+try:
+    import tkinter
+except ImportError:
+    # if we are on linux, we suggest to install the python3-tk package
+    import platform
+    if 'Linux' in platform.platform():
+        message = '\nYour Python installation is missing tkinter\n\n'
+        if platform.freedesktop_os_release()['ID'] == 'debian':
+            message += 'Please install the python3-tk package'
+        else:
+            message += 'Please install the python3-tkinter package'
+        raise Exception(message)
+
 import tkinter.font
 
 from ..game import next_round_turn


### PR DESCRIPTION
On (at least) Debian, tkinter is not installed by default, so let's fail with an informative message for the user. If the Linux OS is not Debian-based, the package to install has a different name. I am not sure if non-Debian distributions do not install tkinter by default either.