### PR TITLE
Fix maze_generator still using old seed argument to get_new_maze

### DIFF
--- a/pelita/maze_generator.py
+++ b/pelita/maze_generator.py
@@ -384,7 +384,7 @@ def add_pacmen(maze):
     maze[1, -2] = b'y'
     maze[2, -2] = b'x'
 
-def get_new_maze(height, width, nfood, dead_ends=False, rng=None):
+def create_maze(height, width, nfood, dead_ends=False, rng=None):
     """Create a new maze in text format.
 
     The maze is created with a recursive creation algorithm. The maze part of

--- a/pelita/scripts/pelita_createlayout.py
+++ b/pelita/scripts/pelita_createlayout.py
@@ -87,7 +87,7 @@ def main():
                             rng=args.seed, dead_ends=args.dead_ends)
 
     sys.stdout.write(maze_str+'\n')
-    sys.stdout.close()
+    sys.stdout.flush()
 
 if __name__ == "__main__":
     main()

--- a/pelita/scripts/pelita_createlayout.py
+++ b/pelita/scripts/pelita_createlayout.py
@@ -84,7 +84,7 @@ def main():
     args = parser.parse_args()
 
     maze_str = get_new_maze(args.height, args.width, nfood=args.food,
-                            seed=args.seed, dead_ends=args.dead_ends)
+                            rng=args.seed, dead_ends=args.dead_ends)
 
     sys.stdout.write(maze_str+'\n')
     sys.stdout.close()

--- a/pelita/scripts/pelita_createlayout.py
+++ b/pelita/scripts/pelita_createlayout.py
@@ -7,7 +7,7 @@ The maze will be sent to sys.out .
 import sys
 import argparse
 
-from pelita.maze_generator import get_new_maze
+from pelita.maze_generator import create_maze
 
 HEIGHT = 16
 WIDTH = 32
@@ -83,7 +83,7 @@ def main():
 
     args = parser.parse_args()
 
-    maze_str = get_new_maze(args.height, args.width, nfood=args.food,
+    maze_str = create_maze(args.height, args.width, nfood=args.food,
                             rng=args.seed, dead_ends=args.dead_ends)
 
     sys.stdout.write(maze_str+'\n')

--- a/test/test_maze_generation.py
+++ b/test/test_maze_generation.py
@@ -293,10 +293,10 @@ def test_remove_all_chambers(maze_chamber):
     # we are removing just a few walls?
 
 @pytest.mark.parametrize('iteration', range(1,11))
-def test_get_new_maze(iteration):
+def test_create_maze(iteration):
     # generate a few mazes and check them for consistency
     local_seed = 12345 * iteration
-    maze_str = mg.get_new_maze(8,16,nfood=15,rng=local_seed)
+    maze_str = mg.create_maze(8,16,nfood=15,rng=local_seed)
     maze = mg.str_to_maze(maze_str)
     height, width = maze.shape
     # check that the returned maze has all the pacmen
@@ -330,7 +330,7 @@ def test_get_new_maze(iteration):
 
 def test_odd_width():
     with pytest.raises(ValueError):
-        mg.get_new_maze(2,3,1)
+        mg.create_maze(2,3,1)
 
 def test_add_food():
     mini = """########


### PR DESCRIPTION
Plus bonus commit: rename `get_new_maze` → `create_maze` which to me follows more common API conventions. If this is merged, I suggest that #856 is rebased.

@otizonaizit Do you know why you close the stdout stream? I assume flushing is enough?