### PR TITLE
Optimize Maze Generation

### DIFF
--- a/pelita/layout.py
+++ b/pelita/layout.py
@@ -116,8 +116,11 @@ def get_layout_by_name(layout_name):
         # reraise as ValueError with appropriate error message.
         raise ValueError(f"Layout: '{layout_name}' is not known.") from None
 
-def parse_layout(layout_str, food=None, bots=None):
+def parse_layout(layout_str, food=None, bots=None, strict=True):
     """Parse a layout string.
+
+    If strict is False, the layout string must not be valid and parse_layout will
+    try its best to interpret it. This is useful only during testing.
 
     A valid layout string is enclosed by walls and rectangular:
 
@@ -178,7 +181,7 @@ def parse_layout(layout_str, food=None, bots=None):
                 # set width of layout
                 width = len(row)
                 # check that width is even
-                if width % 2:
+                if width % 2 and strict:
                     raise ValueError(f"Layout width must be even (found {width})!")
                 rows.append(row)
                 continue
@@ -230,7 +233,7 @@ def parse_layout(layout_str, food=None, bots=None):
     for i, bot in enumerate(lbots):
         if bot is None and BOT_I2N[i] not in bots:
             missing_bots.append(BOT_I2N[i])
-    if missing_bots:
+    if missing_bots and strict:
             raise ValueError(f"Missing bot(s): {missing_bots}")
     lfood.sort()
 

--- a/pelita/maze_generator.py
+++ b/pelita/maze_generator.py
@@ -674,6 +674,8 @@ def create_maze_graph(trapped_food=10, total_food=30, width=32, height=16, rng=N
     # transform to graph to find dead ends and chambers for food distribution
     # IMPORTANT: we have to include one column of the right border in the graph
     # generation, or our algorith to find chambers would get confused
+    # Note: this only works because in the right side of the maze we have no walls
+    # except for the surrounding ones.
     graph = walls_to_graph_team(walls, shape=(width//2+1, height))
 
     # the algorithm should actually guarantee this, but just to make sure, let's
@@ -690,6 +692,9 @@ def create_maze_graph(trapped_food=10, total_food=30, width=32, height=16, rng=N
     # make sure that the tiles available for food distribution do not include
     # those right on the border of the homezone
     # also, no food on the initial positions of the pacmen
+    # IMPORTANT: the relevant chamber tiles are only those in the left side of
+    # the maze. By detecing chambers on only half of the maze, we may still have
+    # spurious chambers on the right side
     border = width//2 - 1
     chamber_tiles = {tile for tile in chamber_tiles if tile[0] < border} - pacmen_pos
     all_tiles = {(x, y) for x in range(border) for y in range(height)}

--- a/pelita/maze_generator.py
+++ b/pelita/maze_generator.py
@@ -54,7 +54,7 @@ def sample_nodes(nodes, k, rng=None):
         return nodes
 
 
-def find_chambers(graph, width):
+def find_trapped_tiles(graph, width, include_chambers=False):
     main_chamber = set()
     chamber_tiles = set()
 
@@ -74,11 +74,13 @@ def find_chambers(graph, width):
     chamber_tiles -= main_chamber
 
     # combine connected subgraphs
-    #subgraphs = G.subgraph(chamber_tiles)
-    #chambers = list(nx.connected_components(subgraphs))
+    if include_chambers:
+        subgraphs = graph.subgraph(chamber_tiles)
+        chambers = list(nx.connected_components(subgraphs))
+    else:
+        chambers = []
 
-    #return chambers, chamber_tiles
-    return chamber_tiles
+    return chamber_tiles, chambers
 
 
 def distribute_food(all_tiles, chamber_tiles, trapped_food, total_food, rng=None):
@@ -293,7 +295,7 @@ def generate_maze(trapped_food=10, total_food=30, width=32, height=16, rng=None)
     # this gives us a set of tiles that are "trapped" within chambers, i.e. tunnels
     # with a dead-end or a section of tiles fully enclosed by walls except for a single
     # tile entrance
-    chamber_tiles = find_chambers(graph, width)
+    chamber_tiles, _ = find_trapped_tiles(graph, width, include_chambers=False)
 
     # we want to distribute the food only on the left half of the maze
     # make sure that the tiles available for food distribution do not include

--- a/pelita/maze_generator.py
+++ b/pelita/maze_generator.py
@@ -472,24 +472,30 @@ def distribute_food(all_tiles, chamber_tiles, trapped_food, total_food, rng=None
             f"number of trapped food ({trapped_food}) must not exceed total number of food ({total_food})"
         )
 
-    # breakpoint()
+    if total_food > len(all_tiles):
+        raise ValueError(
+            f"number of total food ({total_food}) exceeds available tiles in maze ({len(all_tiles)})"
+        )
 
-    # distribute as much food in chambers as possible
+    free_tiles = all_tiles - chamber_tiles
+
+    # distribute as much trapped food in chambers as possible
     tf_pos = sample_nodes(chamber_tiles, trapped_food, rng=rng)
 
     # distribute remaining food outside of chambers
     free_food = total_food - len(tf_pos)
 
-    free_tiles = all_tiles - chamber_tiles
-
-    # extend free_nodes with all available nodes
-    # if remaining food exceeds non-chamber squares
-    if free_food > len(free_tiles):
-        free_tiles = all_tiles - tf_pos
-
     ff_pos = sample_nodes(free_tiles, free_food, rng=rng)
 
-    return sorted(tf_pos | ff_pos)
+    # there were not enough tiles to distribute all leftover food
+    leftover_food = total_food - len(ff_pos) - len(tf_pos)
+    if leftover_food > 0:
+        leftover_tiles = chamber_tiles - tf_pos
+        leftover_food_pos = sample_nodes(leftover_tiles, leftover_food, rng=rng)
+    else:
+        leftover_food_pos = set()
+
+    return sorted(tf_pos | ff_pos | leftover_food_pos)
 
 
 def create_maze_food(trapped_food, total_food, width, height, rng=None):

--- a/pelita/maze_generator.py
+++ b/pelita/maze_generator.py
@@ -284,7 +284,7 @@ def generate_maze(trapped_food=10, total_food=30, width=32, height=16, rng=None)
     ### TODO: hide the chamber_finding in another function, create the graph with
     # a wall on the right border + 1, so that find chambers works reliably and
     # we can get rid of the  {.... if tile[0] < border} in the following
-    # also, improve find_chambers so that it does not use x and width, but just
+    # also, improve find_trapped_tiles so that it does not use x and width, but just
     # requires two sets of nodes representing the left and the right of the border
     # and then the main chambers is that one that has a non-empty intersection
     # with both.

--- a/pelita/maze_generator.py
+++ b/pelita/maze_generator.py
@@ -280,6 +280,14 @@ def generate_maze(trapped_food=10, total_food=30, width=32, height=16, rng=None)
     pacmen_pos = set([(1, height - 3), (1, height - 2)])
     walls = generate_half_maze(width, height, height//2, pacmen_pos, rng=rng)
 
+    ### TODO: hide the chamber_finding in another function, create the graph with
+    # a wall on the right border + 1, so taht find chambers works reliably and
+    # we can get rid of the  {.... if tile[0] < border} in the following
+    # also, improve find_chambers so that it does not use x and width, but just
+    # requires two sets of nodes representing the left and the right of the border
+    # and then the main chambers is that one that has a non-empty intersection
+    # with both.
+
     # transform to graph to find dead ends and chambers for food distribution
     # IMPORTANT: we have to include one column of the right border in the graph
     # generation, or our algorith to find chambers would get confused

--- a/pelita/maze_generator.py
+++ b/pelita/maze_generator.py
@@ -498,9 +498,15 @@ def distribute_food(all_tiles, chamber_tiles, trapped_food, total_food, rng=None
     return sorted(tf_pos | ff_pos | leftover_food_pos)
 
 
-def create_maze_food(trapped_food, total_food, width, height, rng=None):
+def create_layout(trapped_food, total_food, width, height, rng=None):
     if width % 2 != 0:
         raise ValueError(f"Width must be even ({width} given)")
+
+    if width < 4:
+        raise ValueError(f"Width must be at least 4, but {width} was given")
+
+    if height < 4:
+        raise ValueError(f"Height must be at least 4, but {height} was given")
 
     rng = default_rng(rng)
 

--- a/pelita/maze_generator.py
+++ b/pelita/maze_generator.py
@@ -115,7 +115,7 @@ def distribute_food(all_tiles, chamber_tiles, trapped_food, total_food, rng=None
     return tf_pos | ff_pos | leftover_food_pos
 
 
-def add_wall(partition, walls, ngaps, vertical, rng=None):
+def add_wall_and_split(partition, walls, ngaps, vertical, rng=None):
     rng = default_rng(rng)
 
     (xmin, ymin), (xmax, ymax) = partition
@@ -200,13 +200,13 @@ def add_wall(partition, walls, ngaps, vertical, rng=None):
                       ((xmin, pos+1), (xmax,  ymax))]
 
     for partition in partitions:
-        walls |= add_wall(
+        walls |= add_wall_and_split(
             partition, walls, max(1, ngaps // 2), not vertical, rng=rng
         )
 
     return walls
 
-def create_half_maze(width, height, ngaps_center, bots_pos, rng=None):
+def generate_half_maze(width, height, ngaps_center, bots_pos, rng=None):
     # use binary space partitioning
     rng = default_rng(rng)
 
@@ -244,7 +244,7 @@ def create_half_maze(width, height, ngaps_center, bots_pos, rng=None):
     partition = ((1, 1), (x_wall - 1, ymax * 2))
 
 
-    walls = add_wall(
+    walls = add_wall_and_split(
         partition,
         walls,
         ngaps_center // 2,
@@ -260,7 +260,7 @@ def create_half_maze(width, height, ngaps_center, bots_pos, rng=None):
     return walls
 
 
-def create_maze(trapped_food=10, total_food=30, width=32, height=16, rng=None):
+def generate_maze(trapped_food=10, total_food=30, width=32, height=16, rng=None):
     if width % 2 != 0:
         raise ValueError(f"Width must be even ({width} given)")
 
@@ -276,7 +276,7 @@ def create_maze(trapped_food=10, total_food=30, width=32, height=16, rng=None):
     # this allows us to cut the execution time in two, because the following
     # graph operations are quite expensive
     pacmen_pos = set([(1, height - 3), (1, height - 2)])
-    walls = create_half_maze(width, height, height//2, pacmen_pos, rng=rng)
+    walls = generate_half_maze(width, height, height//2, pacmen_pos, rng=rng)
 
     # transform to graph to find dead ends and chambers for food distribution
     # IMPORTANT: we have to include one column of the right border in the graph

--- a/pelita/maze_generator.py
+++ b/pelita/maze_generator.py
@@ -1,441 +1,64 @@
 """
