### PR TITLE
add a new `graph` cached attribute to the `Bot` object

### DIFF
--- a/pelita/team.py
+++ b/pelita/team.py
@@ -154,6 +154,9 @@ class Team:
         # Cache the homezone so that we don’t have to create it at each step
         self._homezone = create_homezones(self._shape, self._walls)
 
+        # Cache the graph representation of the maze
+        self._graph = walls_to_graph(self._walls)
+
         return self.team_name
 
     def get_move(self, game_state):
@@ -179,7 +182,8 @@ class Team:
                        enemy=game_state['enemy'],
                        round=game_state['round'],
                        bot_turn=game_state['bot_turn'],
-                       rng=self._random)
+                       rng=self._random,
+                       graph=self._graph)
 
         team = me._team
 
@@ -490,6 +494,7 @@ class Bot:
                           deaths,
                           was_killed,
                           random,
+                          graph,
                           round,
                           bot_char,
                           is_blue,
@@ -525,6 +530,7 @@ class Bot:
         self.team_name = team_name
         self.error_count = error_count
         self.is_noisy = is_noisy
+        self.graph = graph
 
         # The legal positions that the bot can reach from its current position,
         # including the current position.
@@ -685,7 +691,7 @@ class Bot:
 
 
 # def __init__(self, *, bot_index, position, initial_position, walls, homezone, food, is_noisy, score, random, round, is_blue):
-def make_bots(*, walls, shape, initial_positions, homezone, team, enemy, round, bot_turn, rng):
+def make_bots(*, walls, shape, initial_positions, homezone, team, enemy, round, bot_turn, rng, graph):
     bots = {}
 
     team_index = team['team_index']
@@ -711,6 +717,7 @@ def make_bots(*, walls, shape, initial_positions, homezone, team, enemy, round, 
             bot_turn=bot_turn,
             bot_char=BOT_I2N[team_index + idx*2],
             random=rng,
+            graph=graph,
             position=team['bot_positions'][idx],
             initial_position=team_initial_positions[idx],
             is_blue=team_index % 2 == 0,
@@ -735,6 +742,7 @@ def make_bots(*, walls, shape, initial_positions, homezone, team, enemy, round, 
             round=round,
             bot_char = BOT_I2N[team_index + idx*2],
             random=rng,
+            graph=graph,
             position=enemy['bot_positions'][idx],
             initial_position=enemy_initial_positions[idx],
             is_blue=enemy_index % 2 == 0,

--- a/pelita/team.py
+++ b/pelita/team.py
@@ -154,8 +154,10 @@ class Team:
         # Cache the homezone so that we don’t have to create it at each step
         self._homezone = create_homezones(self._shape, self._walls)
 
-        # Cache the graph representation of the maze
-        self._graph = walls_to_graph(self._walls)
+        # Cache the graph representation of the maze -> stores a read-only view of the
+        # graph, so that local modifications in the move function are not carried
+        # over
+        self._graph = walls_to_graph(self._walls).copy(as_view=True)
 
         return self.team_name
 

--- a/pelita/utils.py
+++ b/pelita/utils.py
@@ -3,9 +3,13 @@ import random
 import networkx as nx
 
 
-from .team import make_bots, create_homezones, walls_to_graph
+from .team import make_bots, create_homezones
 from .layout import (get_random_layout, get_layout_by_name, get_available_layouts,
                      parse_layout, BOT_N2I, initial_positions)
+
+# this import is needed for backward compatibility, do not remove or you'll break
+# older clients!
+from .team import walls_to_graph
 
 RNG = random.Random()
 

--- a/pelita/utils.py
+++ b/pelita/utils.py
@@ -264,6 +264,7 @@ def setup_test_game(*, layout, is_blue=True, round=None, score=None, seed=None,
                     enemy=enemy,
                     round=round,
                     bot_turn=0,
-                    rng=rng)
+                    rng=rng,
+                    graph=walls_to_graph(layout['walls']))
     return bot
 

--- a/pelita/utils.py
+++ b/pelita/utils.py
@@ -3,51 +3,12 @@ import random
 import networkx as nx
 
 
-from .team import make_bots, create_homezones
+from .team import make_bots, create_homezones, walls_to_graph
 from .layout import (get_random_layout, get_layout_by_name, get_available_layouts,
-                     parse_layout, BOT_N2I, initial_positions, wall_dimensions)
+                     parse_layout, BOT_N2I, initial_positions)
 
 RNG = random.Random()
 
-def walls_to_graph(walls):
-    """Return a networkx Graph object given the walls of a maze.
-
-    Parameters
-    ----------
-    walls : set[(x0,y0), (x1,y1), ...]
-         a set of wall coordinates
-
-    Returns
-    -------
-    graph : networkx.Graph
-         a networkx Graph representing the free squares in the maze and their
-         connections. Note that 'free' in this context means that the corresponding
-         square in the maze is not a wall (but can contain food or bots).
-
-    Notes
-    -----
-    Nodes in the graph are (x,y) coordinates representing squares in the maze
-    which are not walls.
-    Edges in the graph are ((x1,y1), (x2,y2)) tuples of coordinates of two
-    adjacent squares. Adjacent means that you can go from one square to one of
-    its adjacent squares by making ore single step (up, down, left, or right).
-    """
-    graph = nx.Graph()
-    width, height = wall_dimensions(walls)
-
-    for x in range(width):
-        for y in range(height):
-            if (x, y) not in walls:
-                # this is a free position, get its neighbors
-                for delta_x, delta_y in ((1,0), (-1,0), (0,1), (0,-1)):
-                    neighbor = (x + delta_x, y + delta_y)
-                    # we don't need to check for getting neighbors out of the maze
-                    # because our mazes are all surrounded by walls, i.e. our
-                    # deltas will not put us out of the maze
-                    if neighbor not in walls:
-                        # this is a genuine neighbor, add an edge in the graph
-                        graph.add_edge((x, y), neighbor)
-    return graph
 
 def _parse_layout_arg(*, layout=None, food=None, bots=None, seed=None):
 


### PR DESCRIPTION
Introduce a new cached attribute `graph` to the `Bot` object.
This PR also moves the `walls_to_graph` function from `utils.py` to `team.py`, where it arguably now belongs. An alias `walls_to_graph` is left in `utils.py` for backward compatibility.

Fixes: #789 