### PR TITLE
Reduce default shadow distance to 1

### DIFF
--- a/pelita/game.py
+++ b/pelita/game.py
@@ -37,7 +37,7 @@ NOISE_RADIUS = 5
 MAX_FOOD_AGE = 30
 
 #: Food pellet shadow distance
-SHADOW_DISTANCE = 3
+SHADOW_DISTANCE = 1
 
 class TkViewer:
     def __init__(self, *, address, controller, geometry=None, delay=None, stop_after=None, fullscreen=False):

--- a/test/test_filter_gamestates.py
+++ b/test/test_filter_gamestates.py
@@ -9,7 +9,7 @@ from pelita.game import setup_game, play_turn, prepare_bot_state, split_food
 from pelita.layout import parse_layout
 from pelita.player import stepping_player
 import pelita.utils
-
+import pelita.game
 
 def make_gamestate():
     def dummy_team(bot, state):
@@ -774,6 +774,10 @@ def test_relocate_expired_food_nospaceleft():
 def test_pacman_resets_age():
     # We move bot a across the border
     # Once it becomes a bot, the food_age should reset
+    # XXX: BAD TRICK to make this test work independent of the
+    #      actually configured SHADOW_DISTANCE
+    old_SHADOW_DISTANCE = pelita.game.SHADOW_DISTANCE
+    pelita.game.SHADOW_DISTANCE = 3
     test_layout = (
     """ ##################
         #         x     y#
@@ -807,3 +811,4 @@ def test_pacman_resets_age():
     state = play_turn(state)
     assert state['turn'] == 3
     assert state['food_age'] == [{}, {}]
+    pelita.game.SHADOW_DISTANCE = old_SHADOW_DISTANCE

--- a/test/test_team.py
+++ b/test/test_team.py
@@ -4,7 +4,8 @@ import pytest
 import networkx
 
 from pelita.layout import parse_layout, get_random_layout, initial_positions
-from pelita.game import run_game, setup_game, play_turn
+from pelita.game import run_game, setup_game, play_turn, SHADOW_DISTANCE
+from pelita.gamestate_filters import manhattan_dist
 
 def stopping(bot, state):
     return bot.position
@@ -395,12 +396,14 @@ def test_bot_attributes():
 
         assert bot.walls == tuple(sorted(bot.walls))
         assert bot.homezone == tuple(sorted(bot.homezone))
-
         if bot.is_blue:
             assert set(bot.homezone) == set(homezones[0])
             assert set(bot.enemy[0].homezone) == set(homezones[1])
-            assert set(bot.shaded_food) == set([(1, 1), (3, 1), (4, 1), (5, 1)])
-            assert set(bot.other.shaded_food) == set([(1, 1), (3, 1), (4, 1), (5, 1)])
+            shaded_food = set(food for food in bot.food if
+                              manhattan_dist(bot.position, food) <= SHADOW_DISTANCE or
+                              manhattan_dist(bot.other.position, food) <= SHADOW_DISTANCE)
+            assert set(bot.shaded_food) == shaded_food
+            assert set(bot.other.shaded_food) == shaded_food
             assert set(bot.enemy[0].shaded_food) == set()
             assert set(bot.enemy[1].shaded_food) == set()
         else:


### PR DESCRIPTION
In Heraklion we noticed that the value 3 for the shadow distance for food relocation was a bit too broad. It made a purely attacking strategy overwhelmingly more worth investing than a defending or mixed strategy. by reducing the shadow to 1 we still avoid pure camping, but still make it worth to explore defending strategies.

I know it all sounds quite hand-wavy, but it is very difficult to put numbers onto this reasoning.