### PR TITLE
CI: Removing codecov

### DIFF
--- a/.github/workflows/test_pytest.yml
+++ b/.github/workflows/test_pytest.yml
@@ -33,13 +33,6 @@ jobs:
         python -m pytest -v -s --cov=./pelita/ test/
       timeout-minutes: 8
 
-    - name: "Upload coverage to Codecov"
-      uses: codecov/codecov-action@v4
-      with:
-        fail_ci_if_error: true
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
     - name: Upload coverage data to coveralls.io
       uses: AndreMiras/coveralls-python-action@develop
       if: runner.os == 'Linux' # Only works on Linux


### PR DESCRIPTION
codecov-action@v4 fails with upload errors although I provided a token. Maybe we don’t need both codecov + coveralls anyway, so I am giving up on this one for now.

```
==> Running command '/home/runner/work/_actions/codecov/codecov-action/v4/dist/codecov create-commit'
/home/runner/work/_actions/codecov/codecov-action/v4/dist/codecov create-commit --git-service github -Z
==> Uploader SHASUM verified (e70beb7c9e3d894678e7d4d0fcb94e59133212dbda5ca7406b625a0167ce4ca8  codecov)
info - 2024-04-21 10:52:22,182 -- ci service found: github-actions
warning - 2024-04-21 10:52:22,190 -- No config file could be found. Ignoring config.
info - 2024-04-21 10:52:22,401 -- Process Commit creating complete
error - 2024-04-21 10:52:22,401 -- Commit creating failed: {"detail":"You do not have permission to perform this action."}
Error: Codecov: Failed to properly create commit: The process '/home/runner/work/_actions/codecov/codecov-action/v4/dist/codecov' failed with exit code 1
```