-Generate maze layouts for 'pelita', without dead ends.
+Generate mazes for pelita
 
-Algorithm:
-* start with an empty grid
-* draw a wall with gaps, dividing the grid in 2
-* repeat recursively for each sub-grid
-* find dead ends
-* remove a wall at the dead ends
+The algorithm is a form of binary space partitioning:
 
-Players 1,3 always start in the bottom left; 2,4 in the top right
-Food is placed randomly (though not too close to the pacmen starting positions)
+* start with an empty grid enclosed by walls
+* draw a wall with k gaps, dividing the grid in 2 partitions
+* repeat recursively for each sub-partitions, where walls have k/2 gaps
+* pacmen are always in the bottom left and in the top right
+* Food is distributed according to specifications
 
 Notes:
-the final map includes a symmetric, flipped copy
-the first wall has k gaps, the next wall has k/2 gaps, etc. (min=1)
+The final maze includes is created by first generating the left half maze and then
+generating the right half by making mirroring the left half. The resulting maze is
+centrosymmetric.
+
+Definitions:
+Articulation point - a node in the graph that if removed would disconnect the
+    graph in to two subgraphs. Find them with: nx.articulation_points(graph)
+
+Dead-end - nodes in the graph with connectivity 1 -> that node is necessarily
+    connected to an articulation point. Find them with
+    {node for node in graph if graph.degree(node) == 1}
+
+Tunnel: nodes in a sequence of articulation points connecting with a dead-end
+
+Chamber: nodes connected to the main graph by a single articulation point -> it
+    is basically a space with an entrance of a single node
+
 
 Inspired by code by Dan Gillick
 Completely rewritten by Pietro Berkes
 Rewritten again (but not completely) by Tiziano Zito
