### PR TITLE
Make legal_positions a static attribute instead of a dynamic property

### DIFF
--- a/pelita/team.py
+++ b/pelita/team.py
@@ -478,38 +478,20 @@ class Bot:
         self.error_count = error_count
         self.is_noisy = is_noisy
 
+        # The legal positions that the bot can reach from its current position,
+        # including the current position.
+        self.legal_positions = []
+
+        for direction in [(0, 0), (-1, 0), (1, 0), (0, 1), (0, -1)]:
+            new_pos = (position[0] + direction[0],
+                       position[1] + direction[1])
+            if not new_pos in self.walls:
+                self.legal_positions.append(new_pos)
+
         # Attributes for Bot
         if self._is_on_team:
             assert bot_turn is not None
             self._bot_turn = bot_turn
-
-    # @property
-    # def legal_directions(self):
-        # """ The legal moves that the bot can make from its current position,
-        # including no move at all.
-        # """
-        # legal_directions = [(0, 0)]
-
-        # for move in [(-1, 0), (1, 0), (0, 1), (0, -1)]:
-            # new_pos = (self.position[0] + move[0], self.position[1] + move[1])
-            # if not new_pos in self.walls:
-                # legal_directions.append(move)
-
-        # return legal_directions
-
-    @property
-    def legal_positions(self):
-        """ The legal positions that the bot can reach from its current position,
-        including the current position.
-        """
-        legal_positions = []
-
-        for direction in [(0, 0), (-1, 0), (1, 0), (0, 1), (0, -1)]:
-            new_pos = (self.position[0] + direction[0], self.position[1] + direction[1])
-            if not new_pos in self.walls:
-                legal_positions.append(new_pos)
-
-        return legal_positions
 
     @property
     def _team(self):


### PR DESCRIPTION
The bot attribute `bot.legal_positions` used to be a property, i.e. the list of positions got generated on the fly every time the code tried to access `bot.legal_positions`. This could be surprising, especially if the code was trying to implement something like "remove the enemy positions from the legal positions so that I run accidentally on top of an enemy".
We have seen repeatedly code like this:

```python
1 if bot.enemy[0].position in bot.legal_positions:
2     bot.legal_positions.pop(bot.enemy[0].position)
3 if bot.enemy[1].position in bot.legal_positions:
4     bot.legal_positions.pop(bot.enemy[1].position)
5 
6 for new_pos in bot.legal_positions:
    ...
```

The problem with this code if `bot.legal_position` is a dynamically generated list is that it would run without generating any error, but does not do what the coder thinks, because `bot.legal_positions` in line `6` will still be unaltered, i.e. it will still contain the enemy positions.

As there's no special reason to have it this way, this PR changes `bot.legal_positions` to be a static attribute, generated once at `Bot`'s instantiation time.
There are no backward compatibility concerns: if people were trying to write to `bot.legal_positions` before they had to make a copy anyway, so their code will continue to work. This PR is only making new things possible that weren't possible before.