### PR TITLE
BF: TK UI shows wrong homezone for blue team

### DIFF
--- a/pelita/ui/tk_canvas.py
+++ b/pelita/ui/tk_canvas.py
@@ -705,7 +705,7 @@ class TkApplication:
                 has_food = pos in game_state['food']
                 is_wall = pos in game_state['walls']
                 bots = [idx for idx, bot in enumerate(game_state['bots']) if bot==pos]
-                if pos[0] <= (game_state['shape'][0] // 2):
+                if pos[0] < (game_state['shape'][0] // 2):
                     zone = "blue"
                 else:
                     zone = "red"


### PR DESCRIPTION
Fix longstanding bug introduced in 92ca5553f61e05c5edaf9f3bd240628bb1ef06f8

The homezone for the blue team shown in the field status (bottom right) is one square too big. Typical off-by-one error ;-)

(see screenshot)
![screenshot1](https://github.com/ASPP/pelita/assets/347147/7155bf20-d25d-4a4b-a324-421fd8344d17)