+Rewritten completely by Jakob Zahn & Tiziano Zito
 """
-
 import networkx as nx
-import numpy as np
-
 
 from .base_utils import default_rng
-from .team import walls_to_graph as walls_to_graph_team
-
-north = (0, -1)
-south = (0, 1)
-east = (1, 0)
-west = (-1, 0)
+from .team import walls_to_graph
 
 
-# character constants for walls, food, and empty spaces
-W = b"#"
-F = b"."
-E = b" "
+def mirror(nodes, width, height):
+    nodes = set(nodes)
+    other = set((width - 1 - x, height - 1 - y) for x, y in nodes)
+    return nodes | other
 
 
-def empty_maze(height, width):
-    """Return an empty maze with external walls.
-
-    A maze is a 2D array of characters representing walls, food, and agents.
-    An empty maze is made of empty tiles, except for the external walls.
-    """
-
-    maze = np.empty((height, width), dtype="c")
-    maze.fill(E)
-
-    # add external walls
-    maze[0, :].fill(W)
-    maze[-1, :].fill(W)
-    maze[:, 0].fill(W)
-    maze[:, -1].fill(W)
-
-    return maze
-
-
-def maze_to_bytes(maze):
-    """Return bytes representation of maze."""
-    lines = [b"".join(maze[i, :]) for i in range(maze.shape[0])]
-    return b"\n".join(lines)
-
-
-def maze_to_str(maze):
-    """Return a ascii-string representation of maze."""
-    bytes_ = maze_to_bytes(maze)
-    return bytes_.decode("ascii")
-
-
-def bytes_to_maze(bytes_):
-    """Return a maze numpy bytes array from a bytes representation."""
-    rows = []
-    for line in bytes_.splitlines():
-        line = line.strip()
-        if len(line) == 0:
-            # skip empty lines
-            continue
-        cols = []
-        for idx in range(len(line.strip())):
-            # this crazyness is needed because bytes do not iterate like
-            # strings: see the comments about iterating over bytes in
-            # https://docs.python.org/3/library/stdtypes.html#bytes-objects
-            cols.append(line[idx : idx + 1])
-        rows.append(cols)
-
-    maze = np.array(rows, dtype=bytes)
-    return maze
-
-
-def str_to_maze(str_):
-    """Return a maze numpy bytes array from a ascii string representation."""
-    bytes_maze = str_.encode("ascii")
-    return bytes_to_maze(bytes_maze)
-
-
-def create_half_maze(maze, ngaps_center, rng=None):
-    """Fill the left half of the maze with random walls.
-
-    The second half can be created by mirroring the left part using
-    the 'complete_maze' function.
-    """
+def sample_nodes(nodes, k, rng=None):
     rng = default_rng(rng)
 
-    # first, we need a wall in the middle
+    if k < len(nodes):
+        return set(rng.sample(sorted(nodes), k=k))
+    else:
+        return nodes
 
-    # the gaps in the central wall have to be chosen such that they can
-    # be mirrored
-    ch = maze.shape[0] - 2
-    candidates = list(range(ch // 2))
-    rng.shuffle(candidates)
-    half_gaps_pos = candidates[: ngaps_center // 2]
-    gaps_pos = []
-    for pos in half_gaps_pos:
-        gaps_pos.append(pos)
-        gaps_pos.append(ch - pos - 1)
 
-    # make wall
-    _add_wall_at(
-        maze,
-        (maze.shape[1] - 2) // 2 - 1,
-        ngaps_center,
-        vertical=True,
-        rng=rng,
-        gaps_pos=gaps_pos,
-    )
-
-    # then, fill the left half with walls
-    _add_wall(maze[:, : maze.shape[1] // 2], ngaps_center // 2, vertical=False, rng=rng)
-
-
-def _add_wall_at(maze, pos, ngaps, vertical, rng, gaps_pos=None):
-    """
-    add a wall with gaps
-
-    maze -- maze where to place wall, plus a border of one element
-    pos -- position where to put the wall within the center of the maze
-           (border excluded)
-    """
-
-    if not vertical:
-        maze = maze.T
-
-    center = maze[1:-1, 1:-1]
-    ch, cw = center.shape
-
-    # place wall
-    center[:, pos].fill(W)
-
-    # place gaps
-    ngaps = max(1, ngaps)
-    # choose position of gaps if necessary
-    if gaps_pos is None:
-        # choose aandom positions
-        gaps_pos = list(range(ch))
-        rng.shuffle(gaps_pos)
-        gaps_pos = gaps_pos[:ngaps]
-        # do not block entrances
-        if maze[0][pos + 1] == E:
-            gaps_pos.insert(0, 0)
-        if maze[-1][pos + 1] == E:
-            gaps_pos.insert(0, ch - 1)
-    for gp in gaps_pos:
-        center[gp, pos] = E
-
-    sub_mazes = [maze[:, : pos + 2], maze[:, pos + 1 :]]
-
-    if not vertical:
-        sub_mazes = [sm.T for sm in sub_mazes]
-
-    return sub_mazes
-
-
-def _add_wall(maze, ngaps, vertical, rng):
-    """Recursively build the walls of the maze.
-
-    grid -- 2D array of characters representing the maze
-    ngaps -- number of empty spaces to leave in the wall
-    vertical -- if True, create a vertical wall, otherwise horizontal
-    """
-
-    h, w = maze.shape
-    center = maze[1:-1, 1:-1]
-    ch, cw = center.shape
-
-    # no space for walls, interrupt recursion
-    if ch < 3 and cw < 3:
-        return
-
-    size = cw if vertical else ch
-    # create a wall only if there is some space in this direction
-    min_size = rng.randint(3, 5)
-    if size >= min_size:
-        # place the wall at random spot
-        pos = rng.randint(1, size - 2)
-        sub_mazes = _add_wall_at(maze, pos, ngaps, vertical, rng=rng)
-
-        # recursively add walls
-        for sub_maze in sub_mazes:
-            _add_wall(sub_maze, max(1, ngaps // 2), not vertical, rng=rng)
-
-
-def walls_to_graph(maze):
-    """Transform a maze in a graph.
-
-    The data on the nodes correspond to their coordinates, data on edges is
-    the actions to take to transition to that edge.
-
-    Returns:
-    graph -- a Graph
-    first_node -- the first node in the Graph
-    """
-
-    h, w = maze.shape
-    directions = [east, south]
-
-    graph = nx.Graph()
-    # define nodes for maze
-    for x in range(w):
-        for y in range(h):
-            if maze[y, x] != W:
-                graph.add_node((x, y))
-                # this is a free position, get its neighbors too
-                for dx, dy in directions:
-                    nbx, nby = (x + dx, y + dy)
-                    # do not go out of bounds
-                    try:
-                        if maze[nby, nbx] == E:
-                            graph.add_edge((x, y), (nbx, nby))
-                    except IndexError:
-                        # this move brought us out of the maze, just ignore it
-                        continue
-    return graph
-
-
-def find_dead_ends(graph, width):
-    """Find dead ends in a graph."""
-
-    dead_ends = []
-    for node in graph.nodes():
-        if graph.degree(node) == 1 and node[0] < width - 1:
-            dead_ends.append(node)
-
-    return dead_ends
-
-
-def remove_dead_end(dead_node, maze):
-    """Remove one dead end in a maze."""
-
-    h, w = maze.shape
-
-    # loop through the neighboring positions and remove the first wall we find
-    # as long as it is not on the outer border or in the middle of the maze
-    # not in the central wall x==w//2-1
-    directions = (north, south, east, west)
-    for direction in directions:
-        nbx = dead_node[0] + direction[0]
-        nby = dead_node[1] + direction[1]
-        if nbx not in (0, w - 1, w // 2 - 1) and nby not in (0, h - 1):
-            neighbor = maze[nby, nbx]
-            if neighbor == W:
-                maze[nby, nbx] = E
-                break
-
-
-def remove_all_dead_ends(maze):
-    height, width = maze.shape
-    while True:
-        maze_graph = walls_to_graph(maze)
-        dead_ends = find_dead_ends(maze_graph, width)
-        if len(dead_ends) == 0:
-            break
-        remove_dead_end(dead_ends[0], maze)
-
-
-def get_neighboring_walls(maze, locs):
-    """Given a list of coordinates in the maze, return all neighboring walls.
-
-    Walls on the outer border are ignored automatically."""
-    height, width = maze.shape
-    walls = []
-    seen = []
-    for nodex, nodey in locs:
-        # if we are already on the border, skip this node
-        if nodex <= 0 or nodex >= (width - 1) or nodey <= 0 or nodey >= (height - 1):
-            continue
-        # explore all directions around the current node
-        for dirx, diry in (north, south, east, west):
-            # get coordinates of neighbor in direction (dirx, diry)
-            adjx, adjy = nodex + dirx, nodey + diry
-            if (adjx, adjy) in seen:
-                # we have visited this neighbor already
-                continue
-            else:
-                seen.append((adjx, adjy))
-            # check that we still are inside the maze
-            if adjx <= 0 or adjx >= (width - 1) or adjy <= 0 or adjy >= (height - 1):
-                # the neighbor is out of the maze
-                continue
-            if maze[adjy, adjx] == W:
-                # this is a wall, store it
-                walls.append((adjx, adjy))
-    return walls
-
-
-def remove_all_chambers(maze, rng=None):
-    rng = default_rng(rng)
-    width = maze.shape[1]
-
-    while True:
-        maze_graph = walls_to_graph(maze)
-        # this will find one of the chambers, if there is any
-        # entrance, chamber = find_chamber(maze_graph)
-        chamber_tiles = find_chambers(maze_graph, width)
-
-        if len(chamber_tiles) == 0:
-            break
-
-        subgraphs = maze_graph.subgraph(chamber_tiles)
-        chambers = list(nx.connected_components(subgraphs))
-
-        for chamber in chambers:
-            # get all the walls around the chamber
-            walls = get_neighboring_walls(maze, chamber)
-
-            # choose a wall at random among the neighboring one and get rid of it
-            if walls:
-                bad_wall = rng.choice(walls)
-                maze[bad_wall[1], bad_wall[0]] = E
-
-
-def add_food(maze, max_food, rng=None):
-    """Add max_food pellets on the left side of the maze.
-
-    We exclude the pacmen's starting positions and the central dividing border
-    """
-    rng = default_rng(rng)
-
-    if max_food == 0:
-        # no food needs to be added, return here
-        return
-    h, w = maze.shape
-    pacmen = [(1, h - 2), (1, h - 3)]
-    # get all free slots on the left side, excluding the dividing border
-    free_y, free_x = np.where(maze[:, : w // 2 - 1] == E)
-    # convert it to a list of coordinate tuples
-    free = list(zip(free_x, free_y))
-    # remove the pacmen starting coordinates (we have to check that they are
-    # indeed free before try to remove them
-    [free.remove(pacman) for pacman in pacmen if pacman in free]
-    # check if we have any free slots left
-    if len(free) == 0 and max_food > 0:
-        raise ValueError(f"No space left for food in maze")
-    elif max_food > len(free):
-        # check if we can indeed fit so much food in the maze
-        raise ValueError(f"Can not fit {max_food} pellet in {len(free)} free slots")
-    elif max_food < 0:
-        raise ValueError(f"Can not add negative number of food ({max_food} given)")
-
-    # now take max_food random positions out of this list
-    food = rng.sample(free, max_food)
-    # fit it in the maze
-    for col, row in food:
-        maze[row, col] = F
-
-
-def add_pacmen(maze):
-    ## starting pacmen positions
-    maze[-2, 1] = b"b"
-    maze[-3, 1] = b"a"
-    maze[1, -2] = b"y"
-    maze[2, -2] = b"x"
-
-
-def hold_pacmen(maze):
-    ## starting pacmen positions
-    maze[-2, 1] = E
-    maze[-3, 1] = E
-    maze[1, -2] = E
-    maze[2, -2] = E
-
-
-def create_maze(height, width, nfood, dead_ends=False, rng=None):
-    """Create a new maze in text format.
-
-    The maze is created with a recursive creation algorithm. The maze part of
-    the blue team is a center-mirror version of the one for the red team.
-
-    The function reserves space for 2 PacMan for each team in upper-right
-    and lower-left corners of the maze. Food is added at random.
-
-    Input arguments:
-    height, width -- the size of the maze, including the outer walls
-    nfood -- number of food dots for each team
-    seed -- if not None, the random seed used to generate the maze
-    dead_ends -- if True allow for dead ends and chambers in the maze
-
-    A dead-end is a node with connectivity one.
-    A chamber is a sub-graph such that there is a node in the sub-graph, the
-    entrance to the chamber, that when removed from the graph will result in the
-    graph to be split into two disconnected graphs.
-    """
-    if width % 2 != 0:
-        raise ValueError(f"Width must be even ({width} given)")
-
-    rng = default_rng(rng)
-
-    maze = empty_maze(height, width)
-    create_half_maze(maze, height // 2, rng=rng)
-
-    # make space for pacman (2 pacman each)
-    maze[-2, 1] = E
-    maze[-3, 1] = E
-
-    # remove dead ends
-    if not dead_ends:
-        remove_all_dead_ends(maze)
-        remove_all_chambers(maze, rng=rng)
-
-    # add food
-    add_food(maze, nfood, rng=rng)
-
-    # complete right part of maze with mirror copy
-    maze[:, width // 2 :] = np.flipud(np.fliplr(maze[:, : width // 2]))
-
-    # add pacman
-    add_pacmen(maze)
-
-    return maze_to_str(maze)
-
-
-def find_chambers(G: nx.Graph, width: int):
+def find_chambers(graph, width):
     main_chamber = set()
     chamber_tiles = set()
 
-    for chamber in nx.biconnected_components(G):
+    for chamber in nx.biconnected_components(graph):
         max_x = max(chamber, key=lambda n: n[0])[0]
         min_x = min(chamber, key=lambda n: n[0])[0]
         if min_x < width // 2 <= max_x:
@@ -492,8 +115,7 @@ def distribute_food(all_tiles, chamber_tiles, trapped_food, total_food, rng=None
     return tf_pos | ff_pos | leftover_food_pos
 
 
-
-def generate_walls(partition, walls, ngaps, vertical, rng=None):
+def add_wall(partition, walls, ngaps, vertical, rng=None):
     rng = default_rng(rng)
 
     (xmin, ymin), (xmax, ymax) = partition
@@ -578,13 +200,13 @@ def generate_walls(partition, walls, ngaps, vertical, rng=None):
                       ((xmin, pos+1), (xmax,  ymax))]
 
     for partition in partitions:
-        walls |= generate_walls(
+        walls |= add_wall(
             partition, walls, max(1, ngaps // 2), not vertical, rng=rng
         )
 
     return walls
 
-def generate_half_maze(width, height, ngaps_center, bots_pos, rng=None):
+def create_half_maze(width, height, ngaps_center, bots_pos, rng=None):
     # use binary space partitioning
     rng = default_rng(rng)
 
@@ -622,7 +244,7 @@ def generate_half_maze(width, height, ngaps_center, bots_pos, rng=None):
     partition = ((1, 1), (x_wall - 1, ymax * 2))
 
 
-    walls = generate_walls(
+    walls = add_wall(
         partition,
         walls,
         ngaps_center // 2,
@@ -638,22 +260,7 @@ def generate_half_maze(width, height, ngaps_center, bots_pos, rng=None):
     return walls
 
 
-def mirror(nodes, width, height):
-    nodes = set(nodes)
-    other = set((width - 1 - x, height - 1 - y) for x, y in nodes)
-    return nodes | other
-
-
-def sample_nodes(nodes, k, rng=None):
-    rng = default_rng(rng)
-
-    if k < len(nodes):
-        return set(rng.sample(sorted(nodes), k=k))
-    else:
-        return nodes
-
-
-def create_maze_graph(trapped_food=10, total_food=30, width=32, height=16, rng=None):
+def create_maze(trapped_food=10, total_food=30, width=32, height=16, rng=None):
     if width % 2 != 0:
         raise ValueError(f"Width must be even ({width} given)")
 
@@ -669,14 +276,14 @@ def create_maze_graph(trapped_food=10, total_food=30, width=32, height=16, rng=N
     # this allows us to cut the execution time in two, because the following
     # graph operations are quite expensive
     pacmen_pos = set([(1, height - 3), (1, height - 2)])
-    walls = generate_half_maze(width, height, height//2, pacmen_pos, rng=rng)
+    walls = create_half_maze(width, height, height//2, pacmen_pos, rng=rng)
 
     # transform to graph to find dead ends and chambers for food distribution
     # IMPORTANT: we have to include one column of the right border in the graph
     # generation, or our algorith to find chambers would get confused
     # Note: this only works because in the right side of the maze we have no walls
     # except for the surrounding ones.
-    graph = walls_to_graph_team(walls, shape=(width//2+1, height))
+    graph = walls_to_graph(walls, shape=(width//2+1, height))
 
     # the algorithm should actually guarantee this, but just to make sure, let's
     # fail if the graph is not fully connected

--- a/pelita/maze_generator.py
+++ b/pelita/maze_generator.py
@@ -306,12 +306,13 @@ def get_neighboring_walls(maze, locs):
 
 def remove_all_chambers(maze, rng=None):
     rng = default_rng(rng)
+    width = maze.shape[1]
 
     while True:
         maze_graph = walls_to_graph(maze)
         # this will find one of the chambers, if there is any
         # entrance, chamber = find_chamber(maze_graph)
-        chambers, chamber_tiles = find_chambers(maze_graph, maze.shape)
+        chambers, chamber_tiles = find_chambers(maze_graph, width)
 
         if not chambers:
             break
@@ -426,16 +427,14 @@ def create_maze(height, width, nfood, dead_ends=False, rng=None):
     return maze_to_str(maze)
 
 
-def find_chambers(G: nx.Graph, shape):
-    w, h = shape
-
+def find_chambers(G: nx.Graph, width: int):
     main_chamber = set()
     chamber_tiles = set()
 
     for chamber in nx.biconnected_components(G):
         max_x = max(chamber, key=lambda n: n[0])[0]
         min_x = min(chamber, key=lambda n: n[0])[0]
-        if min_x < w // 2 <= max_x:
+        if min_x < width // 2 <= max_x:
             # only the main chamber covers both sides
             # our own mazes should only have one central chamber
             # but other configurations could have more than one
@@ -519,7 +518,7 @@ def create_maze_food(trapped_food, total_food, width, height, rng=None):
     half_graph = walls_to_graph(maze[:, : width // 2])
     full_graph = walls_to_graph(maze)
 
-    _, chamber_tiles = find_chambers(full_graph, (width, height))
+    _, chamber_tiles = find_chambers(full_graph, width)
 
     chamber_tiles = [tile for tile in chamber_tiles if tile[0] < width // 2]
     half_food = distribute_food(

--- a/pelita/maze_generator.py
+++ b/pelita/maze_generator.py
@@ -258,15 +258,15 @@ def remove_all_dead_ends(maze):
     while True:
         maze_graph = walls_to_graph(maze)
         dead_ends = find_dead_ends(maze_graph, width)
-        for dead_end in dead_ends:
-            remove_dead_end(dead_end, maze)
-
         if len(dead_ends) == 0:
             break
+        remove_dead_end(dead_ends[0], maze)
 
 
-def find_chambers(graph, cuts, shape):
-    w, h = shape
+def find_chambers(graph, shape):
+    cuts = set(nx.articulation_points(graph))
+
+    h, w = shape
     chamber_tiles = set()
     G = graph
 
@@ -321,20 +321,23 @@ def get_neighboring_walls(maze, locs):
 def remove_all_chambers(maze, rng=None):
     rng = default_rng(rng)
 
-    maze_graph = walls_to_graph(maze)
-    # this will find one of the chambers, if there is any
-    # entrance, chamber = find_chamber(maze_graph)
-    cuts = list(nx.articulation_points(maze_graph))
-    chambers, chamber_tiles = find_chambers(maze_graph, cuts, maze.shape)
+    while True:
+        maze_graph = walls_to_graph(maze)
+        # this will find one of the chambers, if there is any
+        # entrance, chamber = find_chamber(maze_graph)
+        chambers, chamber_tiles = find_chambers(maze_graph, maze.shape)
 
-    for chamber in chambers:
-        # get all the walls around the chamber
-        walls = get_neighboring_walls(maze, chamber)
+        if not chambers:
+            break
 
-        # choose a wall at random among the neighboring one and get rid of it
-        if walls:
-            bad_wall = rng.choice(walls)
-            maze[bad_wall[1], bad_wall[0]] = E
+        for chamber in chambers:
+            # get all the walls around the chamber
+            walls = get_neighboring_walls(maze, chamber)
+
+            # choose a wall at random among the neighboring one and get rid of it
+            if walls:
+                bad_wall = rng.choice(walls)
+                maze[bad_wall[1], bad_wall[0]] = E
 
 
 def add_food(maze, max_food, rng=None):

--- a/pelita/maze_generator.py
+++ b/pelita/maze_generator.py
@@ -33,6 +33,7 @@ Completely rewritten by Pietro Berkes
 Rewritten again (but not completely) by Tiziano Zito
 Rewritten completely by Jakob Zahn & Tiziano Zito
 """
