### PR TITLE
Improved Pelita server mode

### DIFF
--- a/pelita/game.py
+++ b/pelita/game.py
@@ -570,7 +570,8 @@ def prepare_bot_state(game_state, idx=None):
         'enemy': enemy_state,
         'round': game_state['round'],
         'bot_turn': bot_turn,
-        'timeout_length': game_state['timeout_length']
+        'timeout_length': game_state['timeout_length'],
+        'max_rounds': game_state['max_rounds'],
     }
 
     if bot_initialization:

--- a/pelita/game.py
+++ b/pelita/game.py
@@ -228,7 +228,7 @@ def setup_viewers(viewers=None, options=None, print_result=True):
             viewer_state['viewers'].append(ReplayWriter(open(viewer[1], 'w')))
         elif viewer in ('tk', 'tk-no-sync'):
             if not zmq_publisher:
-                zmq_publisher = ZMQPublisher(address='tcp://127.0.0.1:*')
+                zmq_publisher = ZMQPublisher(address='tcp://127.0.0.1')
                 viewer_state['viewers'].append(zmq_publisher)
             if viewer == 'tk':
                 viewer_state['controller'] = setup_controller()

--- a/pelita/game.py
+++ b/pelita/game.py
@@ -506,12 +506,18 @@ def prepare_bot_state(game_state, idx=None):
     """
 
     bot_initialization = game_state.get('turn') is None and idx is not None
+    bot_finalization = game_state.get('turn') is not None and idx is not None
 
     if bot_initialization:
         # We assume that we are in get_initial phase
         turn = idx
         bot_turn = None
         seed = game_state['rnd'].randint(0, sys.maxsize)
+    elif bot_finalization:
+        # Called for remote players in _exit
+        turn = idx
+        bot_turn = None
+        seed = None
     else:
         turn = game_state['turn']
         bot_turn = game_state['turn'] // 2
@@ -977,9 +983,10 @@ def check_exit_remote_teams(game_state):
     """ If the we are gameover, we want the remote teams to shut down. """
     if game_state['gameover']:
         _logger.info("Gameover. Telling teams to exit.")
-        for team in game_state['teams']:
+        for idx, team in enumerate(game_state['teams']):
             try:
-                team._exit()
+                team_game_state = prepare_bot_state(game_state, idx=idx)
+                team._exit(team_game_state)
             except AttributeError:
                 pass
 

--- a/pelita/network.py
+++ b/pelita/network.py
@@ -10,6 +10,10 @@ import zmq
 
 _logger = logging.getLogger(__name__)
 
+# 41736 is the word PELI(T)A when read upside down in reverse without glasses
+# The missing T stands for tcp
+PELITA_PORT = 41736
+
 ## Pelita network data structures
 
 # ControlRequest

--- a/pelita/scripts/pelita_main.py
+++ b/pelita/scripts/pelita_main.py
@@ -271,9 +271,9 @@ publisher_opt.add_argument('--publish', type=str, metavar='URL', dest='publish_t
                            help=long_help('Publish the game to this zmq socket.'))
 publisher_opt.add_argument('--no-publish', const=False, action='store_const', dest='publish_to',
                            help=long_help('Do not publish.'))
-parser.set_defaults(publish_to="tcp://127.0.0.1:*")
+parser.set_defaults(publish_to="tcp://127.0.0.1")
 
-advanced_settings.add_argument('--controller', type=str, metavar='URL', default="tcp://127.0.0.1:*",
+advanced_settings.add_argument('--controller', type=str, metavar='URL', default="tcp://127.0.0.1",
                                help=long_help('Channel for controlling the game.'))
 advanced_settings.add_argument('--external-controller', const=True, action='store_const',
                                help=long_help('Force control by an external controller.'))

--- a/pelita/scripts/pelita_main.py
+++ b/pelita/scripts/pelita_main.py
@@ -122,13 +122,18 @@ def scan_server(team_spec):
 
     console.print(f"[bold]Remote player requested. Scanning server for players.")
 
-    import json
-    teams = json.loads(socket.recv().decode('utf8'))
-    if not teams:
-        console.print("No teams found on the server :(")
-
+    WAIT_TIMEOUT = 5000
+    incoming = socket.poll(timeout=WAIT_TIMEOUT)
+    if incoming == zmq.POLLIN:
+        teams = json.loads(socket.recv().decode('utf8'))
+        if not teams:
+            console.print("No teams found on the server :(")
+            return None
+        else:
+            print("Server has the following teams available")
     else:
-        print("Server has the following teams available")
+        console.print(f"Server did not reply in {WAIT_TIMEOUT} ms.")
+        return None
 
     players = []
     for addr, team_name in teams.items():

--- a/pelita/scripts/pelita_main.py
+++ b/pelita/scripts/pelita_main.py
@@ -406,7 +406,7 @@ def main():
         elif team_spec.startswith("pelita://"):
             # check if we need to send a server scan request
             parsed_url = urlparse(team_spec)
-            if parsed_url.path == '/':
+            if parsed_url.path in ('', '/'):
                 scanned_spec = scan_server(team_spec)
                 if scanned_spec:
                     team_specs[idx] = scanned_spec

--- a/pelita/scripts/pelita_player.py
+++ b/pelita/scripts/pelita_player.py
@@ -306,7 +306,7 @@ def main(log):
         start_logging(log)
 
 
-@main.command()
+@main.command(help="Load team and connect to the specified address.")
 @click.argument('team')
 @click.argument('address')
 @click.option('--color',
@@ -317,7 +317,7 @@ def remote_game(team, address, color, silent):
     run_player(team, address, color, silent=silent)
 
 
-@main.command("check-team")
+@main.command("check-team", help="Load team and print its name.")
 @click.argument('team')
 def cli_check_team(team):
     return check_team(team)

--- a/pelita/scripts/pelita_player.py
+++ b/pelita/scripts/pelita_player.py
@@ -350,7 +350,7 @@ def zeroconf_advertise(address, port, team_specs):
             'spec': team,
             'team_name': name,
             'proto_version': 0.2,
-            'path': path,
+            'path': '/' + path,
         }
         full_name = f"{name}._pelita-player._tcp.local."
         info = zeroconf.ServiceInfo(

--- a/pelita/scripts/pelita_player.py
+++ b/pelita/scripts/pelita_player.py
@@ -26,7 +26,7 @@ def with_sys_path(dirname):
     finally:
         sys.path.remove(dirname)
 
-def run_player(team_spec, address, color=None, quiet=False, team_name_override=False, silent_bots=False):
+def run_player(team_spec, address, team_name_override=False, silent_bots=False):
     """ Creates a team from `team_spec` and runs
     a game through the zmq PAIR socket on `address`.
 
