### PR TITLE
Use rich for terminal viewers to fix colouring issues on Windows

### DIFF
--- a/pelita/scripts/pelita_main.py
+++ b/pelita/scripts/pelita_main.py
@@ -63,7 +63,7 @@ def scan(team_spec):
                 (addr, team_name) = q.get(timeout=5)
                 #  if not players:
                     #console.print("[bold]Found players:")
-                console.print(f"  [blue]{len(players)})[/] {team_name} \[[blue]{addr}[/]]", highlight=False)
+                console.print(f"  [blue]{len(players)})[/] {team_name} \\[[blue]{addr}[/]]", highlight=False)
                 players.append(f"remote:{addr}")
         except Empty:
             pass


### PR DESCRIPTION
Closes #779 

Also using the rich progress viewer now.

We need to be careful not to pass everything to rich, as it makes the ASCII game slower. Also, the rich auto detection will colourise `...` which occurs in some game layouts.

Tested on Windows. ✓
