### PR TITLE
RF: Add a send queue for outgoing messages to avoid broken players stalling the server

### DIFF
--- a/pelita/scripts/pelita_server.py
+++ b/pelita/scripts/pelita_server.py
@@ -175,6 +175,11 @@ class PelitaServer:
         self.send_queue = queue.SimpleQueue()
 
     def handle_send_queue(self):
+        if self.send_queue.qsize() == 0:
+            # The check for the qsize is not reliable and we only
+            # use it as an optimisation to skip early
+            return
+
         # Handle all unsent messages to pair sockets
         unsent = set()
         try:


### PR DESCRIPTION
Closes #799 by putting outgoing messages in a send queue.

Shielding individual sends with a timeout is not sensible here as it would stall the server when there are crashed bots.

Draft because I am not sure if this is a good design.