### PR TITLE
Do not attempt to send an exit message to a team with a fatal error

### DIFF
--- a/pelita/game.py
+++ b/pelita/game.py
@@ -988,6 +988,9 @@ def check_exit_remote_teams(game_state):
         for idx, team in enumerate(game_state['teams']):
             if len(game_state['fatal_errors'][idx]) > 0:
                 _logger.info(f"Not sending exit to team {idx} which had a fatal error.")
+                # We pretend we already send the exit message, otherwise
+                # the team’s __del__ method will do it once more.
+                team._sent_exit = True
                 continue
             try:
                 team_game_state = prepare_bot_state(game_state, idx=idx)

--- a/pelita/game.py
+++ b/pelita/game.py
@@ -986,6 +986,9 @@ def check_exit_remote_teams(game_state):
     if game_state['gameover']:
         _logger.info("Gameover. Telling teams to exit.")
         for idx, team in enumerate(game_state['teams']):
+            if len(game_state['fatal_errors'][idx]) > 0:
+                _logger.info(f"Not sending exit to team {idx} which had a fatal error.")
+                continue
             try:
                 team_game_state = prepare_bot_state(game_state, idx=idx)
                 team._exit(team_game_state)


### PR DESCRIPTION
As was mentioned in https://github.com/ASPP/pelita/pull/804 we sometimes have timeouts in our CI. In this case, it could be tracked down to the test:

    pytest test/test_remote_game.py::test_remote_move_failures[player_move_import_error-False-ModuleNotFoundError]

I cannot reproduce it right now but it is likely that one of two things happens:

The tested player has an import error, so the game setup fails and triggers a fatalerror. This error causes the game to finish and we end up in `def check_exit_remote_teams` where we notify the players of how the game went down and that they should shut down. As the player has already had a fatal error this can

a) cause a hang in zmq.send (similar to https://github.com/ASPP/pelita/issues/799); this should actually have been taken care of with our helper class `ZMQConnection` but it will still induce a one second timeout.

b) cause a hang in RemotePlayer.__del__ when the process is terminated or maybe cause it in this method’s call to exit

Since we do not need to send anything to a player with a fatalerror (after all, we should assume that it cannot receive any more messages), we simply stop sending a message.

Coincidentally, this would also be enough to fix https://github.com/ASPP/pelita/issues/799 but our fix in https://github.com/ASPP/pelita/pull/801 is still more generic and appropriate.