@@ -36,8 +36,6 @@ def run_player(team_spec, address, color=None, quiet=False, team_name_override=F
         path to the module that declares the team
     address : address to zmq PAIR socket
         the address of the remote team socket
-    color : string, optional
-        the color of the team (for nicer output)
 
     """
 
@@ -76,17 +74,7 @@ def run_player(team_spec, address, color=None, quiet=False, team_name_override=F
         # and general zmq disconnects
         raise
 
-    if not quiet:
-        if color == 'blue':
-            pie = '\033[94m' + 'ᗧ' + '\033[0m'
-        elif color == 'red':
-            pie = '\033[91m' + 'ᗧ' + '\033[0m'
-        else:
-            pie = 'ᗧ'
-        if pelita.game._mswindows:
-            print(f"{color} team '{team_spec}' -> '{team.team_name}'")
-        else:
-            print(f"{pie} {color} team '{team_spec}' -> '{team.team_name}'")
+    _logger.info(f"Running player '{team_spec}' ({team.team_name})")
 
     while True:
         cont = player_handle_request(socket, team, team_name_override=team_name_override, silent_bots=silent_bots)
@@ -321,13 +309,6 @@ def main(log):
 @main.command(help="Load team and connect to the specified address.")
 @click.argument('team')
 @click.argument('address')
-@click.option('--color',
-              default=None,
-              help='which color your team will have in the game')
-@click.option('--quiet',
-              is_flag=True,
-              default=False,
-              help='Do not log to command line')
 @click.option('--team-name-override',
               default=None,
               help='Override the team name')
@@ -335,8 +316,8 @@ def main(log):
               is_flag=True,
               default=False,
               help='Filter bot speak')
-def remote_game(team, address, color, quiet, team_name_override, silent_bots):
-    run_player(team, address, color, quiet=quiet, team_name_override=team_name_override, silent_bots=silent_bots)
+def remote_game(team, address, team_name_override, silent_bots):
+    run_player(team, address, team_name_override=team_name_override, silent_bots=silent_bots)
 
 
 @main.command("check-team", help="Load team and print its name.")

--- a/pelita/scripts/pelita_player.py
+++ b/pelita/scripts/pelita_player.py
@@ -1,36 +1,22 @@
 #!/usr/bin/env python3
 
 import contextlib
-from dataclasses import dataclass
 import importlib
 import json
 import logging
 from pathlib import Path
-import random
-import signal
-import subprocess
 import sys
-from urllib.parse import urlparse
 
 import click
-from rich import print as pprint
-from rich.progress import Progress
-import zeroconf
 import zmq
 
 import pelita
 from ..team import make_team
-from ..network import json_default_handler, PELITA_PORT
+from ..network import json_default_handler
 from .script_utils import start_logging
 
 _logger = logging.getLogger(__name__)
 
-
-MAX_CONNECTIONS = 100
-
-
-zeroconf.log.setLevel(logging.INFO)
-zeroconf.log.addHandler(_logger)
 
 @contextlib.contextmanager
 def with_sys_path(dirname):
@@ -39,27 +25,6 @@ def with_sys_path(dirname):
         yield
     finally:
         sys.path.remove(dirname)
-
-
-@dataclass
-class GameInfo:
-    round: int|None
-    max_rounds: int
-    my_index: int
-    my_name: str
-    my_score: int
-    enemy_name: str
-    enemy_score: int
-    finished: bool = False
-
-    def status(self):
-        plural = "s" if (self.round is not None and self.round > 1) else ""
-        finished = f"[b]Finished[/b] ({self.round} round{plural}): " if self.finished else ""
-        if self.my_index == 0:
-            return f"{finished}[u]{self.my_name} ({self.my_score})[/u] vs {self.enemy_name} ({self.enemy_score})"
-        else:
-            return f"{finished}{self.enemy_name} ({self.enemy_score}) vs [u]{self.my_name} ({self.my_score})[/u]"
-
 
 def run_player(team_spec, address, color=None, silent=False):
     """ Creates a team from `team_spec` and runs
@@ -332,222 +297,6 @@ def team_from_module(module):
     return team
 
 
-def zeroconf_advertise(address, port, team_specs):
-    parsed_url = urlparse("tcp://" + address + ":" + str(port))
-    if parsed_url.scheme != "tcp":
-        _logger.warning("Can only advertise to tcp addresses.")
-        return
-    if parsed_url.hostname == "0.0.0.0":
-        _logger.warning("Can only advertise to a specific interface.")
-        return
-
-    zc = zeroconf.Zeroconf()
-
-    for team, path in team_specs:
-        name = _check_team(team)
-
-        desc = {
-            'spec': team,
-            'team_name': name,
-            'proto_version': 0.2,
-            'path': '/' + path,
-        }
-        full_name = f"{name}._pelita-player._tcp.local."
-        info = zeroconf.ServiceInfo(
-            "_pelita-player._tcp.local.",
-            full_name,
-            parsed_addresses=[parsed_url.hostname],
-            #server='mynewserver.local',
-            port=parsed_url.port,
-            properties=desc,
-        )
-
-        print(f"Registration of service {full_name}, press Ctrl-C to exit...")
-        zc.register_service(info)
-
-
-def with_zmq_router(team_specs, address, port, *, advertise: str, session_key: str, show_progress: bool = True):
-    # TODO: Explain how ROUTER-DEALER works with ZMQ
-
-    # maps zmq dealer id to pair socket
-    dealer_pair_mapping = {}
-    # maps zmq dealer to progress bar
-    dealer_progress_mapping = {}
-    # maps pair socket to zmq dealer id
-    pair_dealer_mapping = {}
-    # maps subprocess to (dealer id, pair socket)
-    proc_dealer_mapping = {}
-
-    def cleanup(signum, frame):
-        for proc in proc_dealer_mapping:
-            proc.terminate()
-        sys.exit()
-
-    signal.signal(signal.SIGTERM, cleanup)
-
-    ctx = zmq.Context()
-    router_sock = ctx.socket(zmq.ROUTER)
-    router_sock.bind(f"tcp://{address}:{port}")
-
-    if advertise:
-        zeroconf_advertise(advertise, port, team_specs)
-
-    poll = zmq.Poller()
-    poll.register(router_sock, zmq.POLLIN)
-
-    from rich.progress import Progress, SpinnerColumn, TimeElapsedColumn
-
-    # TODO handle show_progress
-
-    with Progress(
-        SpinnerColumn(),
-        *Progress.get_default_columns(),
-        TimeElapsedColumn(),
-    ) as progress:
-
-
-        while True:
-            incoming_evts = dict(poll.poll(1000))
-            if router_sock in incoming_evts:
-                dealer_id = router_sock.recv()
-                # TODO: This should recover from failure
-                msg = router_sock.recv_json()
-                if "QUERY-SERVER" in msg:
-                    pass
-
-                elif "ADD-HOST" in msg:
-                    # check key
-                    if not msg.get('key', None) == session_key:
-                        continue
-
-                elif "RELOAD" in msg:
-                    # check key
-                    if not msg.get('key', None) == session_key:
-                        continue
-
-                elif "REQUEST" in msg:
-                    if len(proc_dealer_mapping) >= MAX_CONNECTIONS:
-                        _logger.warn("Exceeding maximum number of connections. Ignoring")
-                        continue
-
-                    requested_url = urlparse(msg['REQUEST'])
-                    progress.console.print(f"Match requested: {requested_url.path}")
-
-                    team_spec = team_specs[0][0]
-                    for spec, path in team_specs:
-                        if requested_url.path == '/' + path:
-                            team_spec = spec
-                            break
-                    else:
-                        # not found. use default but warn
-                        progress.console.print(f"Player for path {requested_url.path} not found. Using default.")
-
-                    info = GameInfo(round=None, max_rounds=None, my_index=0,
-                                    my_name="waiting", my_score=0,
-                                    enemy_name="waiting", enemy_score=0)
-                    task = progress.add_task(info.status(), total=info.max_rounds)
-                    dealer_progress_mapping[dealer_id] = (task, info)
-
-                    # incoming message is a new request
-                    pair_sock = ctx.socket(zmq.PAIR)
-                    port = pair_sock.bind_to_random_port('tcp://127.0.0.1')
-                    pair_addr = 'tcp://127.0.0.1:{}'.format(port)
-
-                    poll.register(pair_sock, zmq.POLLIN)
-
-                    num_running = len(proc_dealer_mapping)
-                    _logger.info(f"Starting match for team {team_specs}. ({num_running} already running.)")
-                    subproc = play_remote(team_spec, pair_addr, silent=show_progress)
-
-                    dealer_pair_mapping[dealer_id] = pair_sock
-                    pair_dealer_mapping[pair_sock] = dealer_id
-                    proc_dealer_mapping[subproc] = (dealer_id, pair_sock)
-
-                    assert len(dealer_pair_mapping) == len(pair_dealer_mapping)
-                elif dealer_id in dealer_pair_mapping:
-                    # incoming message refers to an existing connection
-
-                    task, info = dealer_progress_mapping[dealer_id]
-
-                    try:
-                        is_exit = msg['__action__'] == 'exit'
-                    except KeyError:
-                        is_exit = False
-
-                    if is_exit:
-                        progress.stop_task(task)
-                        progress.update(task, visible=False)
-                        info.finished = True
-                        progress.console.print(info.status())
-
-                    try:
-                        info.round = msg['__data__']['game_state']['round']
-                        info.max_rounds = msg['__data__']['game_state']['max_rounds']
-                    except KeyError:
-                        info.round = None
-
-                    if round is not None:
-                        progress.update(task, completed=info.round, total=info.max_rounds)
-
-                    try:
-                        info.my_index = msg['__data__']['game_state']['team']['team_index']
-                        info.my_name = msg['__data__']['game_state']['team']['name']
-                        info.my_score = msg['__data__']['game_state']['team']['score']
-                        info.enemy_name = msg['__data__']['game_state']['enemy']['name']
-                        info.enemy_score = msg['__data__']['game_state']['enemy']['score']
-
-                        progress.update(task, description=info.status())
-                    except KeyError:
-                        pass
-
-                    dealer_pair_mapping[dealer_id].send_json(msg)
-                else:
-                    _logger.info("Unknown incoming DEALER and not a request.")
-
-            elif len(incoming_evts):
-                # One or more of our spawned players has replied
-                for pair_sock, dealer_id in pair_dealer_mapping.items():
-                    if pair_sock in incoming_evts:
-                        msg = pair_sock.recv()
-                        # route message back
-                        router_sock.send_multipart([dealer_id, msg])
-
-            old_procs = list(proc_dealer_mapping.keys())
-            count = 0
-            for proc in old_procs:
-                if proc.poll() is not None:
-                    dealer_id, pair_sock = proc_dealer_mapping[proc]
-                    del dealer_pair_mapping[dealer_id]
-                    del pair_dealer_mapping[pair_sock]
-                    del proc_dealer_mapping[proc]
-                    count += 1
-            if count:
-                _logger.debug("Cleaned up {} process(es). ({} still running.)".format(count, len(proc_dealer_mapping)))
-
-
-def play_remote(team_spec, pair_addr, silent=False):
-    external_call = [sys.executable,
-                    '-m',
-                    'pelita.scripts.pelita_player',
-                    'remote-game',
-                    team_spec,
-                    pair_addr,
-                    *(['--silent'] if silent else []),
-                    ]
-    _logger.debug("Executing: %r", external_call)
-    sub = subprocess.Popen(external_call)
-    return sub
-
-def _check_team(team_spec):
-    external_call = [sys.executable,
-                    '-m',
-                    'pelita.scripts.pelita_player',
-                    'check-team',
-                    team_spec]
-    _logger.debug("Executing: %r", external_call)
-    res = subprocess.run(external_call, capture_output=True, text=True)
-    return res.stdout.strip()
-
 @click.group()
 @click.option('--log',
               is_flag=False, flag_value="-", default=None, metavar='LOGFILE',
@@ -555,26 +304,6 @@ def _check_team(team_spec):
 def main(log):
     if log is not None:
         start_logging(log)
-
-
-@main.command(help="bind a zmq.ROUTER socket at the given address which forks subprocesses on demand")
-@click.option('--address', default="0.0.0.0")
-@click.option('--port', default=PELITA_PORT)
-@click.option('--team', '-t', 'teams', type=(str, str), multiple=True, required=True, help="Team path")
-@click.option('--advertise', default=None, type=str,
-              help='advertise player on zeroconf')
-@click.option('--show-progress', is_flag=True, default=True)
-def remote_server(address, port, teams, advertise, show_progress):
-    for team, path in teams:
-        team_name = _check_team(team)
-        _logger.info(f"Mapping team {team} ({team_name}) to path {path}")
-
-    session_key = "".join(str(random.randint(0, 9)) for _ in range(12))
-    pprint(f"Use --session-key {session_key} to for the admin API.")
-    with_zmq_router(teams, address, port, advertise=advertise, session_key=session_key, show_progress=show_progress)
-
-    # asyncio repl …
-    # reload via zqm key
 
 
 @main.command()

--- a/pelita/scripts/pelita_player.py
+++ b/pelita/scripts/pelita_player.py
@@ -1,28 +1,35 @@
 #!/usr/bin/env python3
 
-import argparse
 import contextlib
+from dataclasses import dataclass
 import importlib
 import json
 import logging
 from pathlib import Path
+import random
 import signal
 import subprocess
 import sys
 from urllib.parse import urlparse
 
+import click
+from rich import print as pprint
+from rich.progress import Progress
 import zeroconf
 import zmq
 
 import pelita
 from ..team import make_team
-from ..network import json_default_handler
+from ..network import json_default_handler, PELITA_PORT
 from .script_utils import start_logging
 
 _logger = logging.getLogger(__name__)
 
 
-zeroconf.log.setLevel(logging.DEBUG)
+MAX_CONNECTIONS = 100
+
+
+zeroconf.log.setLevel(logging.INFO)
 zeroconf.log.addHandler(_logger)
 
 @contextlib.contextmanager
@@ -34,7 +41,27 @@ def with_sys_path(dirname):
         sys.path.remove(dirname)
 
 
-def run_player(team_spec, address, color=None):
+@dataclass
+class GameInfo:
+    round: int|None
+    max_rounds: int
+    my_index: int
+    my_name: str
+    my_score: int
+    enemy_name: str
+    enemy_score: int
+    finished: bool = False
+
+    def status(self):
+        plural = "s" if (self.round is not None and self.round > 1) else ""
+        finished = f"[b]Finished[/b] ({self.round} round{plural}): " if self.finished else ""
+        if self.my_index == 0:
+            return f"{finished}[u]{self.my_name} ({self.my_score})[/u] vs {self.enemy_name} ({self.enemy_score})"
+        else:
+            return f"{finished}{self.enemy_name} ({self.enemy_score}) vs [u]{self.my_name} ({self.my_score})[/u]"
+
+
+def run_player(team_spec, address, color=None, silent=False):
     """ Creates a team from `team_spec` and runs
     a game through the zmq PAIR socket on `address`.
 
@@ -84,16 +111,17 @@ def run_player(team_spec, address, color=None):
         # and general zmq disconnects
         raise
 
-    if color == 'blue':
-        pie = '\033[94m' + 'ᗧ' + '\033[0m'
-    elif color == 'red':
-        pie = '\033[91m' + 'ᗧ' + '\033[0m'
-    else:
-        pie = 'ᗧ'
-    if pelita.game._mswindows:
-        print(f"{color} team '{team_spec}' -> '{team.team_name}'")
-    else:
-        print(f"{pie} {color} team '{team_spec}' -> '{team.team_name}'")
+    if not silent:
+        if color == 'blue':
+            pie = '\033[94m' + 'ᗧ' + '\033[0m'
+        elif color == 'red':
+            pie = '\033[91m' + 'ᗧ' + '\033[0m'
+        else:
+            pie = 'ᗧ'
+        if pelita.game._mswindows:
+            print(f"{color} team '{team_spec}' -> '{team.team_name}'")
+        else:
+            print(f"{pie} {color} team '{team_spec}' -> '{team.team_name}'")
 
     while True:
         cont = player_handle_request(socket, team)
@@ -294,18 +322,18 @@ def team_from_module(module):
     `module` and returns a team.
     """
     # look for a new-style team
-    move = getattr(module, "move")
-    name = getattr(module, "TEAM_NAME")
+    move = module.move
+    name = module.TEAM_NAME
     if not callable(move):
         raise TypeError("move is not a function")
-    if type(name) is not str:
+    if not isinstance(name, str):
         raise TypeError("TEAM_NAME is not a string")
     team, _ = make_team(move, team_name=name)
     return team
 
 
-def zeroconf_advertise(address, team_spec):
-    parsed_url = urlparse(address)
+def zeroconf_advertise(address, port, team_specs):
+    parsed_url = urlparse("tcp://" + address + ":" + str(port))
     if parsed_url.scheme != "tcp":
         _logger.warning("Can only advertise to tcp addresses.")
         return
@@ -313,34 +341,41 @@ def zeroconf_advertise(address, team_spec):
         _logger.warning("Can only advertise to a specific interface.")
         return
 
-    # TODO: This should only be done once
-    team = load_team(team_spec)
-    name = team.team_name
-
-    desc = {
-        'spec': team_spec,
-        'team_name': name,
-        'proto_version': 0.1
-        }
-    info = zeroconf.ServiceInfo(
-        "_pelita-player._tcp.local.",
-        f"{name}._pelita-player._tcp.local.",
-        parsed_addresses=[parsed_url.hostname],
-        server='mynewserver.local',
-        port=parsed_url.port,
-        properties=desc,
-    )
-
-    # protocol versoin ...
     zc = zeroconf.Zeroconf()
-    zc.engine._listen_socket
-    print("Registration of a service, press Ctrl-C to exit...")
-    zc.register_service(info)
+
+    for team, path in team_specs:
+        name = _check_team(team)
+
+        desc = {
+            'spec': team,
+            'team_name': name,
+            'proto_version': 0.2,
+            'path': path,
+        }
+        full_name = f"{name}._pelita-player._tcp.local."
+        info = zeroconf.ServiceInfo(
+            "_pelita-player._tcp.local.",
+            full_name,
+            parsed_addresses=[parsed_url.hostname],
+            #server='mynewserver.local',
+            port=parsed_url.port,
+            properties=desc,
+        )
+
+        print(f"Registration of service {full_name}, press Ctrl-C to exit...")
+        zc.register_service(info)
 
 
-def with_zmq_router(team_spec, address, *, advertise: bool):
+def with_zmq_router(team_specs, address, port, *, advertise: bool, session_key: str, show_progress: bool = True):
+    # TODO: Explain how ROUTER-DEALER works with ZMQ
+
+    # maps zmq dealer id to pair socket
     dealer_pair_mapping = {}
+    # maps zmq dealer to progress bar
+    dealer_progress_mapping = {}
+    # maps pair socket to zmq dealer id
     pair_dealer_mapping = {}
+    # maps subprocess to (dealer id, pair socket)
     proc_dealer_mapping = {}
 
     def cleanup(signum, frame):
@@ -351,93 +386,216 @@ def with_zmq_router(team_spec, address, *, advertise: bool):
     signal.signal(signal.SIGTERM, cleanup)
 
     ctx = zmq.Context()
-    sock = ctx.socket(zmq.ROUTER)
-    sock.bind(address)
+    router_sock = ctx.socket(zmq.ROUTER)
+    router_sock.bind(f"tcp://{address}:{port}")
 
     if advertise:
-        zeroconf_advertise(address, team_spec)
+        zeroconf_advertise(address, port, team_specs)
 
     poll = zmq.Poller()
-    poll.register(sock, zmq.POLLIN)
+    poll.register(router_sock, zmq.POLLIN)
 
-    while True:
-        evts = dict(poll.poll(1000))
-        if sock in evts:
-            id_ = sock.recv()
-            msg = sock.recv_json()
-            if "REQUEST" in msg:
-                pair_sock = ctx.socket(zmq.PAIR)
-                port = pair_sock.bind_to_random_port('tcp://127.0.0.1')
-                pair_addr = 'tcp://127.0.0.1:{}'.format(port)
+    from rich.progress import Progress, SpinnerColumn, TimeElapsedColumn
 
-                poll.register(pair_sock, zmq.POLLIN)
+    # TODO handle show_progress
 
-                _logger.info("Starting match for team {}. ({} already running.)".format(team_spec, len(proc_dealer_mapping)))
-                sub = play_remote(team_spec, pair_addr)
-
-                dealer_pair_mapping[id_] = pair_sock
-                pair_dealer_mapping[pair_sock] = id_
-                proc_dealer_mapping[sub] = (id_, pair_sock)
-
-                assert len(dealer_pair_mapping) == len(pair_dealer_mapping)
-            elif id_ in dealer_pair_mapping:
-                dealer_pair_mapping[id_].send_json(msg)
-            else:
-                _logger.info("Unknown incoming DEALER and not a request.")
-
-        elif len(evts):
-            for pair_sock, id_ in pair_dealer_mapping.items():
-                if pair_sock in evts:
-                    msg = pair_sock.recv()
-                    sock.send_multipart([id_, msg])
-
-        old_procs = list(proc_dealer_mapping.keys())
-        count = 0
-        for proc in old_procs:
-            if proc.poll() is not None:
-                id_, pair_sock = proc_dealer_mapping[proc]
-                del dealer_pair_mapping[id_]
-                del pair_dealer_mapping[pair_sock]
-                del proc_dealer_mapping[proc]
-                count += 1
-        if count:
-            _logger.debug("Cleaned up {} process(es). ({} still running.)".format(count, len(proc_dealer_mapping)))
+    with Progress(
+        SpinnerColumn(),
+        *Progress.get_default_columns(),
+        TimeElapsedColumn(),
+    ) as progress:
 
 
-def play_remote(team_spec, pair_addr):
+        while True:
+            incoming_evts = dict(poll.poll(1000))
+            if router_sock in incoming_evts:
+                dealer_id = router_sock.recv()
+                # TODO: This should recover from failure
+                msg = router_sock.recv_json()
+                if "QUERY-SERVER" in msg:
+                    pass
+
+                elif "ADD-HOST" in msg:
+                    # check key
+                    if not msg.get('key', None) == session_key:
+                        continue
+
+                elif "RELOAD" in msg:
+                    # check key
+                    if not msg.get('key', None) == session_key:
+                        continue
+
+                elif "REQUEST" in msg:
+                    if len(proc_dealer_mapping) >= MAX_CONNECTIONS:
+                        _logger.warn("Exceeding maximum number of connections. Ignoring")
+                        continue
+
+                    requested_url = urlparse(msg['REQUEST'])
+                    progress.console.print(f"Match requested: {requested_url.path}")
+
+                    team_spec = team_specs[0][0]
+                    for spec, path in team_specs:
+                        if requested_url.path == '/' + path:
+                            team_spec = spec
+                            break
+                    else:
+                        # not found. use default but warn
+                        progress.console.print(f"Player for path {requested_url.path} not found. Using default.")
+
+                    info = GameInfo(round=None, max_rounds=None, my_index=0,
+                                    my_name="waiting", my_score=0,
+                                    enemy_name="waiting", enemy_score=0)
+                    task = progress.add_task(info.status(), total=info.max_rounds)
+                    dealer_progress_mapping[dealer_id] = (task, info)
+
+                    # incoming message is a new request
+                    pair_sock = ctx.socket(zmq.PAIR)
+                    port = pair_sock.bind_to_random_port('tcp://127.0.0.1')
+                    pair_addr = 'tcp://127.0.0.1:{}'.format(port)
+
+                    poll.register(pair_sock, zmq.POLLIN)
+
+                    num_running = len(proc_dealer_mapping)
+                    _logger.info(f"Starting match for team {team_specs}. ({num_running} already running.)")
+                    subproc = play_remote(team_spec, pair_addr, silent=show_progress)
+
+                    dealer_pair_mapping[dealer_id] = pair_sock
+                    pair_dealer_mapping[pair_sock] = dealer_id
+                    proc_dealer_mapping[subproc] = (dealer_id, pair_sock)
+
+                    assert len(dealer_pair_mapping) == len(pair_dealer_mapping)
+                elif dealer_id in dealer_pair_mapping:
+                    # incoming message refers to an existing connection
+
+                    task, info = dealer_progress_mapping[dealer_id]
+
+                    try:
+                        is_exit = msg['__action__'] == 'exit'
+                    except KeyError:
+                        is_exit = False
+
+                    if is_exit:
+                        progress.stop_task(task)
+                        progress.update(task, visible=False)
+                        info.finished = True
+                        progress.console.print(info.status())
+
+                    try:
+                        info.round = msg['__data__']['game_state']['round']
+                        info.max_rounds = msg['__data__']['game_state']['max_rounds']
+                    except KeyError:
+                        info.round = None
+
+                    if round is not None:
+                        progress.update(task, completed=info.round, total=info.max_rounds)
+
+                    try:
+                        info.my_index = msg['__data__']['game_state']['team']['team_index']
+                        info.my_name = msg['__data__']['game_state']['team']['name']
+                        info.my_score = msg['__data__']['game_state']['team']['score']
+                        info.enemy_name = msg['__data__']['game_state']['enemy']['name']
+                        info.enemy_score = msg['__data__']['game_state']['enemy']['score']
+
+                        progress.update(task, description=info.status())
+                    except KeyError:
+                        pass
+
+                    dealer_pair_mapping[dealer_id].send_json(msg)
+                else:
+                    _logger.info("Unknown incoming DEALER and not a request.")
+
+            elif len(incoming_evts):
+                # One or more of our spawned players has replied
+                for pair_sock, dealer_id in pair_dealer_mapping.items():
+                    if pair_sock in incoming_evts:
+                        msg = pair_sock.recv()
+                        # route message back
+                        router_sock.send_multipart([dealer_id, msg])
+
+            old_procs = list(proc_dealer_mapping.keys())
+            count = 0
+            for proc in old_procs:
+                if proc.poll() is not None:
+                    dealer_id, pair_sock = proc_dealer_mapping[proc]
+                    del dealer_pair_mapping[dealer_id]
+                    del pair_dealer_mapping[pair_sock]
+                    del proc_dealer_mapping[proc]
+                    count += 1
+            if count:
+                _logger.debug("Cleaned up {} process(es). ({} still running.)".format(count, len(proc_dealer_mapping)))
+
+
+def play_remote(team_spec, pair_addr, silent=False):
     external_call = [sys.executable,
                     '-m',
                     'pelita.scripts.pelita_player',
+                    'remote-game',
                     team_spec,
-                    pair_addr]
+                    pair_addr,
+                    *(['--silent'] if silent else []),
+                    ]
     _logger.debug("Executing: %r", external_call)
     sub = subprocess.Popen(external_call)
     return sub
 
+def _check_team(team_spec):
+    external_call = [sys.executable,
+                    '-m',
+                    'pelita.scripts.pelita_player',
+                    'check-team',
+                    team_spec]
+    _logger.debug("Executing: %r", external_call)
+    res = subprocess.run(external_call, capture_output=True, text=True)
+    return res.stdout.strip()
 
-def main():
-    parser = argparse.ArgumentParser(description="Runs a Python pelita module.")
-    parser.add_argument('--log', help='print debugging log information to LOGFILE (default \'stderr\')',
-                        metavar='LOGFILE', default=argparse.SUPPRESS, nargs='?')
-    parser.add_argument('--remote', help='bind to a zmq.ROUTER socket at the given address which forks subprocesses on demand',
-                        action='store_const', const=True)
-    parser.add_argument('--advertise', help='advertise player on zeroconf',
-                        action='store_const', const=True)
-    parser.add_argument('--color', help='which color your team will have in the game', default=None)
-    parser.add_argument('team')
-    parser.add_argument('address')
+@click.group()
+@click.option('--log',
+              is_flag=False, flag_value="-", default=None, metavar='LOGFILE',
+              help="print debugging log information to LOGFILE (default 'stderr')")
+def main(log):
+    if log is not None:
+        start_logging(log)
 
-    args = parser.parse_args()
 
-    try:
-        start_logging(args.log)
-    except AttributeError:
-        pass
+@main.command(help="bind a zmq.ROUTER socket at the given address which forks subprocesses on demand")
+@click.option('--address', default="0.0.0.0")
+@click.option('--port', default=PELITA_PORT)
+@click.option('--team', '-t', 'teams', type=(str, str), multiple=True, required=True, help="Team path")
+@click.option('--advertise',
+              is_flag=True, default=False,
+              help='advertise player on zeroconf')
+@click.option('--show-progress', is_flag=True, default=True)
+def remote_server(address, port, teams, advertise, show_progress):
+    for team, path in teams:
+        team_name = _check_team(team)
+        _logger.info(f"Mapping team {team} ({team_name}) to path {path}")
 
-    if args.remote:
-        with_zmq_router(args.team, args.address, advertise=args.advertise)
-    else:
-        run_player(args.team, args.address, args.color)
+    session_key = "".join(str(random.randint(0, 9)) for _ in range(12))
+    pprint(f"Use --session-key {session_key} to for the admin API.")
+    with_zmq_router(teams, address, port, advertise=advertise, session_key=session_key, show_progress=show_progress)
+
+    # asyncio repl …
+    # reload via zqm key
+
+
+@main.command()
+@click.argument('team')
+@click.argument('address')
+@click.option('--color',
+              default=None,
+              help='which color your team will have in the game')
+@click.option('--silent', is_flag=True, default=False)
+def remote_game(team, address, color, silent):
+    run_player(team, address, color, silent=silent)
+
+
+@main.command("check-team")
+@click.argument('team')
+def cli_check_team(team):
+    return check_team(team)
+
+def check_team(team):
+    print(load_team(team).team_name)
 
 
 if __name__ == '__main__':

--- a/pelita/scripts/pelita_player.py
+++ b/pelita/scripts/pelita_player.py
@@ -366,7 +366,7 @@ def zeroconf_advertise(address, port, team_specs):
         zc.register_service(info)
 
 
-def with_zmq_router(team_specs, address, port, *, advertise: bool, session_key: str, show_progress: bool = True):
+def with_zmq_router(team_specs, address, port, *, advertise: str, session_key: str, show_progress: bool = True):
     # TODO: Explain how ROUTER-DEALER works with ZMQ
 
     # maps zmq dealer id to pair socket
@@ -390,7 +390,7 @@ def with_zmq_router(team_specs, address, port, *, advertise: bool, session_key: 
     router_sock.bind(f"tcp://{address}:{port}")
 
     if advertise:
-        zeroconf_advertise(address, port, team_specs)
+        zeroconf_advertise(advertise, port, team_specs)
 
     poll = zmq.Poller()
     poll.register(router_sock, zmq.POLLIN)
@@ -561,8 +561,7 @@ def main(log):
 @click.option('--address', default="0.0.0.0")
 @click.option('--port', default=PELITA_PORT)
 @click.option('--team', '-t', 'teams', type=(str, str), multiple=True, required=True, help="Team path")
-@click.option('--advertise',
-              is_flag=True, default=False,
+@click.option('--advertise', default=None, type=str,
               help='advertise player on zeroconf')
 @click.option('--show-progress', is_flag=True, default=True)
 def remote_server(address, port, teams, advertise, show_progress):

--- a/pelita/scripts/pelita_server.py
+++ b/pelita/scripts/pelita_server.py
@@ -303,6 +303,8 @@ def with_zmq_router(team_specs, address, port, *, advertise: str, session_key: s
             for process_info in list(connection_map.values()):
                 # check if the process has terminated
                 if process_info.proc.poll() is not None:
+                    # We need to unregister the socket or else the polling will take longer and longer
+                    poll.unregister(process_info.pair_socket)
                     del connection_map[process_info.dealer_id]
                     count += 1
             if count:

--- a/pelita/scripts/pelita_server.py
+++ b/pelita/scripts/pelita_server.py
@@ -479,7 +479,7 @@ def configure(ctx, param, filename):
 
     ctx.default_map = settings
 
-@main.command(help="Run pelita server with given players")
+@main.command(help="Start a pelita server with given players")
 @click.option('--config',
               default=None,
               type=click.File('r'),
@@ -496,6 +496,16 @@ def configure(ctx, param, filename):
 @click.option('--max-connections', default=DEFAULT_MAX_CONNECTIONS, show_default=True,
               help='Maximum number of connections that we want to handle')
 def remote_server(address, port, teams, advertise, max_connections):
+    # When used with --config the following yaml format is expected:
+    #
+    #    address: 0.0.0.0
+    #    port: 41736
+    #    teams:
+    #    - name: abc
+    #      spec: pelita/player/StoppingPlayer
+    #    - name: def
+    #      spec: path/to/module
+
     session_key = "".join(str(random.randint(0, 9)) for _ in range(12))
     pprint(f"Use --session-key {session_key} to for the admin API.")
 

--- a/pelita/scripts/pelita_server.py
+++ b/pelita/scripts/pelita_server.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+
+from dataclasses import dataclass
+import logging
+import random
+import signal
+import subprocess
+import sys
+from urllib.parse import urlparse
+
+import click
+from rich import print as pprint
+from rich.progress import Progress
+import zeroconf
+import zmq
+
+from ..network import PELITA_PORT
+from .script_utils import start_logging
+
+_logger = logging.getLogger(__name__)
+
+zeroconf.log.setLevel(logging.INFO)
+zeroconf.log.addHandler(_logger)
+
+MAX_CONNECTIONS = 100
+
+@dataclass
+class GameInfo:
+    round: int|None
+    max_rounds: int
+    my_index: int
+    my_name: str
+    my_score: int
+    enemy_name: str
+    enemy_score: int
+    finished: bool = False
+
+    def status(self):
+        plural = "s" if (self.round is not None and self.round > 1) else ""
+        finished = f"[b]Finished[/b] ({self.round} round{plural}): " if self.finished else ""
+        if self.my_index == 0:
+            return f"{finished}[u]{self.my_name} ({self.my_score})[/u] vs {self.enemy_name} ({self.enemy_score})"
+        else:
+            return f"{finished}{self.enemy_name} ({self.enemy_score}) vs [u]{self.my_name} ({self.my_score})[/u]"
+
+
+def zeroconf_advertise(address, port, team_specs):
+    parsed_url = urlparse("tcp://" + address + ":" + str(port))
+    if parsed_url.scheme != "tcp":
+        _logger.warning("Can only advertise to tcp addresses.")
+        return
+    if parsed_url.hostname == "0.0.0.0":
+        _logger.warning("Can only advertise to a specific interface.")
+        return
+
+    zc = zeroconf.Zeroconf()
+
+    for team, path in team_specs:
+        name = _check_team(team)
+
+        desc = {
+            'spec': team,
+            'team_name': name,
+            'proto_version': 0.2,
+            'path': '/' + path,
+        }
+        full_name = f"{name}._pelita-player._tcp.local."
+        info = zeroconf.ServiceInfo(
+            "_pelita-player._tcp.local.",
+            full_name,
+            parsed_addresses=[parsed_url.hostname],
+            #server='mynewserver.local',
+            port=parsed_url.port,
+            properties=desc,
+        )
+
+        print(f"Registration of service {full_name}, press Ctrl-C to exit...")
+        zc.register_service(info)
+
+
+def with_zmq_router(team_specs, address, port, *, advertise: str, session_key: str, show_progress: bool = True):
+    # TODO: Explain how ROUTER-DEALER works with ZMQ
+
+    # maps zmq dealer id to pair socket
+    dealer_pair_mapping = {}
+    # maps zmq dealer to progress bar
+    dealer_progress_mapping = {}
+    # maps pair socket to zmq dealer id
+    pair_dealer_mapping = {}
+    # maps subprocess to (dealer id, pair socket)
+    proc_dealer_mapping = {}
+
+    def cleanup(signum, frame):
+        for proc in proc_dealer_mapping:
+            proc.terminate()
+        sys.exit()
+
+    signal.signal(signal.SIGTERM, cleanup)
+
+    ctx = zmq.Context()
+    router_sock = ctx.socket(zmq.ROUTER)
+    router_sock.bind(f"tcp://{address}:{port}")
+
+    if advertise:
+        zeroconf_advertise(advertise, port, team_specs)
+
+    poll = zmq.Poller()
+    poll.register(router_sock, zmq.POLLIN)
+
+    from rich.progress import Progress, SpinnerColumn, TimeElapsedColumn
+
+    # TODO handle show_progress
+
+    with Progress(
+        SpinnerColumn(),
+        *Progress.get_default_columns(),
+        TimeElapsedColumn(),
+    ) as progress:
+
+
+        while True:
+            incoming_evts = dict(poll.poll(1000))
+            if router_sock in incoming_evts:
+                dealer_id = router_sock.recv()
+                # TODO: This should recover from failure
+                msg = router_sock.recv_json()
+                if "QUERY-SERVER" in msg:
+                    pass
+
+                elif "ADD-HOST" in msg:
+                    # check key
+                    if not msg.get('key', None) == session_key:
+                        continue
+
+                elif "RELOAD" in msg:
+                    # check key
+                    if not msg.get('key', None) == session_key:
+                        continue
+
+                elif "REQUEST" in msg:
+                    if len(proc_dealer_mapping) >= MAX_CONNECTIONS:
+                        _logger.warn("Exceeding maximum number of connections. Ignoring")
+                        continue
+
+                    requested_url = urlparse(msg['REQUEST'])
+                    progress.console.print(f"Match requested: {requested_url.path}")
+
+                    team_spec = team_specs[0][0]
+                    for spec, path in team_specs:
+                        if requested_url.path == '/' + path:
+                            team_spec = spec
+                            break
+                    else:
+                        # not found. use default but warn
+                        progress.console.print(f"Player for path {requested_url.path} not found. Using default.")
+
+                    info = GameInfo(round=None, max_rounds=None, my_index=0,
+                                    my_name="waiting", my_score=0,
+                                    enemy_name="waiting", enemy_score=0)
+                    task = progress.add_task(info.status(), total=info.max_rounds)
+                    dealer_progress_mapping[dealer_id] = (task, info)
+
+                    # incoming message is a new request
+                    pair_sock = ctx.socket(zmq.PAIR)
+                    port = pair_sock.bind_to_random_port('tcp://127.0.0.1')
+                    pair_addr = 'tcp://127.0.0.1:{}'.format(port)
+
+                    poll.register(pair_sock, zmq.POLLIN)
+
+                    num_running = len(proc_dealer_mapping)
+                    _logger.info(f"Starting match for team {team_specs}. ({num_running} already running.)")
+                    subproc = play_remote(team_spec, pair_addr, silent=show_progress)
+
+                    dealer_pair_mapping[dealer_id] = pair_sock
+                    pair_dealer_mapping[pair_sock] = dealer_id
+                    proc_dealer_mapping[subproc] = (dealer_id, pair_sock)
+
+                    assert len(dealer_pair_mapping) == len(pair_dealer_mapping)
+                elif dealer_id in dealer_pair_mapping:
+                    # incoming message refers to an existing connection
+
+                    task, info = dealer_progress_mapping[dealer_id]
+
+                    try:
+                        is_exit = msg['__action__'] == 'exit'
+                    except KeyError:
+                        is_exit = False
+
+                    if is_exit:
+                        progress.stop_task(task)
+                        progress.update(task, visible=False)
+                        info.finished = True
+                        progress.console.print(info.status())
+
+                    try:
+                        info.round = msg['__data__']['game_state']['round']
+                        info.max_rounds = msg['__data__']['game_state']['max_rounds']
+                    except KeyError:
+                        info.round = None
+
+                    if round is not None:
+                        progress.update(task, completed=info.round, total=info.max_rounds)
+
+                    try:
+                        info.my_index = msg['__data__']['game_state']['team']['team_index']
+                        info.my_name = msg['__data__']['game_state']['team']['name']
+                        info.my_score = msg['__data__']['game_state']['team']['score']
+                        info.enemy_name = msg['__data__']['game_state']['enemy']['name']
+                        info.enemy_score = msg['__data__']['game_state']['enemy']['score']
+
+                        progress.update(task, description=info.status())
+                    except KeyError:
+                        pass
+
+                    dealer_pair_mapping[dealer_id].send_json(msg)
+                else:
+                    _logger.info("Unknown incoming DEALER and not a request.")
+
+            elif len(incoming_evts):
+                # One or more of our spawned players has replied
+                for pair_sock, dealer_id in pair_dealer_mapping.items():
+                    if pair_sock in incoming_evts:
+                        msg = pair_sock.recv()
+                        # route message back
+                        router_sock.send_multipart([dealer_id, msg])
+
+            old_procs = list(proc_dealer_mapping.keys())
+            count = 0
+            for proc in old_procs:
+                if proc.poll() is not None:
+                    dealer_id, pair_sock = proc_dealer_mapping[proc]
+                    del dealer_pair_mapping[dealer_id]
+                    del pair_dealer_mapping[pair_sock]
+                    del proc_dealer_mapping[proc]
+                    count += 1
+            if count:
+                _logger.debug("Cleaned up {} process(es). ({} still running.)".format(count, len(proc_dealer_mapping)))
+
+
+def play_remote(team_spec, pair_addr, silent=False):
+    external_call = [sys.executable,
+                    '-m',
+                    'pelita.scripts.pelita_player',
+                    'remote-game',
+                    team_spec,
+                    pair_addr,
+                    *(['--silent'] if silent else []),
+                    ]
+    _logger.debug("Executing: %r", external_call)
+    sub = subprocess.Popen(external_call)
+    return sub
+
+def _check_team(team_spec):
+    external_call = [sys.executable,
+                    '-m',
+                    'pelita.scripts.pelita_player',
+                    'check-team',
+                    team_spec]
+    _logger.debug("Executing: %r", external_call)
+    res = subprocess.run(external_call, capture_output=True, text=True)
+    return res.stdout.strip()
+
+@click.group()
+@click.option('--log',
+              is_flag=False, flag_value="-", default=None, metavar='LOGFILE',
+              help="print debugging log information to LOGFILE (default 'stderr')")
+def main(log):
+    if log is not None:
+        start_logging(log)
+
+
+@main.command(help="bind a zmq.ROUTER socket at the given address which forks subprocesses on demand")
+@click.option('--address', default="0.0.0.0")
+@click.option('--port', default=PELITA_PORT)
+@click.option('--team', '-t', 'teams', type=(str, str), multiple=True, required=True, help="Team path")
+@click.option('--advertise', default=None, type=str,
+              help='advertise player on zeroconf')
+@click.option('--show-progress', is_flag=True, default=True)
+def remote_server(address, port, teams, advertise, show_progress):
+    for team, path in teams:
+        team_name = _check_team(team)
+        _logger.info(f"Mapping team {team} ({team_name}) to path {path}")
+
+    session_key = "".join(str(random.randint(0, 9)) for _ in range(12))
+    pprint(f"Use --session-key {session_key} to for the admin API.")
+    with_zmq_router(teams, address, port, advertise=advertise, session_key=session_key, show_progress=show_progress)
+
+    # asyncio repl …
+    # reload via zqm key
+
+if __name__ == '__main__':
+    main()

--- a/pelita/scripts/pelita_server.py
+++ b/pelita/scripts/pelita_server.py
@@ -432,19 +432,18 @@ def run_team_in_subprocess(ctx, team_spec, silent_bots=False):
     port = pair_sock.bind_to_random_port('tcp://127.0.0.1')
     pair_addr = 'tcp://127.0.0.1:{}'.format(port)
 
-    subproc = play_remote(team_spec, pair_addr, quiet=True, silent_bots=silent_bots)
+    subproc = play_remote(team_spec, pair_addr, silent_bots=silent_bots)
 
     return subproc, pair_sock
 
 # TODO: This could optionally run in a sandbox (systemd-run)
-def play_remote(team_spec, pair_addr, quiet=False, silent_bots=False):
+def play_remote(team_spec, pair_addr, silent_bots=False):
     external_call = [sys.executable,
                     '-m',
                     'pelita.scripts.pelita_player',
                     'remote-game',
                     team_spec,
                     pair_addr,
-                    *(['--quiet'] if quiet else []),
                     *(['--silent-bots'] if silent_bots else []),
                     ]
     _logger.debug("Executing: %r", external_call)

--- a/pelita/scripts/pelita_server.py
+++ b/pelita/scripts/pelita_server.py
@@ -6,6 +6,7 @@ import random
 import signal
 import subprocess
 import sys
+from typing import Optional
 from urllib.parse import urlparse
 
 import click
@@ -26,7 +27,7 @@ MAX_CONNECTIONS = 100
 
 @dataclass
 class GameInfo:
-    round: int|None
+    round: Optional[int]
     max_rounds: int
     my_index: int
     my_name: str

--- a/pelita/scripts/pelita_server.py
+++ b/pelita/scripts/pelita_server.py
@@ -38,12 +38,14 @@ class GameInfo:
     finished: bool = False
 
     def status(self):
-        plural = "s" if (self.round is not None and self.round > 1) else ""
-        finished = f"[b]Finished[/b] ({self.round} round{plural}): " if self.finished else ""
+        plural = "" if self.round == 1 else "s"
+        finished = f"[b]Finished[/b] ({self.round if self.round is not None else '-'} round{plural}): " if self.finished else ""
+        my_name = self.my_name or "[dim]unknown[/dim]"
+        enemy_name = self.enemy_name or "[dim]unknown[/dim]"
         if self.my_index == 0:
-            return f"{finished}[u]{self.my_name} ({self.my_score})[/u] vs {self.enemy_name} ({self.enemy_score})"
+            return f"{finished}[u]{my_name}[/u] ({self.my_score}) vs {enemy_name} ({self.enemy_score})"
         else:
-            return f"{finished}{self.enemy_name} ({self.enemy_score}) vs [u]{self.my_name} ({self.my_score})[/u]"
+            return f"{finished}{enemy_name} ({self.enemy_score}) vs [u]{my_name}[/u] ({self.my_score})"
 
 def zeroconf_register(zc, address, port, team_spec, path, print=print):
     parsed_url = urlparse("tcp://" + address + ":" + str(port))

--- a/pelita/scripts/pelita_server.py
+++ b/pelita/scripts/pelita_server.py
@@ -14,7 +14,7 @@ from weakref import WeakValueDictionary
 
 import click
 from rich import print as pprint
-from rich.progress import Progress, SpinnerColumn, TaskProgressColumn, BarColumn, TextColumn, TimeElapsedColumn, Task
+from rich.progress import Progress, SpinnerColumn, MofNCompleteColumn, BarColumn, TextColumn, TimeElapsedColumn, Task
 import zeroconf
 import zmq
 
@@ -289,7 +289,7 @@ class PelitaServer:
             SpinnerColumn(),
             TextColumn("[progress.description]{task.description}"),
             BarColumn(),
-            TaskProgressColumn(),
+            MofNCompleteColumn(),
             TimeElapsedColumn(),
         ) as progress:
 

--- a/pelita/scripts/pelita_server.py
+++ b/pelita/scripts/pelita_server.py
@@ -285,7 +285,7 @@ def main(log):
         start_logging(log)
 
 
-@main.command(help="bind a zmq.ROUTER socket at the given address which forks subprocesses on demand")
+@main.command(help="Run pelita server with given players")
 @click.option('--address', default="0.0.0.0")
 @click.option('--port', default=PELITA_PORT)
 @click.option('--team', '-t', 'teams', type=(str, str), multiple=True, required=True, help="Team path")

--- a/pelita/scripts/pelita_server.py
+++ b/pelita/scripts/pelita_server.py
@@ -106,7 +106,7 @@ def zeroconf_deregister(zc: zeroconf.Zeroconf, info: zeroconf.ServiceInfo):
     zc.unregister_service(info)
 
 def with_zmq_router(team_specs, address, port, *, advertise: str, session_key: str,
-                    max_connections: int, show_progress: bool = True):
+                    max_connections: int):
     # TODO: Explain how ROUTER-DEALER works with ZMQ
 
     # maps socket/process/game data
@@ -143,8 +143,6 @@ def with_zmq_router(team_specs, address, port, *, advertise: str, session_key: s
 
     poll = zmq.Poller()
     poll.register(router_sock, zmq.POLLIN)
-
-    # TODO handle show_progress
 
     with Progress(
         SpinnerColumn(),
@@ -302,7 +300,7 @@ def with_zmq_router(team_specs, address, port, *, advertise: str, session_key: s
 
                             num_running = len(connection_map)
                             _logger.info(f"Starting match for team {team_specs}. ({num_running} already running.)")
-                            subproc = play_remote(team_spec, pair_addr, silent=show_progress)
+                            subproc = play_remote(team_spec, pair_addr, silent=True)
 
                             process_info = ProcessInfo(proc=subproc, task=task, info=info, dealer_id=dealer_id, pair_socket=pair_sock)
                             connection_map[process_info.dealer_id] = process_info
@@ -379,10 +377,9 @@ def main(log):
 @click.option('--team', '-t', 'teams', type=(str, str), multiple=True, required=True, help="Team path")
 @click.option('--advertise', default=None, type=str,
               help='advertise player on zeroconf')
-@click.option('--show-progress', is_flag=True, default=True)
 @click.option('--max-connections', default=DEFAULT_MAX_CONNECTIONS, show_default=True,
               help='Maximum number of connections that we want to handle')
-def remote_server(address, port, teams, advertise, show_progress, max_connections):
+def remote_server(address, port, teams, advertise, max_connections):
     for team, path in teams:
         team_name = _check_team(team)
         _logger.info(f"Mapping team {team} ({team_name}) to path {path}")
@@ -391,7 +388,7 @@ def remote_server(address, port, teams, advertise, show_progress, max_connection
     pprint(f"Use --session-key {session_key} to for the admin API.")
 
     with_zmq_router(teams, address, port, advertise=advertise, session_key=session_key,
-                    max_connections=max_connections, show_progress=show_progress)
+                    max_connections=max_connections)
 
     # asyncio repl …
     # reload via zqm key

--- a/pelita/scripts/pelita_server.py
+++ b/pelita/scripts/pelita_server.py
@@ -337,7 +337,8 @@ def with_zmq_router(team_specs, address, port, *, advertise: str, session_key: s
                     del connection_map[process_info.dealer_id]
                     count += 1
             if count:
-                progress.console.log("Cleaned up {} process(es). ({} still running.)".format(count, len(connection_map)))
+                plural = "" if count == 1 else "es"
+                progress.console.log(f"Cleaned up {count} process{plural}. ({len(connection_map)} still running.)")
 
 
 def play_remote(team_spec, pair_addr, silent=False):

--- a/pelita/scripts/pelita_server.py
+++ b/pelita/scripts/pelita_server.py
@@ -129,19 +129,19 @@ class PelitaServer:
 
         def cleanup(signum, frame):
             for process_info in self.connection_map.values():
-                _logger.warn(f"Cleaning up unfinished process: {process_info.proc}.")
+                _logger.warn(f"Terminating unfinished process: {process_info.proc.args!r}.")
                 process_info.proc.terminate()
             finish_time = time.monotonic() + 3
             for process_info in self.connection_map.values():
                 # We need to wait for all processes to finish
                 # Otherwise we might exit before the signal has been sent
-                _logger.debug(f"Waiting for process {process_info.proc} to terminate")
+                _logger.debug(f"Waiting for process {process_info.proc.args!r} to terminate")
                 remainder = finish_time - time.monotonic()
                 if remainder > 0:
                     try:
                         process_info.proc.wait(remainder)
                     except subprocess.TimeoutExpired:
-                        _logger.warn(f"Process {process_info.proc} has not finished.")
+                        _logger.warn(f"Process {process_info.proc.args!r} has not finished.")
 
             sys.exit()
 
@@ -213,7 +213,7 @@ class PelitaServer:
             # TODO: Do not update status with every message
 
             requested_url = urlparse(msg_obj['REQUEST'])
-            progress.console.log(f"Request {requested_url.path} for dealer {dealer_id}")
+            progress.console.log(f"Request from id {dealer_id.hex()}: {requested_url.scheme}://{requested_url.hostname}{requested_url.path}")
 
             team_spec = self.team_specs[0][0]
             for spec, path in self.team_specs:

--- a/pelita/scripts/pelita_server.py
+++ b/pelita/scripts/pelita_server.py
@@ -297,7 +297,7 @@ def with_zmq_router(team_specs, address, port, *, advertise: str, session_key: s
 
                         msg = process_info.pair_socket.recv()
                         # route message back
-                        router_sock.send_multipart([dealer_id, msg])
+                        router_sock.send_multipart([process_info.dealer_id, msg])
 
             count = 0
             for process_info in list(connection_map.values()):

--- a/pelita/scripts/pelita_server.py
+++ b/pelita/scripts/pelita_server.py
@@ -368,18 +368,19 @@ def run_team_in_subprocess(ctx, team_spec):
     port = pair_sock.bind_to_random_port('tcp://127.0.0.1')
     pair_addr = 'tcp://127.0.0.1:{}'.format(port)
 
-    subproc = play_remote(team_spec, pair_addr, silent=True)
+    subproc = play_remote(team_spec, pair_addr, quiet=True, silent_bots=True)
 
     return subproc, pair_sock
 
-def play_remote(team_spec, pair_addr, silent=False):
+def play_remote(team_spec, pair_addr, quiet=False, silent_bots=False):
     external_call = [sys.executable,
                     '-m',
                     'pelita.scripts.pelita_player',
                     'remote-game',
                     team_spec,
                     pair_addr,
-                    *(['--silent'] if silent else []),
+                    *(['--quiet'] if quiet else []),
+                    *(['--silent-bots'] if silent_bots else []),
                     ]
     _logger.debug("Executing: %r", external_call)
     sub = subprocess.Popen(external_call)

--- a/pelita/scripts/pelita_server.py
+++ b/pelita/scripts/pelita_server.py
@@ -193,26 +193,27 @@ class PelitaServer:
             if not msg_obj.get('key', None) == self.session_key:
                 return
 
-            progress.console.print("TODO: Status information")
+            progress.console.print("List of teams:")
+            for team in self.team_infos:
+                progress.console.print(team)
 
         elif "TEAM" in msg_obj:
             # check key
             if not msg_obj.get('key', None) == self.session_key:
                 return
 
-            team_spec = msg_obj.get('team')
-            path = msg_obj.get('path')
+            team_spec = msg_obj.get('team_spec')
 
             if msg_obj.get('TEAM') == 'ADD':
-                team_info = load_team_info(team_spec, path=path)
+                team_info = load_team_info(team_spec)
                 self.team_infos.append(team_info)
-                info = zeroconf_register(self.zc, self.advertise, self.port, team_spec, path, print=progress.console.print)
+                info = zeroconf_register(self.zc, self.advertise, self.port, team.spec, team.server_path, print=progress.console.print)
                 if info:
-                    self.team_serviceinfo_mapping[(team_spec, path)] = info
+                    self.team_serviceinfo_mapping[(team.spec, team.server_path)] = info
 
             if msg_obj.get('TEAM') == 'REMOVE':
                 # TODO: cannot remove from self.team_infos yet
-                info = self.team_serviceinfo_mapping[(team_spec, path)]
+                info = self.team_serviceinfo_mapping[(team.spec, team.server_path)]
                 zeroconf_deregister(self.zc, info)
 
         elif "SCAN" in msg_obj:
@@ -537,12 +538,11 @@ def show_statistics(url, session_key):
     send_api_message(url, session_key, "STATUS", "show-stats")
 
 @main.command(help="Add team")
+@click.argument('team_spec')
 @click.option('--url', default="pelita://localhost/")
 @click.option('--session-key', type=str, required=True)
-@click.option('--team', 'team', type=(str, str), required=True, help="Team path")
-def add_team(url, session_key, team):
-    team_spec, path = team
-    send_api_message(url, session_key, "TEAM", "ADD", team=team_spec, path=path)
+def add_team(url, session_key, team_spec):
+    send_api_message(url, session_key, "TEAM", "ADD", team_spec=team_spec)
 
 
 if __name__ == '__main__':

--- a/pelita/scripts/pelita_server.py
+++ b/pelita/scripts/pelita_server.py
@@ -181,9 +181,7 @@ class PelitaServer:
         try:
             msg_obj = json.loads(message)
         except ValueError as e:
-            # TODO should not continue
-            progress.console.log(f"Error {e!r} when parsing incoming message. Ignoring.")
-            _logger.warn(f"Error {e!r} when parsing incoming message. Ignoring.")
+            _logger.debug(f"Error {e!r} when parsing incoming message. Ignoring.")
             return
 
         # TODO actions
@@ -362,9 +360,9 @@ class PelitaServer:
                 has_router_sock = incoming_evts.pop(self.router_sock, None)
 
                 if has_router_sock == zmq.POLLIN:
-                    dealer_id, message = self.router_sock.recv_multipart()
-
                     try:
+                        dealer_id, message = self.router_sock.recv_multipart()
+
                         # check if we know the dealer already
                         if dealer_id in self.connection_map.keys():
                             # incoming message refers to an existing connection
@@ -375,7 +373,7 @@ class PelitaServer:
                             self.handle_new_connection(dealer_id, message, progress)
 
                     except Exception as e:
-                        _logger.warn(f"Error {e!r} when handling incoming message {message}. Ignoring.")
+                        _logger.debug(f"Error {e!r} when handling incoming message {message}. Ignoring.")
 
                 # Are there any non-router messages waiting for us?
                 if len(incoming_evts):

--- a/pelita/scripts/pelita_server.py
+++ b/pelita/scripts/pelita_server.py
@@ -407,7 +407,7 @@ def main(log):
 @main.command(help="Run pelita server with given players")
 @click.option('--address', default="0.0.0.0")
 @click.option('--port', default=PELITA_PORT)
-@click.option('--team', '-t', 'teams', type=(str, str), multiple=True, required=True, help="Team path")
+@click.option('--team', 'teams', type=(str, str), multiple=True, required=True, help="Team path")
 @click.option('--advertise', default=None, type=str,
               help='advertise player on zeroconf')
 @click.option('--max-connections', default=DEFAULT_MAX_CONNECTIONS, show_default=True,
@@ -455,7 +455,7 @@ def show_statistics(url, session_key):
 @main.command(help="Add team")
 @click.option('--url', default="pelita://localhost/")
 @click.option('--session-key', type=str, required=True)
-@click.option('--team', '-t', 'team', type=(str, str), required=True, help="Team path")
+@click.option('--team', 'team', type=(str, str), required=True, help="Team path")
 def add_team(url, session_key, team):
     team_spec, path = team
     send_api_message(url, session_key, "TEAM", "ADD", team=team_spec, path=path)

--- a/pelita/team.py
+++ b/pelita/team.py
@@ -233,7 +233,7 @@ class Team:
             "say": me._say
         }
 
-    def _exit(self):
+    def _exit(self, game_state=None):
         """ Dummy function. Only needed for `RemoteTeam`. """
         pass
 
@@ -418,10 +418,16 @@ class RemoteTeam:
         except ZMQClientError:
             raise
 
-    def _exit(self):
+    def _exit(self, game_state=None):
         # We only want to exit once.
         if getattr(self, '_sent_exit', False):
             return
+
+        if game_state:
+            payload = {'game_state': game_state}
+        else:
+            payload = {}
+
         try:
             # TODO: make zmqconnection stateful. set flag when already disconnected
             # For now, we simply check the state of the socket so that we do not send
@@ -429,7 +435,7 @@ class RemoteTeam:
             if self.zmqconnection.socket.closed:
                 return
             # TODO: Include final state with exit message
-            self.zmqconnection.send("exit", {}, timeout=1)
+            self.zmqconnection.send("exit", payload, timeout=1)
             self._sent_exit = True
         except ZMQUnreachablePeer:
             _logger.info("Remote Player %r is already dead during exit. Ignoring.", self)

--- a/pelita/team.py
+++ b/pelita/team.py
@@ -302,7 +302,13 @@ class RemoteTeam:
             _logger.info("Connecting zmq.DEALER to remote player at {}.".format(send_addr))
 
             socket.send_json({"REQUEST": team_spec})
-            ok = socket.recv()
+            WAIT_TIMEOUT = 5000
+            incoming = socket.poll(timeout=WAIT_TIMEOUT)
+            if incoming == zmq.POLLIN:
+                ok = socket.recv()
+            else:
+                # Server did not respond
+                raise PlayerTimeout()
             self.proc = None
 
         else:

--- a/pelita/team.py
+++ b/pelita/team.py
@@ -7,6 +7,7 @@ import sys
 import traceback
 from io import StringIO
 from pathlib import Path
+from urllib.parse import urlparse
 
 import zmq
 import networkx as nx
@@ -14,7 +15,7 @@ import networkx as nx
 from . import layout
 from .exceptions import PlayerDisconnected, PlayerTimeout
 from .layout import layout_as_str, BOT_I2N, wall_dimensions
-from .network import ZMQClientError, ZMQConnection, ZMQReplyTimeout, ZMQUnreachablePeer
+from .network import ZMQClientError, ZMQConnection, ZMQReplyTimeout, ZMQUnreachablePeer, PELITA_PORT
 
 _logger = logging.getLogger(__name__)
 
@@ -275,7 +276,7 @@ class RemoteTeam:
         #: Default timeout for a request, unless specified in the game_state
         self._request_timeout = 3
 
-        if team_spec.startswith('remote:tcp://'):
+        if team_spec.startswith('pelita://'):
             # We connect to a remote player that is listening
             # on the given team_spec address.
             # We create a new DEALER socket and send a single
@@ -284,8 +285,14 @@ class RemoteTeam:
             # of a player and forward all of our zmq traffic
             # to that player.
 
-            # remove the "remote:" part from the address
-            send_addr = team_spec[len("remote:"):]
+            # given a url pelita://hostname:port/path we extract hostname and port and
+            # convert it to tcp://hostname:port that we use for the zmq connection
+            parsed_url = urlparse(team_spec)
+            if parsed_url.port:
+                port = parsed_url.port
+            else:
+                port = PELITA_PORT
+            send_addr = f"tcp://{parsed_url.hostname}:{port}"
             address = "tcp://*"
             self.bound_to_address = address
 
@@ -293,7 +300,7 @@ class RemoteTeam:
             socket.setsockopt(zmq.LINGER, 0)
             socket.connect(send_addr)
             _logger.info("Connecting zmq.DEALER to remote player at {}.".format(send_addr))
-            socket.send_json({"REQUEST": address})
+            socket.send_json({"REQUEST": team_spec})
             self.proc = None
 
         else:
@@ -327,6 +334,7 @@ class RemoteTeam:
         external_call = [sys.executable,
                          '-m',
                          player,
+                         'remote-game',
                          team_spec,
                          address,
                          '--color',
@@ -420,6 +428,7 @@ class RemoteTeam:
             # over an already closed socket.
             if self.zmqconnection.socket.closed:
                 return
+            # TODO: Include final state with exit message
             self.zmqconnection.send("exit", {}, timeout=1)
             self._sent_exit = True
         except ZMQUnreachablePeer:

--- a/pelita/team.py
+++ b/pelita/team.py
@@ -344,9 +344,7 @@ class RemoteTeam:
                          player,
                          'remote-game',
                          team_spec,
-                         address,
-                         '--color',
-                         color]
+                         address]
 
         _logger.debug("Executing: %r", external_call)
         if store_output == subprocess.DEVNULL:

--- a/pelita/team.py
+++ b/pelita/team.py
@@ -300,7 +300,9 @@ class RemoteTeam:
             socket.setsockopt(zmq.LINGER, 0)
             socket.connect(send_addr)
             _logger.info("Connecting zmq.DEALER to remote player at {}.".format(send_addr))
+
             socket.send_json({"REQUEST": team_spec})
+            ok = socket.recv()
             self.proc = None
 
         else:

--- a/pelita/viewer.py
+++ b/pelita/viewer.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import sys
 
 import zmq
 from rich.console import Console
@@ -12,6 +13,7 @@ from . import layout
 from .network import SetEncoder
 
 _logger = logging.getLogger(__name__)
+_mswindows = (sys.platform == "win32")
 
 # Only highlight explicit markup
 pprint = Console(highlight=False).print
@@ -183,8 +185,22 @@ class ReplayWriter:
 
 class ResultPrinter:
     def show_state(self, state):
+        if (state['turn'] is None and
+            state['round'] is None):
+            # TODO: We must ensure that this is only printed once
+            self.print_team_names(state['team_names'])
+
         if state["gameover"]:
             self.print_possible_winner(state)
+
+    def print_team_names(self, team_names):
+        # TODO: The team_spec is missing in the state.
+        # Should we print it here?
+        pie = '' if _mswindows else 'ᗧ'
+
+        for col, team_name in zip(['blue', 'red'], team_names):
+            if team_name is not None:
+                pprint(f"[{col}]{pie}[/{col}] {col} team: '{team_name}'")
 
     def print_possible_winner(self, state):
         """ Checks the game state for a winner.

--- a/pelita/viewer.py
+++ b/pelita/viewer.py
@@ -200,7 +200,7 @@ class ResultPrinter:
 
         for col, team_name in zip(['blue', 'red'], team_names):
             if team_name is not None:
-                pprint(f"[{col}]{pie}[/{col}] {col} team: '{team_name}'")
+                pprint(f"[bright_{col}]{pie}[/bright_{col}] {col} team: '{team_name}'")
 
     def print_possible_winner(self, state):
         """ Checks the game state for a winner.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ pelita = "pelita.scripts.pelita_main:main"
 pelita-tournament = "pelita.scripts.pelita_tournament:main"
 pelita-tkviewer = "pelita.scripts.pelita_tkviewer:main"
 pelita-player = "pelita.scripts.pelita_player:main"
+pelita-server = "pelita.scripts.pelita_server:main"
 pelita-createlayout = "pelita.scripts.pelita_createlayout:main"
 
 [tool.aliases]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "pytest>=4",
     "zeroconf",
     "rich",
+    "click",
 ]
 dynamic = ["version"]
 

--- a/test/test_network.py
+++ b/test/test_network.py
@@ -5,7 +5,7 @@ import sys
 
 import zmq
 
-from pelita.network import bind_socket, extract_port_range
+from pelita.network import bind_socket
 from pelita.team import make_team
 from pelita.scripts.pelita_player import player_handle_request
 
@@ -29,22 +29,6 @@ def test_bind_socket_fail(zmq_context):
     with pytest.raises(zmq.ZMQError):
         bind_socket(socket, "bad-address", '--publish')
     socket.close()
-
-def test_extract_port_range():
-    test_cases = [
-        ("tcp://*",                     dict(addr="tcp://*")),
-        ("tcp://*:",                    dict(addr="tcp://*:")),
-        ("tcp://*:*",                   dict(addr="tcp://*", port_min=None, port_max=None)),
-        ("tcp://*:123",                 dict(addr="tcp://*:123")),
-        ("tcp://*:[123:124]",           dict(addr="tcp://*", port_min=123, port_max=124)),
-        ("tcp://*:123:[124:125]]",      dict(addr="tcp://*:123", port_min=124, port_max=125)),
-        ("tcp://*:123[124:125]]",       dict(addr="tcp://*:123[124:125]]")),
-        ("ipc:///tmp/pelita-publisher", dict(addr="ipc:///tmp/pelita-publisher"))
-    ]
-
-    for test in test_cases:
-        extracted = extract_port_range(test[0])
-        assert extracted == test[1]
 
 
 def test_simpleclient(zmq_context):

--- a/test/test_remote_game.py
+++ b/test/test_remote_game.py
@@ -30,10 +30,10 @@ def remote_teams():
     addr_food_eater = "127.0.0.1"
     remote = [sys.executable, '-m', 'pelita.scripts.pelita_server', 'remote-server', '--address', '127.0.0.1']
 
-    remote_stopping = remote + ['--port', str(port_stopping), '--team', 'pelita/player/StoppingPlayer', 'stopper']
-    remote_food_eater = remote + ['--port', str(port_food_eater), '--team', 'pelita/player/FoodEatingPlayer', 'fooder']
+    remote_stopping = remote + ['--port', str(port_stopping), '--team', 'pelita/player/StoppingPlayer']
+    remote_food_eater = remote + ['--port', str(port_food_eater), '--team', 'pelita/player/FoodEatingPlayer']
 
-    teams = [f'pelita://127.0.0.1:{port_stopping}/stopper', f'pelita://127.0.0.1:{port_food_eater}/fooder']
+    teams = [f'pelita://127.0.0.1:{port_stopping}/Stopping_Players', f'pelita://127.0.0.1:{port_food_eater}/Food_Eating_Players']
     with run_and_terminate_process(remote_stopping):
         with run_and_terminate_process(remote_food_eater):
             yield teams

--- a/test/test_remote_game.py
+++ b/test/test_remote_game.py
@@ -26,14 +26,14 @@ def remote_teams():
     port_stopping = RNG.randint(49153,65534)
     port_food_eater = port_stopping+1
 
-    addr_stopping = f'tcp://127.0.0.1:{port_stopping}'
-    addr_food_eater = f'tcp://127.0.0.1:{port_food_eater}'
-    remote = [sys.executable, '-m', 'pelita.scripts.pelita_player', '--remote']
+    addr_stopping = "127.0.0.1"
+    addr_food_eater = "127.0.0.1"
+    remote = [sys.executable, '-m', 'pelita.scripts.pelita_server', 'remote-server', '--address', '127.0.0.1']
 
-    remote_stopping = remote + ['pelita/player/StoppingPlayer', addr_stopping ]
-    remote_food_eater = remote + ['pelita/player/FoodEatingPlayer', addr_food_eater]
+    remote_stopping = remote + ['--port', str(port_stopping), '--team', 'pelita/player/StoppingPlayer', 'stopper']
+    remote_food_eater = remote + ['--port', str(port_food_eater), '--team', 'pelita/player/FoodEatingPlayer', 'fooder']
 
-    teams = [f'remote:{addr_stopping}', f'remote:{addr_food_eater}']
+    teams = [f'pelita://127.0.0.1:{port_stopping}/stopper', f'pelita://127.0.0.1:{port_food_eater}/fooder']
     with run_and_terminate_process(remote_stopping):
         with run_and_terminate_process(remote_food_eater):
             yield teams

--- a/test/test_remote_game.py
+++ b/test/test_remote_game.py
@@ -121,12 +121,9 @@ def test_remote_dumps_are_written():
     path = Path(out_folder.name)
     blue_lines = (path / 'blue.out').read_text().split('\n')
     red_lines = (path / 'red.out').read_text().split('\n')
-    # The first line contains the welcome message 'blue team 'path' -> 'name''
-    assert 'blue team' in blue_lines[0]
-    assert 'red team' in red_lines[0]
     # now check what has been printed
-    assert blue_lines[1:] == ['1 0 p1', '1 1 p1', '2 0 p1', '2 1 p1', '']
-    assert red_lines[1:] == ['1 0 p2', '1 1 p2', '2 0 p2', '2 1 p2', '']
+    assert blue_lines == ['1 0 p1', '1 1 p1', '2 0 p1', '2 1 p1', '']
+    assert red_lines == ['1 0 p2', '1 1 p2', '2 0 p2', '2 1 p2', '']
 
     assert (path / 'blue.err').read_text() == 'p1err\np1err\np1err\np1err\n'
     assert (path / 'red.err').read_text() == 'p2err\np2err\np2err\np2err\n'
@@ -176,12 +173,8 @@ def test_remote_dumps_with_failure(failing_team):
 
     blue_lines = (path / 'blue.out').read_text().split('\n')
     red_lines = (path / 'red.out').read_text().split('\n')
-    # The first line contains the welcome message 'blue team 'path' -> 'name''
-    assert 'blue team' in blue_lines[0]
-    assert 'red team' in red_lines[0]
-    # now check what has been printed
-    assert blue_lines[1:] == ['']
-    assert red_lines[1:] == ['']
+    assert blue_lines == ['']
+    assert red_lines == ['']
 
     blue_err = (path / 'blue.err').read_text()
     red_err = (path / 'red.err').read_text()


### PR DESCRIPTION
Will still need refinements (that I’m still working on) but already runs and closes #776 and #769.

The short news is you start a Pelita server like this:

    pelita-server remote-server  --address 0.0.0.0 \
            --team ../BayesAvengers.py avengers \
            --team ../trilobots.py trilobots \
            --advertise 10.10.1.2

(--advertise is only needed when we want to use zeroconf)

This will start a server on port 41736 (which is the default for the new URL scheme) and we can run a match with both teams on the server as follows:

    pelita --ascii pelita://10.10.1.2/avengers pelita://10.10.1.2/trilobots

(The specific IP should not be needed and could also be a hostname.)

When the network allows for using zeroconf then it should also be possible to use SCAN and detect all players on the server automatically.


It is not wildly incompatible to the old version but I did not put in any special effort to make it work with the current PyPI version (Pelita 2.3.1), so all clients will need an update in order to play against the new server.