+
 import networkx as nx
 
 from .base_utils import default_rng
@@ -181,7 +182,7 @@ def add_wall_and_split(partition, walls, ngaps, vertical, rng=None):
     ngaps = max(1, ngaps)
     wall_pos = list(range(max_length))
     rng.shuffle(wall_pos)
-    gaps_pos = wall_pos[:ngaps]
+
     for gap in wall_pos[:ngaps]:
         if vertical:
             wall.discard((pos, ymin+gap))
@@ -207,6 +208,7 @@ def add_wall_and_split(partition, walls, ngaps, vertical, rng=None):
         )
 
     return walls
+
 
 def generate_half_maze(width, height, ngaps_center, bots_pos, rng=None):
     # use binary space partitioning
@@ -245,7 +247,6 @@ def generate_half_maze(width, height, ngaps_center, bots_pos, rng=None):
     walls |= wall
     partition = ((1, 1), (x_wall - 1, ymax * 2))
 
-
     walls = add_wall_and_split(
         partition,
         walls,
@@ -274,14 +275,14 @@ def generate_maze(trapped_food=10, total_food=30, width=32, height=16, rng=None)
 
     rng = default_rng(rng)
 
-    # get a full maze, but only the left half is filled with random walls
+    # generate a full maze, but only the left half is filled with random walls
     # this allows us to cut the execution time in two, because the following
     # graph operations are quite expensive
     pacmen_pos = set([(1, height - 3), (1, height - 2)])
     walls = generate_half_maze(width, height, height//2, pacmen_pos, rng=rng)
 
     ### TODO: hide the chamber_finding in another function, create the graph with
-    # a wall on the right border + 1, so taht find chambers works reliably and
+    # a wall on the right border + 1, so that find chambers works reliably and
     # we can get rid of the  {.... if tile[0] < border} in the following
     # also, improve find_chambers so that it does not use x and width, but just
     # requires two sets of nodes representing the left and the right of the border
@@ -290,7 +291,7 @@ def generate_maze(trapped_food=10, total_food=30, width=32, height=16, rng=None)
 
     # transform to graph to find dead ends and chambers for food distribution
     # IMPORTANT: we have to include one column of the right border in the graph
-    # generation, or our algorith to find chambers would get confused
+    # generation, or our algorithm to find chambers would get confused
     # Note: this only works because in the right side of the maze we have no walls
     # except for the surrounding ones.
     graph = walls_to_graph(walls, shape=(width//2+1, height))
@@ -298,7 +299,7 @@ def generate_maze(trapped_food=10, total_food=30, width=32, height=16, rng=None)
     # the algorithm should actually guarantee this, but just to make sure, let's
     # fail if the graph is not fully connected
     if not nx.is_connected(graph):
-        raise ValueError(f"Generated maze is not fully connected, try a different random seed")
+        raise ValueError("Generated maze is not fully connected, try a different random seed")
 
     # this gives us a set of tiles that are "trapped" within chambers, i.e. tunnels
     # with a dead-end or a section of tiles fully enclosed by walls except for a single
@@ -310,7 +311,7 @@ def generate_maze(trapped_food=10, total_food=30, width=32, height=16, rng=None)
     # those right on the border of the homezone
     # also, no food on the initial positions of the pacmen
     # IMPORTANT: the relevant chamber tiles are only those in the left side of
-    # the maze. By detecing chambers on only half of the maze, we may still have
+    # the maze. By detecting chambers on only half of the maze, we may still have
     # spurious chambers on the right side
     border = width//2 - 1
     chamber_tiles = {tile for tile in chamber_tiles if tile[0] < border} - pacmen_pos
@@ -328,4 +329,3 @@ def generate_maze(trapped_food=10, total_food=30, width=32, height=16, rng=None)
                "shape" : (width, height) }
 
     return layout
-

--- a/pelita/maze_generator.py
+++ b/pelita/maze_generator.py
@@ -23,7 +23,6 @@ Rewritten again (but not completely) by Tiziano Zito
 import networkx as nx
 import numpy as np
 
-from pelita.team import walls_to_graph
 
 from .base_utils import default_rng
 
@@ -202,7 +201,7 @@ def _add_wall(maze, ngaps, vertical, rng):
             _add_wall(sub_maze, max(1, ngaps // 2), not vertical, rng=rng)
 
 
-def maze_to_graph(maze):
+def walls_to_graph(maze):
     """Transform a maze in a graph.
 
     The data on the nodes correspond to their coordinates, data on edges is
@@ -268,7 +267,7 @@ def remove_dead_end(dead_node, maze):
 def remove_all_dead_ends(maze):
     height, width = maze.shape
     while True:
-        maze_graph = walls_to_graph(maze, maze.shape)
+        maze_graph = walls_to_graph(maze)
         dead_ends = find_dead_ends(maze_graph, width)
         if len(dead_ends) == 0:
             break
@@ -309,7 +308,7 @@ def remove_all_chambers(maze, rng=None):
     rng = default_rng(rng)
 
     while True:
-        maze_graph = walls_to_graph(maze, maze.shape)
+        maze_graph = walls_to_graph(maze)
         # this will find one of the chambers, if there is any
         # entrance, chamber = find_chamber(maze_graph)
         chambers, chamber_tiles = find_chambers(maze_graph, maze.shape)
@@ -517,8 +516,8 @@ def create_maze_food(trapped_food, total_food, width, height, rng=None):
     walls = np.transpose((x, y)).tolist()
     walls = tuple(sorted(tuple(wall) for wall in walls))
 
-    half_graph = maze_to_graph(maze[:, : width // 2])
-    full_graph = maze_to_graph(maze)
+    half_graph = walls_to_graph(maze[:, : width // 2])
+    full_graph = walls_to_graph(maze)
 
     _, chamber_tiles = find_chambers(full_graph, (width, height))
 

--- a/test/test_maze_generation.py
+++ b/test/test_maze_generation.py
@@ -185,7 +185,13 @@ def test_remove_multiple_dead_ends():
     expected_maze = mg.str_to_maze(expected_maze)
     assert np.all(maze == expected_maze)
 
-def test_find_chamber():
+    graph = mg.walls_to_graph(maze)
+    width = maze.shape[1]
+    dead_ends = mg.find_dead_ends(graph, width)
+    assert len(dead_ends) == 0
+
+
+def test_find_chambers():
     # This maze has one single chamber, whose entrance is one of the
     # nodes (1,2), (1,3) or (1,4)
     maze_chamber = """############
@@ -204,28 +210,17 @@ def test_find_chamber():
     # now check that we detect it
     graph = mg.walls_to_graph(maze)
     # there are actually two nodes that can be considered entrances
-    entrance, chamber = mg.find_chamber(graph)
-    assert entrance in ((1,2), (1,3), (1,4))
-    # check that the chamber contains the right nodes. Convert to set, because
-    # the order is irrelevant
-    if entrance == (1,4):
-        expected_chamber = {(1,1), (1,2), (1,3), (2,1), (2,2), (3,1), (3,2)}
-    elif entrance == (1,3):
-        expected_chamber = {(1,1), (1,2), (2,1), (2,2), (3,1), (3,2)}
-    else:
-        expected_chamber = {(1,1), (2,1), (2,2), (3,1), (3,2)}
-    assert set(chamber) == expected_chamber
+    chambers, chamber_tiles = mg.find_chambers(graph, maze_orig.shape)
+    assert len(chambers) == 1
+    assert chambers[0] == {(1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (3, 1), (3, 2)}
 
     # now remove the chamber and verify that we don't detect anything
     # we just remove wall (4,1) manually
     maze = mg.str_to_maze(maze_chamber)
     maze[1,4] = mg.E # REMEMBER! Indexing is maze[y,x]!!!
     graph = mg.walls_to_graph(maze)
-    entrance, chamber = mg.find_chamber(graph)
-    assert entrance is None
-    assert chamber == []
-
-
+    chambers, chamber_tiles = mg.find_chambers(graph, maze_orig.shape)
+    assert chambers == []
 
 
 maze_one_chamber = """############

--- a/test/test_maze_generation.py
+++ b/test/test_maze_generation.py
@@ -119,7 +119,6 @@ def test_add_food():
     assert np.all(lmaze == maze)
 
 
-@pytest.mark.xfail
 def test_distribute_food():
     maze_chamber = """############
                       #   #      #
@@ -129,11 +128,9 @@ def test_distribute_food():
                       #          #
                       ############"""
 
-    maze = mg.str_to_maze(maze_chamber)
-    graph = mg.walls_to_graph(maze)
+    graph, shape = layout_str_to_graph(maze_chamber)
     all_tiles = set(graph.nodes)
-    width = maze.shape[1]
-    chamber_tiles = mg.find_chambers(graph, width)
+    chamber_tiles, _ = mg.find_trapped_tiles(graph, shape[0], include_chambers=True)
 
     # expected exceptions
     with pytest.raises(ValueError):

--- a/test/test_maze_generation.py
+++ b/test/test_maze_generation.py
@@ -210,7 +210,8 @@ def test_find_chambers():
     # now check that we detect it
     graph = mg.walls_to_graph(maze)
     # there are actually two nodes that can be considered entrances
-    chambers, chamber_tiles = mg.find_chambers(graph, maze_orig.shape)
+    width = maze_orig.shape[1]
+    chambers, chamber_tiles = mg.find_chambers(graph, width)
     assert len(chambers) == 1
     assert chambers[0] == {(1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (3, 1), (3, 2)}
 
@@ -219,7 +220,7 @@ def test_find_chambers():
     maze = mg.str_to_maze(maze_chamber)
     maze[1,4] = mg.E # REMEMBER! Indexing is maze[y,x]!!!
     graph = mg.walls_to_graph(maze)
-    chambers, chamber_tiles = mg.find_chambers(graph, maze_orig.shape)
+    chambers, chamber_tiles = mg.find_chambers(graph, width)
     assert chambers == []
 
 

--- a/test/test_maze_generation.py
+++ b/test/test_maze_generation.py
@@ -79,46 +79,6 @@ def test_find_trapped_tiles():
 
 
 
-@pytest.mark.xfail
-def test_add_food():
-    mini = """########
-              #      #
-              #      #
-              ########"""
-    maze = mg.str_to_maze(mini)
-    # We have 12 empty squares in total, so 6 on the left side.
-    # -> 2 slots are taken by the dividing border, so we have 4 left
-    # -> 2 are reserved for pacmen, so we have only 2 slots for food
-    # - check that we can indeed accommodate 2 pellets in the maze
-    lmaze = maze.copy()
-    mg.add_food(lmaze, 2)
-    assert (lmaze == mg.F).sum() == 2
-    # - check that if we add a wall in a free spot that is not reserved by the
-    #   pacmen we can only accommodate 1 pellet
-    lmaze = maze.copy()
-    lmaze[1,2] = mg.W
-    mg.add_food(lmaze, 1)
-    assert (lmaze == mg.F).sum() == 1
-    # - if we try to add more food, we complain
-    lmaze = maze.copy()
-    lmaze[1,2] = mg.W
-    with pytest.raises(ValueError):
-        mg.add_food(lmaze, 2)
-    # - check that if no space is left we complain
-    lmaze = maze.copy()
-    lmaze[1,2], lmaze[2,2] = mg.W, mg.W
-    with pytest.raises(ValueError):
-        mg.add_food(lmaze, 1)
-    # - check that we fail if we get passed unreasonable amounts of food
-    lmaze = maze.copy()
-    with pytest.raises(ValueError):
-        mg.add_food(lmaze, -1)
-    # - check that we can cope with no food to add
-    lmaze = maze.copy()
-    mg.add_food(lmaze, 0)
-    assert np.all(lmaze == maze)
-
-
 def test_distribute_food():
     maze_chamber = """############
                       #   #      #
@@ -130,7 +90,7 @@ def test_distribute_food():
 
     graph, shape = layout_str_to_graph(maze_chamber)
     all_tiles = set(graph.nodes)
-    chamber_tiles, _ = mg.find_trapped_tiles(graph, shape[0], include_chambers=True)
+    chamber_tiles, _ = mg.find_trapped_tiles(graph, shape[0], include_chambers=False)
 
     # expected exceptions
     with pytest.raises(ValueError):

--- a/test/test_maze_generation.py
+++ b/test/test_maze_generation.py
@@ -30,10 +30,10 @@ maze_103525239 = """
 ################################
 """
 
-def test_create_maze_stability():
+def test_generate_maze_stability():
     # we only test that we keep in returning the same maze when the random
     # seed is fixed, in case something changes during future porting/refactoring
-    new_layout = mg.create_maze(rng=SEED)
+    new_layout = mg.generate_maze(rng=SEED)
     old_layout = pl.parse_layout(maze_103525239)
     assert old_layout == new_layout
 
@@ -259,22 +259,22 @@ np_maze_generator_86523 = """
 
 
 @pytest.mark.parametrize('iteration', range(100))
-def test_create_maze(iteration):
+def test_generate_maze(iteration):
     local_seed = SEED * iteration
     rng = Random(local_seed)
 
     # edge cases
     # width not even
     with pytest.raises(ValueError):
-        mg.create_maze(0, 0, 9, 10, rng=rng)
+        mg.generate_maze(0, 0, 9, 10, rng=rng)
 
     # width too small
     with pytest.raises(ValueError):
-        mg.create_maze(0, 0, 2, 10, rng=rng)
+        mg.generate_maze(0, 0, 2, 10, rng=rng)
 
     # height too small
     with pytest.raises(ValueError):
-        mg.create_maze(0, 0, 10, 2, rng=rng)
+        mg.generate_maze(0, 0, 10, 2, rng=rng)
 
 
     width = rng.choice(range(16, 65, 2))
@@ -282,7 +282,7 @@ def test_create_maze(iteration):
     total_food = int(0.15 * width * height / 2)
     trapped_food = int(total_food / 3)
 
-    ld = mg.create_maze(trapped_food, total_food, width, height, rng=rng)
+    ld = mg.generate_maze(trapped_food, total_food, width, height, rng=rng)
 
     walls = set(ld["walls"])
 
@@ -352,12 +352,12 @@ def test_create_maze(iteration):
 
     # verify that we generate exactly the same maze if started with the same seed
     seed = rng.randint(1,100000)
-    l1 = mg.create_maze(trapped_food, total_food, width, height, rng=seed)
-    l2 = mg.create_maze(trapped_food, total_food, width, height, rng=seed)
+    l1 = mg.generate_maze(trapped_food, total_food, width, height, rng=seed)
+    l2 = mg.generate_maze(trapped_food, total_food, width, height, rng=seed)
     assert l1 == l2
 
 @pytest.mark.parametrize('iteration', range(100))
-def test_create_maze_food(iteration):
+def test_generate_maze_food(iteration):
     local_seed = SEED + iteration
     rng = Random(local_seed)
 
@@ -365,7 +365,7 @@ def test_create_maze_food(iteration):
     height = 5
     total_food = 10
     trapped_food = 0
-    ld = mg.create_maze(trapped_food, total_food, width, height, rng=rng)
+    ld = mg.generate_maze(trapped_food, total_food, width, height, rng=rng)
     # check that we never place food on the border
     x_food = {x for (x, y) in ld['food']}
     assert width//2 not in x_food

--- a/test/test_maze_generation.py
+++ b/test/test_maze_generation.py
@@ -508,6 +508,17 @@ def test_create_layout(iteration):
     assert min(ld["walls"]) == (0, 0)
     assert max(ld["walls"]) == (width - 1, height - 1)
 
+    # verify that the types in the dictionary are as expected
+    def is_seq_of_tuples(seq_type, thing):
+        assert type(thing) is seq_type
+        for item in thing:
+            assert type(item) is tuple
+
+    is_seq_of_tuples(tuple, ld["walls"])
+    is_seq_of_tuples(list, ld["food"])
+    is_seq_of_tuples(list, ld["bots"])
+    assert type(ld["shape"]) is tuple
+
     # verify that we generate exactly the same maze if started with the same seed
     seed = rng.randint(1,100000)
     l1 = mg.create_layout(trapped_food, total_food, width, height, rng=seed)

--- a/test/test_maze_generation.py
+++ b/test/test_maze_generation.py
@@ -507,3 +507,9 @@ def test_create_layout(iteration):
     # verify shape
     assert min(ld["walls"]) == (0, 0)
     assert max(ld["walls"]) == (width - 1, height - 1)
+
+    # verify that we generate exactly the same maze if started with the same seed
+    seed = rng.randint(1,100000)
+    l1 = mg.create_layout(trapped_food, total_food, width, height, rng=seed)
+    l2 = mg.create_layout(trapped_food, total_food, width, height, rng=seed)
+    assert l1 == l2

--- a/test/test_maze_generation.py
+++ b/test/test_maze_generation.py
@@ -6,191 +6,38 @@ import numpy as np
 import pytest
 
 import pelita.maze_generator as mg
-import pelita.layout
+import pelita.layout as pl
 
 SEED = 103525239
 
 
-def test_maze_bytes_str_conversions():
-    # note that the first empty line is needed!
-    maze_str = """
-                  ##################
-                  #. ... .##.     y#
-                  # # #  .  .### #x#
-                  # # ##.   .      #
-                  #      .   .## # #
-                  #a# ###.  .  # # #
-                  #b     .##. ... .#
-                  ##################"""
-    maze_bytes = bytes(maze_str, 'ascii')
-    maze_clist = [[b'#',b'#',b'#',b'#',b'#',b'#',b'#',b'#',b'#',b'#',b'#',b'#',b'#',b'#',b'#',b'#',b'#',b'#'],
-                  [b'#',b'.',b' ',b'.',b'.',b'.',b' ',b'.',b'#',b'#',b'.',b' ',b' ',b' ',b' ',b' ',b'y',b'#'],
-                  [b'#',b' ',b'#',b' ',b'#',b' ',b' ',b'.',b' ',b' ',b'.',b'#',b'#',b'#',b' ',b'#',b'x',b'#'],
-                  [b'#',b' ',b'#',b' ',b'#',b'#',b'.',b' ',b' ',b' ',b'.',b' ',b' ',b' ',b' ',b' ',b' ',b'#'],
-                  [b'#',b' ',b' ',b' ',b' ',b' ',b' ',b'.',b' ',b' ',b' ',b'.',b'#',b'#',b' ',b'#',b' ',b'#'],
-                  [b'#',b'a',b'#',b' ',b'#',b'#',b'#',b'.',b' ',b' ',b'.',b' ',b' ',b'#',b' ',b'#',b' ',b'#'],
-                  [b'#',b'b',b' ',b' ',b' ',b' ',b' ',b'.',b'#',b'#',b'.',b' ',b'.',b'.',b'.',b' ',b'.',b'#'],
-                  [b'#',b'#',b'#',b'#',b'#',b'#',b'#',b'#',b'#',b'#',b'#',b'#',b'#',b'#',b'#',b'#',b'#',b'#']]
-    maze_arr = np.array(maze_clist, dtype=bytes)
-    assert np.all(mg.bytes_to_maze(maze_bytes) == maze_arr)
-    assert np.all(mg.str_to_maze(maze_str) == maze_arr)
-    # round trip
-    # we must dedent the string and remove the first newline
-    # we have the newline in the first line to have dedent work out of the box
-    maze_str = textwrap.dedent(maze_str[1:])
-    maze_bytes = bytes(maze_str, 'ascii')
-    assert mg.maze_to_bytes(maze_arr) == maze_bytes
-    assert mg.maze_to_str(maze_arr) == maze_str
+maze_103525239 = """
+################################
+#.   .....#....##    .      . y#
+# .# #########      # .    #  x#
+#  # # .     .    # ######    ##
+#  #    .    # ##.         #   #
+#  ####### ###    #.      .# ..#
+# .#     .  ..    ### # ##.#####
+# ### ###### ####  .    #.   . #
+# .   .#    .  #### ###### ### #
+#####.## # ###    ..  .     #. #
+#.. #.      .#    ### #######  #
+#   #         .## #    .    #  #
+##    ###### #    .     . # #  #
+#a  #    . #      ######### #. #
+#b .      .    ##....#.....   .#
+################################
+"""
 
-
-def test_create_half_maze():
-    # this test is not really testing that create_half_maze does a good job
+def test_create_maze_stability():
     # we only test that we keep in returning the same maze when the random
     # seed is fixed, in case something changes during future porting/refactoring
-    maze_str = """################################
-                  #         #    #               #
-                  #  # #########                 #
-                  #  # #                         #
-                  #  #         # #               #
-                  #  ####### ###                 #
-                  #  #                           #
-                  # ### ###### ###               #
-                  #      #       #               #
-                  ##### ## # ###                 #
-                  #   #        #                 #
-                  #   #          #               #
-                  ##    ###### #                 #
-                  #   #      #                   #
-                  #              #               #
-                  ################################"""
+    new_layout = mg.create_maze(rng=SEED)
+    old_layout = pl.parse_layout(maze_103525239)
+    assert old_layout == new_layout
 
-    maze = mg.empty_maze(16,32)
-    mg.create_half_maze(maze, 8, rng=SEED)
-    expected = mg.str_to_maze(maze_str)
-    assert np.all(maze == expected)
-
-def test_conversion_to_nx_graph():
-    maze_str = """##################
-                  #       ##       #
-                  # # #      ### # #
-                  # # ##           #
-                  #           ## # #
-                  # # ###      # # #
-                  #       ##       #
-                  ##################"""
-    maze = mg.str_to_maze(maze_str)
-    graph = mg.walls_to_graph(maze)
-    # now derive a maze from a graph manually
-    # - start with a maze full of walls
-    newmaze = mg.empty_maze(maze.shape[0], maze.shape[1])
-    newmaze.fill(mg.W)
-    # - loop through each node of the graph and remove a wall at the
-    # corresponding coordinate
-    for node in graph.nodes():
-        newmaze[node[1], node[0]] = mg.E
-    assert np.all(maze == newmaze)
-
-def test_find_one_dead_end():
-    # this maze has exactly one dead end at coordinate (1,1)
-    maze_dead = """########
-                   # #    #
-                   #      #
-                   #      #
-                   ########"""
-
-    maze = mg.str_to_maze(maze_dead)
-    graph = mg.walls_to_graph(maze)
-    width = maze.shape[1]
-    dead_ends = mg.find_dead_ends(graph, width)
-    assert len(dead_ends) == 1
-    assert dead_ends[0] == (1,1)
-
-def test_find_multiple_dead_ends():
-    # this maze has exactly three dead ends at coordinates (1,1), (1,5), (3,5)
-    maze_dead = """############
-                   # #        #
-                   #          #
-                   #          #
-                   # # #      #
-                   # # #      #
-                   ############"""
-
-    maze = mg.str_to_maze(maze_dead)
-    graph = mg.walls_to_graph(maze)
-    width = maze.shape[1]
-    dead_ends = mg.find_dead_ends(graph, width)
-    assert len(dead_ends) == 3
-    dead_ends.sort()
-    assert dead_ends[0] == (1,1)
-    assert dead_ends[1] == (1,5)
-    assert dead_ends[2] == (3,5)
-
-def test_find_multiple_dead_ends_on_the_right():
-    # this maze has exactly three dead ends at coordinates (10,1), (10,5), (8,5)
-    maze_dead = """############
-                   #        # #
-                   #          #
-                   #          #
-                   #      # # #
-                   #      # # #
-                   ############"""
-
-    maze = mg.str_to_maze(maze_dead)
-    graph = mg.walls_to_graph(maze)
-    width = maze.shape[1]
-    dead_ends = mg.find_dead_ends(graph, width)
-    assert len(dead_ends) == 3
-    dead_ends.sort()
-    assert dead_ends[2] == (10,5)
-    assert dead_ends[1] == (10,1)
-    assert dead_ends[0] == (8,5)
-
-def test_remove_one_dead_end():
-    # this maze has exactly one dead end at coordinate (1,1)
-    maze_dead = """########
-                   # #    #
-                   #      #
-                   #      #
-                   ########"""
-
-    maze = mg.str_to_maze(maze_dead)
-    mg.remove_dead_end((1,1), maze)
-    assert maze[1,1] == mg.E
-
-def test_remove_multiple_dead_ends():
-    # this maze has exactly three dead ends at coordinates (1,1), (1,5), (3,5)
-    maze_dead = """############
-                   # #        #
-                   #          #
-                   #          #
-                   # # #      #
-                   # # #      #
-                   ############"""
-
-    maze = mg.str_to_maze(maze_dead)
-    mg.remove_all_dead_ends(maze)
-    # There are many ways of getting rid of the two dead ends at the bottom
-    # The one that requires the less work is to remove the left-bottom wall
-    # This one is the solution we get from remove_all_dead_ends, but just
-    # because the order in which we find dead ends is from top to bottom and from
-    # left to right.
-    # In other words, remove the dead ends here actually means getting this maze back
-    expected_maze = """############
-                       #          #
-                       #          #
-                       #          #
-                       # # #      #
-                       #   #      #
-                       ############"""
-    expected_maze = mg.str_to_maze(expected_maze)
-    assert np.all(maze == expected_maze)
-
-    graph = mg.walls_to_graph(maze)
-    width = maze.shape[1]
-    dead_ends = mg.find_dead_ends(graph, width)
-    assert len(dead_ends) == 0
-
-
+@pytest.mark.xfail
 def test_find_chambers():
     # This maze has one single chamber, whose entrance is one of the
     # nodes (1,2), (1,3) or (1,4)
@@ -271,7 +118,7 @@ maze_chamber_bonanza = """################################
                           #   #    #  #   #              #
                           ################################"""
 
-
+@pytest.mark.xfail
 @pytest.mark.parametrize("maze_chamber", (maze_one_chamber,
                                           maze_two_chambers,
                                           maze_neighbor_chambers,
@@ -287,46 +134,7 @@ def test_remove_all_chambers(maze_chamber):
     # walls. How can we test that this is not what we are doing but that instead
     # we are removing just a few walls?
 
-@pytest.mark.parametrize('iteration', range(1,11))
-def test_create_maze(iteration):
-    # generate a few mazes and check them for consistency
-    local_seed = SEED * iteration
-    maze_str = mg.create_maze(8,16,nfood=15,rng=local_seed)
-    maze = mg.str_to_maze(maze_str)
-    height, width = maze.shape
-    # check that the returned maze has all the pacmen
-    for pacman in (b'a',b'x',b'b',b'y'):
-        assert np.any(maze == pacman)
-        # now that we now we have a pacman, check that we have it only once
-        # and remove it by putting an empty space instead
-        row, col = np.nonzero(maze == pacman)
-        assert len(row) == 1
-        assert len(col) == 1
-        maze[row,col] = mg.E
-
-    # check that we have in total twice nfood in the maze
-    assert (maze == mg.F).sum() == 15*2
-    # remove the food for computing dead ends and chambers
-    maze[maze == mg.F] = mg.E
-
-    # check that the returned maze is center-mirror symmetric
-    left_maze = np.flipud(np.fliplr(maze[:,width//2:]))
-    assert np.all(left_maze == maze[:,:width//2])
-
-    # check that we don't have any dead ends
-    # no node in the graph should have only one connection
-    graph = mg.walls_to_graph(maze)
-    for node, degree in graph.degree():
-        assert degree > 1
-
-    # now check that we don't have chambers, i.e. the connectivity of the
-    # graph is > 1
-    assert nx.node_connectivity(graph) > 1
-
-def test_odd_width():
-    with pytest.raises(ValueError):
-        mg.create_maze(2,3,1)
-
+@pytest.mark.xfail
 def test_add_food():
     mini = """########
               #      #
@@ -366,6 +174,7 @@ def test_add_food():
     assert np.all(lmaze == maze)
 
 
+@pytest.mark.xfail
 def test_distribute_food():
     maze_chamber = """############
                       #   #      #
@@ -448,52 +257,24 @@ np_maze_generator_86523 = """
 ################################
 """
 
-def test_create_maze_graph_compatibility():
-    # make sure that we are reproducing the mazes generated by the old
-    # numpy implementation
-    seed = 86523
-    height, width = 16,32
-
-
-    # original call was:
-    #np_str = mg.create_maze(height, width, food, dead_ends=True, rng=seed)
-    np_layout = pelita.layout.parse_layout(np_maze_generator_86523)
-    new_layout = mg.create_maze_graph(trapped_food=0, total_food=30, width=width, height=height, rng=seed)
-    # we can not compare the food distribution, because the two algorithms
-    # distribute food in a different way
-    assert np_layout['walls'] == new_layout['walls']
-    assert np_layout['bots'] == new_layout['bots']
 
 @pytest.mark.parametrize('iteration', range(100))
-def test_numpy_compatibility(iteration):
-    local_seed = SEED + iteration
-    height, width = 16,32
-    rand = Random()
-    rand.seed(local_seed)
-    l_str = mg.create_maze(height, width, 30, dead_ends=True, rng=rand)
-    np_layout = pelita.layout.parse_layout(l_str)
-    rand.seed(local_seed)
-    new_layout = mg.create_maze_graph(trapped_food=0, total_food=30, width=width, height=height, rng=rand)
-    assert np_layout['walls'] == new_layout['walls']
-    assert np_layout['bots'] == new_layout['bots']
-
-@pytest.mark.parametrize('iteration', range(100))
-def test_create_maze_graph(iteration):
+def test_create_maze(iteration):
     local_seed = SEED * iteration
     rng = Random(local_seed)
 
     # edge cases
     # width not even
     with pytest.raises(ValueError):
-        mg.create_maze_graph(0, 0, 9, 10, rng=rng)
+        mg.create_maze(0, 0, 9, 10, rng=rng)
 
     # width too small
     with pytest.raises(ValueError):
-        mg.create_maze_graph(0, 0, 2, 10, rng=rng)
+        mg.create_maze(0, 0, 2, 10, rng=rng)
 
     # height too small
     with pytest.raises(ValueError):
-        mg.create_maze_graph(0, 0, 10, 2, rng=rng)
+        mg.create_maze(0, 0, 10, 2, rng=rng)
 
 
     width = rng.choice(range(16, 65, 2))
@@ -501,7 +282,7 @@ def test_create_maze_graph(iteration):
     total_food = int(0.15 * width * height / 2)
     trapped_food = int(total_food / 3)
 
-    ld = mg.create_maze_graph(trapped_food, total_food, width, height, rng=rng)
+    ld = mg.create_maze(trapped_food, total_food, width, height, rng=rng)
 
     walls = set(ld["walls"])
 
@@ -571,12 +352,12 @@ def test_create_maze_graph(iteration):
 
     # verify that we generate exactly the same maze if started with the same seed
     seed = rng.randint(1,100000)
-    l1 = mg.create_maze_graph(trapped_food, total_food, width, height, rng=seed)
-    l2 = mg.create_maze_graph(trapped_food, total_food, width, height, rng=seed)
+    l1 = mg.create_maze(trapped_food, total_food, width, height, rng=seed)
+    l2 = mg.create_maze(trapped_food, total_food, width, height, rng=seed)
     assert l1 == l2
 
 @pytest.mark.parametrize('iteration', range(100))
-def test_create_maze_graph(iteration):
+def test_create_maze_food(iteration):
     local_seed = SEED + iteration
     rng = Random(local_seed)
 
@@ -584,7 +365,7 @@ def test_create_maze_graph(iteration):
     height = 5
     total_food = 10
     trapped_food = 0
-    ld = mg.create_maze_graph(trapped_food, total_food, width, height, rng=rng)
+    ld = mg.create_maze(trapped_food, total_food, width, height, rng=rng)
     # check that we never place food on the border
     x_food = {x for (x, y) in ld['food']}
     assert width//2 not in x_food

--- a/test/test_maze_generation.py
+++ b/test/test_maze_generation.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 
 import pelita.maze_generator as mg
+import pelita.layout
 
 SEED = 103525239
 
@@ -66,7 +67,6 @@ def test_create_half_maze():
     maze = mg.empty_maze(16,32)
     mg.create_half_maze(maze, 8, rng=SEED)
     expected = mg.str_to_maze(maze_str)
-    print(mg.maze_to_str(maze))
     assert np.all(maze == expected)
 
 def test_conversion_to_nx_graph():
@@ -211,17 +211,16 @@ def test_find_chambers():
     graph = mg.walls_to_graph(maze)
     # there are actually two nodes that can be considered entrances
     width = maze_orig.shape[1]
-    chambers, chamber_tiles = mg.find_chambers(graph, width)
-    assert len(chambers) == 1
-    assert chambers[0] == {(1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (3, 1), (3, 2)}
+    chamber_tiles = mg.find_chambers(graph, width)
+    assert chamber_tiles == {(1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (3, 1), (3, 2)}
 
     # now remove the chamber and verify that we don't detect anything
     # we just remove wall (4,1) manually
     maze = mg.str_to_maze(maze_chamber)
     maze[1,4] = mg.E # REMEMBER! Indexing is maze[y,x]!!!
     graph = mg.walls_to_graph(maze)
-    chambers, chamber_tiles = mg.find_chambers(graph, width)
-    assert chambers == []
+    chamber_tiles = mg.find_chambers(graph, width)
+    assert len(chamber_tiles) == 0
 
 
 maze_one_chamber = """############
@@ -291,7 +290,7 @@ def test_remove_all_chambers(maze_chamber):
 @pytest.mark.parametrize('iteration', range(1,11))
 def test_create_maze(iteration):
     # generate a few mazes and check them for consistency
-    local_seed = 12345 * iteration
+    local_seed = SEED * iteration
     maze_str = mg.create_maze(8,16,nfood=15,rng=local_seed)
     maze = mg.str_to_maze(maze_str)
     height, width = maze.shape
@@ -380,7 +379,7 @@ def test_distribute_food():
     graph = mg.walls_to_graph(maze)
     all_tiles = set(graph.nodes)
     width = maze.shape[1]
-    chambers, chamber_tiles = mg.find_chambers(graph, width)
+    chamber_tiles = mg.find_chambers(graph, width)
 
     # expected exceptions
     with pytest.raises(ValueError):
@@ -389,32 +388,30 @@ def test_distribute_food():
     with pytest.raises(ValueError):
         mg.distribute_food(all_tiles, chamber_tiles, 10, 8)
 
-    # food is sorted, so that comparisons are stable for set seeds
     # no intersection of food positions and chamber_tiles
     trapped_food = 0
     total_food = 10
     food = mg.distribute_food(all_tiles, chamber_tiles, trapped_food, total_food)
-    assert sorted(food) == food
     assert len(set(food) & chamber_tiles) == trapped_food
 
     # trapped food is placed in chamber as requested
     # all food is placed as requested
     trapped_food = 3
     food = mg.distribute_food(all_tiles, chamber_tiles, trapped_food, total_food)
-    assert len(set(food) & chamber_tiles) == trapped_food
+    assert len(food & chamber_tiles) == trapped_food
     assert len(food) == total_food
 
     # food is completely contained in chamber
     total_food = trapped_food = 3
     food = mg.distribute_food(all_tiles, chamber_tiles, trapped_food, total_food)
-    assert set(food).issubset(chamber_tiles)
+    assert food.issubset(chamber_tiles)
     assert len(food) == total_food
 
     # best effort placement of trapped food
     trapped_food = 10  # > 7 chamber_tiles
     total_food = 20
     food = mg.distribute_food(all_tiles, chamber_tiles, trapped_food, total_food)
-    assert len(set(food) & chamber_tiles) == len(chamber_tiles)
+    assert len(food & chamber_tiles) == len(chamber_tiles)
     assert len(food) == total_food
 
     # distribute only leftover food in chambers, fill non-chambers first
@@ -425,31 +422,78 @@ def test_distribute_food():
     total_food = n_free_tiles + trapped_food + leftover_food
     food = mg.distribute_food(all_tiles, chamber_tiles, trapped_food, total_food)
     assert len(food) == total_food
-    assert (set(food) & free_tiles) == free_tiles
-    assert len(set(food) & chamber_tiles) == trapped_food + leftover_food
+    assert (food & free_tiles) == free_tiles
+    assert len(food & chamber_tiles) == trapped_food + leftover_food
 
     # edge case, no food at all
     food = mg.distribute_food(all_tiles, chamber_tiles, 0, 0)
     assert len(food) == 0
 
+np_maze_generator_86523 = """
+################################
+# #  ..  ..  # ##    # ..  #  y#
+# # . .           .. ## ####  x#
+#       .. . #     . #   . ## ##
+#.#### #######    ####.#. .#   #
+#. .  .        ## .# # #       #
+#.#  ## ######     #  .### #####
+#     ....   . ## ## #      #  #
+#  #      # ## ## .   ....     #
+##### ###.  #     ###### ##  #.#
+#       # # #. ##        .  . .#
+#   #. .#.####    ####### ####.#
+## ## .   # .     # . ..       #
+#a  #### ## ..           . . # #
+#b  #  .. #    ## #  ..  ..  # #
+################################
+"""
 
-@pytest.mark.parametrize('iteration', range(1,11))
-def test_create_layout(iteration):
-    local_seed = 12345 * iteration
+def test_create_maze_graph_compatibility():
+    # make sure that we are reproducing the mazes generated by the old
+    # numpy implementation
+    seed = 86523
+    height, width = 16,32
+
+
+    # original call was:
+    #np_str = mg.create_maze(height, width, food, dead_ends=True, rng=seed)
+    np_layout = pelita.layout.parse_layout(np_maze_generator_86523)
+    new_layout = mg.create_maze_graph(trapped_food=0, total_food=30, width=width, height=height, rng=seed)
+    # we can not compare the food distribution, because the two algorithms
+    # distribute food in a different way
+    assert np_layout['walls'] == new_layout['walls']
+    assert np_layout['bots'] == new_layout['bots']
+
+@pytest.mark.parametrize('iteration', range(100))
+def test_numpy_compatibility(iteration):
+    local_seed = SEED + iteration
+    height, width = 16,32
+    rand = Random()
+    rand.seed(local_seed)
+    l_str = mg.create_maze(height, width, 30, dead_ends=True, rng=rand)
+    np_layout = pelita.layout.parse_layout(l_str)
+    rand.seed(local_seed)
+    new_layout = mg.create_maze_graph(trapped_food=0, total_food=30, width=width, height=height, rng=rand)
+    assert np_layout['walls'] == new_layout['walls']
+    assert np_layout['bots'] == new_layout['bots']
+
+@pytest.mark.parametrize('iteration', range(100))
+def test_create_maze_graph(iteration):
+    local_seed = SEED * iteration
     rng = Random(local_seed)
 
     # edge cases
     # width not even
     with pytest.raises(ValueError):
-        mg.create_layout(0, 0, 9, 10, rng=rng)
+        mg.create_maze_graph(0, 0, 9, 10, rng=rng)
 
     # width too small
     with pytest.raises(ValueError):
-        mg.create_layout(0, 0, 2, 10, rng=rng)
+        mg.create_maze_graph(0, 0, 2, 10, rng=rng)
 
     # height too small
     with pytest.raises(ValueError):
-        mg.create_layout(0, 0, 10, 2, rng=rng)
+        mg.create_maze_graph(0, 0, 10, 2, rng=rng)
 
 
     width = rng.choice(range(16, 65, 2))
@@ -457,7 +501,7 @@ def test_create_layout(iteration):
     total_food = int(0.15 * width * height / 2)
     trapped_food = int(total_food / 3)
 
-    ld = mg.create_layout(trapped_food, total_food, width, height, rng=rng)
+    ld = mg.create_maze_graph(trapped_food, total_food, width, height, rng=rng)
 
     walls = set(ld["walls"])
 
@@ -490,20 +534,26 @@ def test_create_layout(iteration):
 
         return True
 
+    # check that the maze is mirrored around the center
     left_walls, right_walls = split(ld["walls"], width)
-    assert is_full_mirror(left_walls, right_walls, width, height)
-
     left_food, right_food = split(ld["food"], width)
+    assert is_full_mirror(left_walls, right_walls, width, height)
     assert is_full_mirror(left_food, right_food, width, height)
 
+    # check that the maze is completely enclosed by walls
     assert border.issubset(set(ld["walls"]))
+
+    # check that there is enough food
     assert len(ld["food"]) == 2 * total_food
+
+    # check that the bots are where they are supposed to be
     assert ld["bots"] == [
         (1, height - 3),
         (width - 2, 2),
         (1, height - 2),
         (width - 2, 1),
     ]
+
     # verify shape
     assert min(ld["walls"]) == (0, 0)
     assert max(ld["walls"]) == (width - 1, height - 1)
@@ -521,6 +571,21 @@ def test_create_layout(iteration):
 
     # verify that we generate exactly the same maze if started with the same seed
     seed = rng.randint(1,100000)
-    l1 = mg.create_layout(trapped_food, total_food, width, height, rng=seed)
-    l2 = mg.create_layout(trapped_food, total_food, width, height, rng=seed)
+    l1 = mg.create_maze_graph(trapped_food, total_food, width, height, rng=seed)
+    l2 = mg.create_maze_graph(trapped_food, total_food, width, height, rng=seed)
     assert l1 == l2
+
+@pytest.mark.parametrize('iteration', range(100))
+def test_create_maze_graph(iteration):
+    local_seed = SEED + iteration
+    rng = Random(local_seed)
+
+    width = 10
+    height = 5
+    total_food = 10
+    trapped_food = 0
+    ld = mg.create_maze_graph(trapped_food, total_food, width, height, rng=rng)
+    # check that we never place food on the border
+    x_food = {x for (x, y) in ld['food']}
+    assert width//2 not in x_food
+    assert width//2 - 1 not in x_food

--- a/test/test_maze_generation.py
+++ b/test/test_maze_generation.py
@@ -13,8 +13,8 @@ SEED = 103525239
 def layout_str_to_graph(l_str):
     l_dict = pl.parse_layout(l_str, strict=False)
     graph = pt.walls_to_graph(l_dict['walls'], shape=l_dict['shape'])
-    graph.shape = l_dict['shape']
-    return graph
+    shape = l_dict['shape']
+    return graph, shape
 
 maze_103525239 = """
 ################################
@@ -52,8 +52,8 @@ def test_find_trapped_tiles():
                      #          #
                      ############"""
 
-    graph = layout_str_to_graph(one_chamber)
-    one_chamber_tiles, chambers = mg.find_trapped_tiles(graph, graph.shape[0], include_chambers=True)
+    graph, shape = layout_str_to_graph(one_chamber)
+    one_chamber_tiles, chambers = mg.find_trapped_tiles(graph, shape[0], include_chambers=True)
     assert len(chambers) == 1
     tiles_1 = {(1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (3, 1), (3, 2)}
     assert one_chamber_tiles == tiles_1
@@ -68,8 +68,8 @@ def test_find_trapped_tiles():
                       #      #   #
                       #      #   #
                       ############"""
-    graph = layout_str_to_graph(two_chambers)
-    two_chambers_tiles, chambers = mg.find_trapped_tiles(graph, graph.shape[0], include_chambers=True)
+    graph, shape = layout_str_to_graph(two_chambers)
+    two_chambers_tiles, chambers = mg.find_trapped_tiles(graph, shape[0], include_chambers=True)
     assert len(chambers) == 2
     tiles_2 = {(8,3), (8,4), (8,5), (8,6), (8,7), (9,4), (9,5),
                (9,6), (9,7), (10, 4), (10,5), (10,6), (10, 7) }

--- a/test/test_maze_generation.py
+++ b/test/test_maze_generation.py
@@ -1,7 +1,5 @@
 from random import Random
 
-import networkx as nx
-import numpy as np
 import pytest
 
 import pelita.maze_generator as mg
@@ -58,7 +56,6 @@ def test_find_trapped_tiles():
     tiles_1 = {(1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (3, 1), (3, 2)}
     assert one_chamber_tiles == tiles_1
 
-
     two_chambers = """############
                       #   #      #
                       #   #      #
@@ -74,10 +71,6 @@ def test_find_trapped_tiles():
     tiles_2 = {(8,3), (8,4), (8,5), (8,6), (8,7), (9,4), (9,5),
                (9,6), (9,7), (10, 4), (10,5), (10,6), (10, 7) }
     assert two_chambers_tiles == tiles_1 | tiles_2
-
-    # only find chambers in the left side of the maze
-
-
 
 def test_distribute_food():
     maze_chamber = """############
@@ -140,6 +133,7 @@ def test_distribute_food():
     food = mg.distribute_food(all_tiles, chamber_tiles, 0, 0)
     assert len(food) == 0
 
+
 np_maze_generator_86523 = """
 ################################
 # #  ..  ..  # ##    # ..  #  y#
@@ -158,7 +152,6 @@ np_maze_generator_86523 = """
 #b  #  .. #    ## #  ..  ..  # #
 ################################
 """
-
 
 @pytest.mark.parametrize('iteration', range(100))
 def test_generate_maze(iteration):


### PR DESCRIPTION
Hey guys,

analogous to #852, I also tried to use the first version of the optimized chamber finding algorithm in the maze generation as well.

The timings went from several seconds down to less than half a second consistently for script execution.
However, looking at the profiling, only 5% (25 ms) are actually maze generation and the rest of the time was spent in importing:

<details>
<summary>absolute times</summary>

```
  _     ._   __/__   _ _  _  _ _/_   Recorded: 09:47:34  Samples:  233
 /_//_/// /_\ / //_// / //_'/ //     Duration: 0.480     CPU time: 1.285
/   _/                      v5.0.1

Program: scripts/pelita_createlayout.py

0.479 <module>  pelita_createlayout.py:1
├─ 0.299 <module>  ../__init__.py:1
│  └─ 0.297 <module>  ../game.py:1
│     ├─ 0.183 <module>  ../team.py:1
│     │  └─ 0.181 <module>  networkx/__init__.py:1
│     │        [18 frames hidden]  networkx, importlib
│     ├─ 0.074 <module>  ../viewer.py:1
│     │  ├─ 0.062 <module>  rich/console.py:1
│     │  │     [11 frames hidden]  rich, fractions
│     │  └─ 0.010 <module>  rich/progress.py:1
│     ├─ 0.030 <module>  ../network.py:1
│     │  └─ 0.028 <module>  zmq/__init__.py:1
│     │        [10 frames hidden]  zmq, importlib, enum
│     └─ 0.006 <module>  logging/__init__.py:1
├─ 0.146 <module>  ../maze_generator.py:1
│  └─ 0.146 <module>  numpy/__init__.py:1
│        [30 frames hidden]  numpy, typing
├─ 0.024 main  pelita_createlayout.py:65
│  └─ 0.022 get_new_maze  ../maze_generator.py:381
│     ├─ 0.012 remove_all_chambers  ../maze_generator.py:321
│     │  └─ 0.006 articulation_points  networkx/algorithms/components/biconnected.py:263
│     │     └─ 0.006 _biconnected_dfs  networkx/algorithms/components/biconnected.py:338
│     └─ 0.010 remove_all_dead_ends  ../maze_generator.py:256
│        └─ 0.008 walls_to_graph  ../maze_generator.py:193
└─ 0.008 compile  <built-in>
```
</details>

<details>
<summary>relative times</summary>

```
  _     ._   __/__   _ _  _  _ _/_   Recorded: 09:47:34  Samples:  233
 /_//_/// /_\ / //_// / //_'/ //     Duration: 0.480     CPU time: 1.285
/   _/                      v5.0.1

Program: scripts/pelita_createlayout.py

100.0% <module>  pelita_createlayout.py:1
├─ 62.4% <module>  ../__init__.py:1
│  └─ 62.0% <module>  ../game.py:1
│     ├─ 38.2% <module>  ../team.py:1
│     │  └─ 37.8% <module>  networkx/__init__.py:1
│     │        [18 frames hidden]  networkx, importlib
│     ├─ 15.4% <module>  ../viewer.py:1
│     │  ├─ 12.9% <module>  rich/console.py:1
│     │  │     [11 frames hidden]  rich, fractions
│     │  └─ 2.1% <module>  rich/progress.py:1
│     ├─ 6.3% <module>  ../network.py:1
│     │  └─ 5.8% <module>  zmq/__init__.py:1
│     │        [10 frames hidden]  zmq, importlib, enum
│     └─ 1.3% <module>  logging/__init__.py:1
├─ 30.5% <module>  ../maze_generator.py:1
│  └─ 30.5% <module>  numpy/__init__.py:1
│        [30 frames hidden]  numpy, typing
├─ 5.0% main  pelita_createlayout.py:65
│  └─ 4.6% get_new_maze  ../maze_generator.py:381
│     ├─ 2.5% remove_all_chambers  ../maze_generator.py:321
│     │  └─ 1.3% articulation_points  networkx/algorithms/components/biconnected.py:263
│     │     └─ 1.3% _biconnected_dfs  networkx/algorithms/components/biconnected.py:338
│     └─ 2.1% remove_all_dead_ends  ../maze_generator.py:256
│        └─ 1.7% walls_to_graph  ../maze_generator.py:193
└─ 1.7% compile  <built-in>
```
</details>

Would that be fast enough to generate mazes on-the-fly?

For now, I think this would not make the layout database obsolete as one still does not have direct control over the number of dead ends and chambers.