### PR TITLE
WIP: Standalone viewer with overlay graphics

### DIFF
--- a/pelita/network.py
+++ b/pelita/network.py
@@ -274,14 +274,20 @@ class ZMQPublisher:
     Parameters
     ----------
     address : string
-        The address which the publisher binds.
+        The address which the publisher binds or connects to.
+    bind : bool
+        Whether we are in bind or connect mode
     """
-    def __init__(self, address):
+    def __init__(self, address, bind=True):
         self.address = address
         self.context = zmq.Context()
         self.socket = self.context.socket(zmq.PUB)
-        self.socket_addr = bind_socket(self.socket, self.address, '--publish')
-        _logger.debug("Bound zmq.PUB to {}".format(self.socket_addr))
+        if bind:
+            self.socket_addr = bind_socket(self.socket, self.address, '--publish')
+            _logger.debug("Bound zmq.PUB to {}".format(self.socket_addr))
+        else:
+            self.socket.connect(self.address)
+            _logger.debug("Connected zmq.PUB to {}".format(self.address))
 
     def _send(self, action, data):
         info = {'round': data['round'], 'turn': data['turn']}

--- a/pelita/scripts/pelita_tkviewer.py
+++ b/pelita/scripts/pelita_tkviewer.py
@@ -29,6 +29,8 @@ parser.add_argument('subscribe_sock', metavar="URL", type=str,
                     help='subscribe socket')
 parser.add_argument('--controller-address', metavar="URL", type=str,
                     help='controller address')
+parser.add_argument('--standalone-mode', const=True, action='store_const',
+                    help='Activate bind mode for a standalone viewer')
 parser.add_argument('--geometry', type=geometry_string,
                     help='geometry')
 parser.add_argument('--fullscreen', const=True, action='store_const',
@@ -61,6 +63,7 @@ def main():
         'geometry': args.geometry,
         'fullscreen' : args.fullscreen,
         'delay': args.delay,
+        'standalone_mode': args.standalone_mode,
         'stop_after': args.stop_after,
         'stop_after_kill': args.stop_after_kill
     }

--- a/pelita/ui/tk_canvas.py
+++ b/pelita/ui/tk_canvas.py
@@ -152,9 +152,6 @@ class Trafo:
     def screen(self, model_x, model_y):
         return self.mesh_graph.mesh_to_screen((self.mesh_x, self.mesh_y), (model_x, model_y))
 
-class UI:
-    pass
-
 class TkApplication:
     def __init__(self, window, controller_address=None,
                  geometry=None, delay=1, stop_after=None, stop_after_kill=False, fullscreen=False):
@@ -196,93 +193,91 @@ class TkApplication:
         self._universe = None
         self._game_state = None
 
-        self.ui = UI()
+        self.ui_header_canvas = tkinter.Canvas(window, height=50)
+        self.ui_header_canvas.config(background="white", bd=0, highlightthickness=0, relief='ridge')
 
-        self.ui.header_canvas = tkinter.Canvas(window, height=50)
-        self.ui.header_canvas.config(background="white", bd=0, highlightthickness=0, relief='ridge')
+        self.ui_sub_header = tkinter.Frame(window, height=25)
+        self.ui_sub_header.config(background="white")
 
-        self.ui.sub_header = tkinter.Frame(window, height=25)
-        self.ui.sub_header.config(background="white")
+        self.ui_status_canvas = tkinter.Frame(window, height=25)
+        self.ui_status_canvas.config(background="white")
 
-        self.ui.status_canvas = tkinter.Frame(window, height=25)
-        self.ui.status_canvas.config(background="white")
+        self.ui_game_canvas = tkinter.Canvas(window)
+        self.ui_game_canvas.config(background="white", bd=0, highlightthickness=0, relief='ridge')
+        self.ui_game_canvas.bind('<Configure>', lambda e: window.after_idle(self.update))
+        self.ui_game_canvas.bind('<Button-1>', self.on_click)
 
-        self.ui.game_canvas = tkinter.Canvas(window)
-        self.ui.game_canvas.config(background="white", bd=0, highlightthickness=0, relief='ridge')
-        self.ui.game_canvas.bind('<Configure>', lambda e: window.after_idle(self.update))
-        self.ui.game_canvas.bind('<Button-1>', self.on_click)
+        self.ui_status_00 = tkinter.Frame(self.ui_status_canvas, background="white", padx=5, pady=0)
+        self.ui_status_01 = tkinter.Frame(self.ui_status_canvas, background="white", padx=5, pady=0)
+        self.ui_status_02 = tkinter.Frame(self.ui_status_canvas, background="white", padx=5, pady=0)
+        self.ui_status_10 = tkinter.Frame(self.ui_status_canvas, background="white", padx=5, pady=0)
+        self.ui_status_11 = tkinter.Frame(self.ui_status_canvas, background="white", padx=5, pady=0)
+        self.ui_status_12 = tkinter.Frame(self.ui_status_canvas, background="white", padx=5, pady=0)
+        self.ui_status_20 = tkinter.Frame(self.ui_status_canvas, background="white", padx=5, pady=0)
+        self.ui_status_21 = tkinter.Frame(self.ui_status_canvas, background="white", padx=5, pady=0)
+        self.ui_status_22 = tkinter.Frame(self.ui_status_canvas, background="white", padx=5, pady=0)
 
-        self.ui.status_00 = tkinter.Frame(self.ui.status_canvas, background="white", padx=5, pady=0)
-        self.ui.status_01 = tkinter.Frame(self.ui.status_canvas, background="white", padx=5, pady=0)
-        self.ui.status_02 = tkinter.Frame(self.ui.status_canvas, background="white", padx=5, pady=0)
-        self.ui.status_10 = tkinter.Frame(self.ui.status_canvas, background="white", padx=5, pady=0)
-        self.ui.status_11 = tkinter.Frame(self.ui.status_canvas, background="white", padx=5, pady=0)
-        self.ui.status_12 = tkinter.Frame(self.ui.status_canvas, background="white", padx=5, pady=0)
-        self.ui.status_20 = tkinter.Frame(self.ui.status_canvas, background="white", padx=5, pady=0)
-        self.ui.status_21 = tkinter.Frame(self.ui.status_canvas, background="white", padx=5, pady=0)
-        self.ui.status_22 = tkinter.Frame(self.ui.status_canvas, background="white", padx=5, pady=0)
+        self.ui_status_00.grid(row=0, column=0, sticky="W")
+        self.ui_status_01.grid(row=0, column=1, sticky="WE")
+        self.ui_status_02.grid(row=0, column=2, sticky="E")
+        self.ui_status_10.grid(row=1, column=0, sticky="W")
+        self.ui_status_11.grid(row=1, column=1, columnspan=2, sticky="E")
+#        self.ui_status_12.grid(row=1, column=2, sticky="E")
+        self.ui_status_20.grid(row=2, column=0, sticky="W")
+        self.ui_status_21.grid(row=2, column=1, sticky="W")
+        self.ui_status_22.grid(row=2, column=2, sticky="E")
 
-        self.ui.status_00.grid(row=0, column=0, sticky="W")
-        self.ui.status_01.grid(row=0, column=1, sticky="WE")
-        self.ui.status_02.grid(row=0, column=2, sticky="E")
-        self.ui.status_10.grid(row=1, column=0, sticky="W")
-        self.ui.status_11.grid(row=1, column=1, columnspan=2, sticky="E")
-#        self.ui.status_12.grid(row=1, column=2, sticky="E")
-        self.ui.status_20.grid(row=2, column=0, sticky="W")
-        self.ui.status_21.grid(row=2, column=1, sticky="W")
-        self.ui.status_22.grid(row=2, column=2, sticky="E")
+        self.ui_status_canvas.grid_columnconfigure(0, weight=1, uniform='status')
+        self.ui_status_canvas.grid_columnconfigure(1, weight=1, uniform='status')
+        self.ui_status_canvas.grid_columnconfigure(2, weight=1, uniform='status')
 
-        self.ui.status_canvas.grid_columnconfigure(0, weight=1, uniform='status')
-        self.ui.status_canvas.grid_columnconfigure(1, weight=1, uniform='status')
-        self.ui.status_canvas.grid_columnconfigure(2, weight=1, uniform='status')
-
-        self.ui.button_game_speed_slower = tkinter.Button(self.ui.status_10,
+        self.ui_button_game_speed_slower = tkinter.Button(self.ui_status_10,
             foreground="black",
             background="white",
             justify=tkinter.CENTER,
             text="slower",
             padx=12,
             command=self.delay_inc)
-        self.ui.button_game_speed_slower.pack(side=tkinter.LEFT)
+        self.ui_button_game_speed_slower.pack(side=tkinter.LEFT)
 
-        self.ui.button_game_speed_faster = tkinter.Button(self.ui.status_10,
+        self.ui_button_game_speed_faster = tkinter.Button(self.ui_status_10,
             foreground="black",
             background="white",
             justify=tkinter.CENTER,
             text="faster",
             padx=12,
             command=self.delay_dec)
-        self.ui.button_game_speed_faster.pack(side=tkinter.LEFT)
+        self.ui_button_game_speed_faster.pack(side=tkinter.LEFT)
 
         self._check_speed_button_state()
 
-        self.ui.button_game_toggle_grid = tkinter.Button(self.ui.status_10,
+        self.ui_button_game_toggle_grid = tkinter.Button(self.ui_status_10,
             foreground="black",
             background="white",
             justify=tkinter.CENTER,
             padx=12,
             command=self.toggle_grid)
-        self.ui.button_game_toggle_grid.pack(side=tkinter.LEFT)
+        self.ui_button_game_toggle_grid.pack(side=tkinter.LEFT)
 
         self._check_grid_toggle_state()
 
-        self.ui.status_fps_info = tkinter.Label(self.ui.status_20,
+        self.ui_status_fps_info = tkinter.Label(self.ui_status_20,
             text="",
             font=(None, 8),
             foreground="black",
             background="white",
             justify=tkinter.CENTER)
-        self.ui.status_fps_info.pack(side=tkinter.LEFT)
+        self.ui_status_fps_info.pack(side=tkinter.LEFT)
 
-        self.ui.status_selected = tkinter.Label(self.ui.status_22,
+        self.ui_status_selected = tkinter.Label(self.ui_status_22,
             text="",
             font=(None, 8),
             foreground="black",
             background="white",
             justify=tkinter.CENTER)
-        self.ui.status_selected.pack(side=tkinter.RIGHT)
+        self.ui_status_selected.pack(side=tkinter.RIGHT)
 
-        tkinter.Button(self.ui.status_00,
+        tkinter.Button(self.ui_status_00,
                        foreground="black",
                        background="white",
                        justify=tkinter.CENTER,
@@ -290,7 +285,7 @@ class TkApplication:
                        padx=12,
                        command=self.toggle_running).pack(side=tkinter.LEFT, expand=tkinter.YES)
 
-        tkinter.Button(self.ui.status_00,
+        tkinter.Button(self.ui_status_00,
                        foreground="black",
                        background="white",
                        justify=tkinter.CENTER,
@@ -298,7 +293,7 @@ class TkApplication:
                        padx=12,
                        command=self.request_step).pack(side=tkinter.LEFT, expand=tkinter.YES)
 
-        tkinter.Button(self.ui.status_00,
+        tkinter.Button(self.ui_status_00,
                        foreground="black",
                        background="white",
                        justify=tkinter.CENTER,
@@ -306,7 +301,7 @@ class TkApplication:
                        padx=12,
                        command=self.request_round).pack(side=tkinter.LEFT, expand=tkinter.YES)
 
-        tkinter.Button(self.ui.status_01,
+        tkinter.Button(self.ui_status_01,
                        foreground="black",
                        background="white",
                        justify=tkinter.CENTER,
@@ -316,27 +311,27 @@ class TkApplication:
                        command=self.quit).pack(side=tkinter.TOP, fill=tkinter.BOTH, anchor=tkinter.CENTER)
 
         # Add circles to show which bot is active.
-        self.ui.bot_traffic_lights_canvas = tkinter.Canvas(self.ui.status_02, height=25, width=44,
+        self.ui_bot_traffic_lights_canvas = tkinter.Canvas(self.ui_status_02, height=25, width=44,
                                                            background="white", bd=0, highlightthickness=0,
                                                            relief='ridge')
-        self.ui.bot_traffic_lights_canvas.pack(side=tkinter.LEFT)
-        self.ui.bot_traffic_lights_c = []
+        self.ui_bot_traffic_lights_canvas.pack(side=tkinter.LEFT)
+        self.ui_bot_traffic_lights_c = []
         for idx in range(4):
             spacing = 10
             x0, y0 = 2.5 + idx * spacing, 13
-            circle = self.ui.bot_traffic_lights_canvas.create_text(x0, y0, text=layout.BOT_I2N[idx], font=(None, 11), fill="black")
-            self.ui.bot_traffic_lights_c.append(circle)
+            circle = self.ui_bot_traffic_lights_canvas.create_text(x0, y0, text=layout.BOT_I2N[idx], font=(None, 11), fill="black")
+            self.ui_bot_traffic_lights_c.append(circle)
 
-        self.ui.status_round_info = tkinter.Label(self.ui.status_02, text="", background="white")
-        self.ui.status_round_info.pack(side=tkinter.LEFT)
+        self.ui_status_round_info = tkinter.Label(self.ui_status_02, text="", background="white")
+        self.ui_status_round_info.pack(side=tkinter.LEFT)
 
-        self.ui.status_layout_info = tkinter.Label(self.ui.status_11, text="", background="white")
-        self.ui.status_layout_info.pack(side=tkinter.LEFT)
+        self.ui_status_layout_info = tkinter.Label(self.ui_status_11, text="", background="white")
+        self.ui_status_layout_info.pack(side=tkinter.LEFT)
 
-        self.ui.header_canvas.pack(side=tkinter.TOP, fill=tkinter.BOTH)
-#        self.ui.sub_header.pack(side=tkinter.TOP, fill=tkinter.BOTH)
-        self.ui.status_canvas.pack(side=tkinter.BOTTOM, fill=tkinter.BOTH)
-        self.ui.game_canvas.pack(side=tkinter.TOP, fill=tkinter.BOTH, expand=tkinter.YES)#fill=tkinter.BOTH, expand=tkinter.YES)
+        self.ui_header_canvas.pack(side=tkinter.TOP, fill=tkinter.BOTH)
+#        self.ui_sub_header.pack(side=tkinter.TOP, fill=tkinter.BOTH)
+        self.ui_status_canvas.pack(side=tkinter.BOTTOM, fill=tkinter.BOTH)
+        self.ui_game_canvas.pack(side=tkinter.TOP, fill=tkinter.BOTH, expand=tkinter.YES)#fill=tkinter.BOTH, expand=tkinter.YES)
 
         self._min_delay = 1
         self._delay = delay
@@ -418,11 +413,11 @@ class TkApplication:
             self.init_mesh(game_state)
 
         if ((self.mesh_graph.screen_width, self.mesh_graph.screen_height)
-            != (self.ui.game_canvas.winfo_width(), self.ui.game_canvas.winfo_height())):
+            != (self.ui_game_canvas.winfo_width(), self.ui_game_canvas.winfo_height())):
             self.size_changed = True
 
-        self.mesh_graph.screen_width = self.ui.game_canvas.winfo_width()
-        self.mesh_graph.screen_height = self.ui.game_canvas.winfo_height()
+        self.mesh_graph.screen_width = self.ui_game_canvas.winfo_width()
+        self.mesh_graph.screen_height = self.ui_game_canvas.winfo_height()
 
         if self.mesh_graph.screen_width < 600:
             if self._default_font.cget('size') != 8:
@@ -437,7 +432,7 @@ class TkApplication:
         for food_pos, food_item in self.food_items.items():
             food_item.food_age = game_state['food_age'].get(food_pos, 0)
             if food_pos not in game_state["food"]:
-                self.ui.game_canvas.delete(food_item.tag)
+                self.ui_game_canvas.delete(food_item.tag)
                 eaten_food.append(food_pos)
         for food_pos in eaten_food:
             del self.food_items[food_pos]
@@ -479,7 +474,7 @@ class TkApplication:
         """
         if not self.size_changed:
             return
-        self.ui.game_canvas.delete("grid")
+        self.ui_game_canvas.delete("grid")
 
         if not self._grid_enabled:
             return
@@ -491,7 +486,7 @@ class TkApplication:
             y0_ = self.mesh_graph.mesh_to_screen_y(y0, 0)
             x1_ = self.mesh_graph.mesh_to_screen_x(x1, 0)
             y1_ = self.mesh_graph.mesh_to_screen_y(y1, 0)
-            self.ui.game_canvas.create_line(x0_, y0_, x1_, y1_, width=0.01, fill="#884488", tag="grid")
+            self.ui_game_canvas.create_line(x0_, y0_, x1_, y1_, width=0.01, fill="#884488", tags="grid")
 
         for x in range(self.mesh_graph.mesh_width + 1):
             draw_line(x - 0.5, -0.5, x - 0.5, self.mesh_graph.mesh_height - 0.5)
@@ -503,7 +498,7 @@ class TkApplication:
         label_style = {
             "font": (None, label_size),
             "fill": "#884488",
-            "tag": "grid",
+            "tags": "grid",
             "justify": tkinter.CENTER,
             "anchor": tkinter.CENTER
         }
@@ -512,24 +507,24 @@ class TkApplication:
             x_pos = self.mesh_graph.mesh_to_screen_x(x, 0)
             # the margin is not autoscaling, so we do the shift on the real grid
             y_pos = self.mesh_graph.mesh_to_screen_y(0, -1) - label_size
-            self.ui.game_canvas.create_text(x_pos, y_pos, text=str(x), **label_style)
+            self.ui_game_canvas.create_text(x_pos, y_pos, text=str(x), **label_style)
 
         for y in range(self.mesh_graph.mesh_height):
             # the margin is not autoscaling, so we do the shift on the real grid
             x_pos = self.mesh_graph.mesh_to_screen_x(0, -1) - label_size
             y_pos = self.mesh_graph.mesh_to_screen_y(y, 0)
-            self.ui.game_canvas.create_text(x_pos, y_pos, text=str(y), **label_style)
+            self.ui_game_canvas.create_text(x_pos, y_pos, text=str(y), **label_style)
 
         x_pos = self.mesh_graph.mesh_to_screen_x(self.mesh_graph.mesh_width, -0.7)
         y_pos = self.mesh_graph.mesh_to_screen_y(0, -1) - label_size
-        self.ui.game_canvas.create_text(x_pos, y_pos, text="x", **label_style)
+        self.ui_game_canvas.create_text(x_pos, y_pos, text="x", **label_style)
 
         x_pos = self.mesh_graph.mesh_to_screen_x(0, -1) - label_size
         y_pos = self.mesh_graph.mesh_to_screen_y(self.mesh_graph.mesh_height, -0.7)
-        self.ui.game_canvas.create_text(x_pos, y_pos, text="y", **label_style)
+        self.ui_game_canvas.create_text(x_pos, y_pos, text="y", **label_style)
 
     def draw_line_of_sight(self, game_state):
-        self.ui.game_canvas.delete("line_of_sight")
+        self.ui_game_canvas.delete("line_of_sight")
         if not self._grid_enabled:
             return
 
@@ -541,7 +536,7 @@ class TkApplication:
             ll = self.mesh_graph.mesh_to_screen(pos, (-1, 1))
             lr = self.mesh_graph.mesh_to_screen(pos, (1, 1))
 
-            self.ui.game_canvas.create_rectangle(*ul, *lr, width=2, outline='#111', tag=("line_of_sight",))
+            self.ui_game_canvas.create_rectangle(*ul, *lr, width=2, outline='#111', tags=("line_of_sight",))
 
         bot = game_state['turn']
         if bot is None:
@@ -579,7 +574,7 @@ class TkApplication:
             y0_ = self.mesh_graph.mesh_to_screen_y(pos[1], loc[1])
             x1_ = self.mesh_graph.mesh_to_screen_x(pos[0], loc[2])
             y1_ = self.mesh_graph.mesh_to_screen_y(pos[1], loc[3])
-            self.ui.game_canvas.create_line(x0_, y0_, x1_, y1_, width=3, fill=line_col, tag=("line_of_sight"))
+            self.ui_game_canvas.create_line(x0_, y0_, x1_, y1_, width=3, fill=line_col, tags=("line_of_sight"))
 
         def draw_box(pos, fill_col):
             ul = self.mesh_graph.mesh_to_screen(pos, (-1, -1))
@@ -587,7 +582,7 @@ class TkApplication:
             ll = self.mesh_graph.mesh_to_screen(pos, (-1, 1))
             lr = self.mesh_graph.mesh_to_screen(pos, (1, 1))
 
-            self.ui.game_canvas.create_rectangle(*ul, *lr, width=0, fill=fill_col, tag=("line_of_sight", "area_of_sight"))
+            self.ui_game_canvas.create_rectangle(*ul, *lr, width=0, fill=fill_col, tags=("line_of_sight", "area_of_sight"))
 
         for dx in range(- sight_distance, sight_distance + 1):
             for dy in range(- sight_distance, sight_distance + 1):
@@ -623,12 +618,12 @@ class TkApplication:
                     if pos[1] == 0:
                         draw_line(pos, loc=(1, -1, -1, -1), line_col=line_col)
 
-        self.ui.game_canvas.tag_lower("area_of_sight")
-        self.ui.game_canvas.tag_raise("wall")
+        self.ui_game_canvas.tag_lower("area_of_sight")
+        self.ui_game_canvas.tag_raise("wall")
 
 
     def draw_bot_shadow(self, game_state):
-        self.ui.game_canvas.delete("bot_shadow")
+        self.ui_game_canvas.delete("bot_shadow")
         if not self._grid_enabled:
             return
 
@@ -643,7 +638,7 @@ class TkApplication:
             ll = self.mesh_graph.mesh_to_screen(pos, (-1, 1))
             lr = self.mesh_graph.mesh_to_screen(pos, (1, 1))
 
-            self.ui.game_canvas.create_rectangle(*ul, *lr, width=2, outline='#111', tag=("bot_shadow",))
+            self.ui_game_canvas.create_rectangle(*ul, *lr, width=2, outline='#111', tags=("bot_shadow",))
 
         bot = game_state['turn']
         if bot is None:
@@ -689,7 +684,7 @@ class TkApplication:
             y0_ = self.mesh_graph.mesh_to_screen_y(pos[1], loc[1])
             x1_ = self.mesh_graph.mesh_to_screen_x(pos[0], loc[2])
             y1_ = self.mesh_graph.mesh_to_screen_y(pos[1], loc[3])
-            self.ui.game_canvas.create_line(x0_, y0_, x1_, y1_, width=2, fill=line_col, tag=("bot_shadow"))
+            self.ui_game_canvas.create_line(x0_, y0_, x1_, y1_, width=2, fill=line_col, tags=("bot_shadow"))
 
 
         def draw_box(pos, fill_col):
@@ -698,7 +693,7 @@ class TkApplication:
             ll = self.mesh_graph.mesh_to_screen(pos, (-1, 1))
             lr = self.mesh_graph.mesh_to_screen(pos, (1, 1))
 
-            self.ui.game_canvas.create_rectangle(*ul, *lr, width=0, fill=fill_col, tag=("bot_shadow", "bot_shadow_area"))
+            self.ui_game_canvas.create_rectangle(*ul, *lr, width=0, fill=fill_col, tags=("bot_shadow", "bot_shadow_area"))
 
         for dx in range(- sight_distance, sight_distance + 1):
             for dy in range(- sight_distance, sight_distance + 1):
@@ -735,9 +730,9 @@ class TkApplication:
                 #     if pos[1] == 0:
                 #         draw_line(pos, loc=(1, -1, -1, -1), line_col=border_col)
 
-        self.ui.game_canvas.tag_lower("bot_shadow_area")
-        self.ui.game_canvas.tag_lower("area_of_sight")
-        self.ui.game_canvas.tag_raise("wall")
+        self.ui_game_canvas.tag_lower("bot_shadow_area")
+        self.ui_game_canvas.tag_lower("area_of_sight")
+        self.ui_game_canvas.tag_raise("wall")
 
 
     def toggle_grid(self):
@@ -757,9 +752,9 @@ class TkApplication:
 
     def _check_grid_toggle_state(self):
         if self._grid_enabled:
-            self.ui.button_game_toggle_grid.config(text="debug")
+            self.ui_button_game_toggle_grid.config(text="debug")
         else:
-            self.ui.button_game_toggle_grid.config(text="debug")
+            self.ui_button_game_toggle_grid.config(text="debug")
 
     def on_click(self, event):
         raw_x, raw_y = event.x, event.y
@@ -775,7 +770,7 @@ class TkApplication:
         """
         if not self.size_changed:
             return
-        self.ui.game_canvas.delete("background")
+        self.ui_game_canvas.delete("background")
 
         center = self.mesh_graph.screen_width // 2
         cols = (BLUE, RED, GREY)
@@ -785,12 +780,12 @@ class TkApplication:
         for color, x_orig in zip(cols, (center - 3, center + 3, center)):
             y_top = self.mesh_graph.mesh_to_screen_y(0, 0)
             y_bottom = self.mesh_graph.mesh_to_screen_y(self.mesh_graph.mesh_height - 1, 0)
-            self.ui.game_canvas.create_line(x_orig, y_top, x_orig, y_bottom, width=scale, fill=color, tag="background")
+            self.ui_game_canvas.create_line(x_orig, y_top, x_orig, y_bottom, width=scale, fill=color, tags="background")
 
     def draw_title(self, game_state):
-        self.ui.header_canvas.delete("title")
+        self.ui_header_canvas.delete("title")
 
-        center = self.ui.header_canvas.winfo_width() // 2
+        center = self.ui_header_canvas.winfo_width() // 2
 
         try:
             team_time = game_state["team_time"]
@@ -813,7 +808,7 @@ class TkApplication:
         right_team = f" {right_score} {right_name} {right_info}"
 
         font_size = guess_size(left_team + ' : ' + right_team,
-                               self.ui.header_canvas.winfo_width(),
+                               self.ui_header_canvas.winfo_width(),
                                30,
                                rel_size = 1)
 
@@ -841,15 +836,15 @@ class TkApplication:
         top = 15
         spacer = 3
 
-        middle_colon = self.ui.header_canvas.create_text(center, top, text=":", font=(None, font_size), tag="title", anchor=tkinter.CENTER)
-        middle_colon_bottom = self.ui.header_canvas.bbox(middle_colon)[3]
-        spacer = (self.ui.header_canvas.bbox(middle_colon)[3] - self.ui.header_canvas.bbox(middle_colon)[1]) / 2
+        middle_colon = self.ui_header_canvas.create_text(center, top, text=":", font=(None, font_size), tags="title", anchor=tkinter.CENTER)
+        middle_colon_bottom = self.ui_header_canvas.bbox(middle_colon)[3]
+        spacer = (self.ui_header_canvas.bbox(middle_colon)[3] - self.ui_header_canvas.bbox(middle_colon)[1]) / 2
 
-        self.ui.header_canvas.create_text(center, top, text=left_team, font=(None, font_size), fill=BLUE, tag="title", anchor=tkinter.E)
-        self.ui.header_canvas.create_text(center+2, top, text=right_team, font=(None, font_size), fill=RED, tag="title", anchor=tkinter.W)
+        self.ui_header_canvas.create_text(center, top, text=left_team, font=(None, font_size), fill=BLUE, tags="title", anchor=tkinter.E)
+        self.ui_header_canvas.create_text(center+2, top, text=right_team, font=(None, font_size), fill=RED, tags="title", anchor=tkinter.W)
 
-        bottom_text = self.ui.header_canvas.create_text(0 + 5, 20 + font_size, text=" " + left_status, font=(None, status_font_size), tag="title", anchor=tkinter.W)
-        self.ui.header_canvas.create_text(self.ui.header_canvas.winfo_width() - 5, 20 + font_size, text=right_status + " ", font=(None, status_font_size), tag="title", anchor=tkinter.E)
+        bottom_text = self.ui_header_canvas.create_text(0 + 5, 20 + font_size, text=" " + left_status, font=(None, status_font_size), tags="title", anchor=tkinter.W)
+        self.ui_header_canvas.create_text(self.ui_header_canvas.winfo_width() - 5, 20 + font_size, text=right_status + " ", font=(None, status_font_size), tags="title", anchor=tkinter.E)
 
     def draw_status_info(self, game_state):
         round = "–" if game_state["round"] is None else game_state["round"]
@@ -858,25 +853,25 @@ class TkApplication:
         layout_name = "–" if game_state["layout_name"] is None else game_state["layout_name"]
 
         round_info = f"Round {round:>3}/{max_rounds}"
-        self.ui.status_round_info.config(text=round_info)
+        self.ui_status_round_info.config(text=round_info)
 
         if self._fps is not None:
             fps_info = "%.f fps" % self._fps
         else:
             fps_info = "– fps"
-        self.ui.status_fps_info.config(text=fps_info)
+        self.ui_status_fps_info.config(text=fps_info)
 
         bot_colors = [BLUE, RED, BLUE, RED]
-        for idx, circle in enumerate(self.ui.bot_traffic_lights_c):
+        for idx, circle in enumerate(self.ui_bot_traffic_lights_c):
             if turn == idx:
-                self.ui.bot_traffic_lights_canvas.itemconfig(circle, fill=bot_colors[idx])
+                self.ui_bot_traffic_lights_canvas.itemconfig(circle, fill=bot_colors[idx])
             else:
-                self.ui.bot_traffic_lights_canvas.itemconfig(circle, fill="#bbb")
+                self.ui_bot_traffic_lights_canvas.itemconfig(circle, fill="#bbb")
 
-        self.ui.status_layout_info.config(text=layout_name)
+        self.ui_status_layout_info.config(text=layout_name)
 
     def draw_selected(self, game_state):
-        self.ui.game_canvas.delete("selected")
+        self.ui_game_canvas.delete("selected")
         if self.selected:
             def field_status(pos):
                 has_food = pos in game_state['food']
@@ -906,22 +901,22 @@ class TkApplication:
 
                 return f"{pos} in {zone} zone: {contents}"
 
-            self.ui.status_selected.config(text=field_status(self.selected))
+            self.ui_status_selected.config(text=field_status(self.selected))
 
             ul = self.mesh_graph.mesh_to_screen(self.selected, (-1, -1))
             ur = self.mesh_graph.mesh_to_screen(self.selected, (1, -1))
             ll = self.mesh_graph.mesh_to_screen(self.selected, (-1, 1))
             lr = self.mesh_graph.mesh_to_screen(self.selected, (1, 1))
 
-            self.ui.game_canvas.create_rectangle(*ul, *lr, fill=SELECTED, tag=("selected",))
-            self.ui.game_canvas.tag_lower("selected")
+            self.ui_game_canvas.create_rectangle(*ul, *lr, fill=SELECTED, tags=("selected",))
+            self.ui_game_canvas.tag_lower("selected")
         else:
-            self.ui.status_selected.config(text="nothing selected")
+            self.ui_status_selected.config(text="nothing selected")
 
 
     def draw_end_of_game(self, display_string):
         """ Draw an end of game string. """
-        self.ui.game_canvas.delete("gameover")
+        self.ui_game_canvas.delete("gameover")
 
         if display_string is None:
             return
@@ -936,16 +931,16 @@ class TkApplication:
 
         for i in [-2, -1, 0, 1, 2]:
             for j in [-2, -1, 0, 1, 2]:
-                self.ui.game_canvas.create_text(center[0] - i, center[1] - j,
+                self.ui_game_canvas.create_text(center[0] - i, center[1] - j,
                         text=display_string,
                         font=(None, font_size, "bold"),
-                        fill="#ED1B22", tag="gameover",
+                        fill="#ED1B22", tags="gameover",
                         justify=tkinter.CENTER, anchor=tkinter.CENTER)
 
-        self.ui.game_canvas.create_text(center[0] , center[1] ,
+        self.ui_game_canvas.create_text(center[0] , center[1] ,
                 text=display_string,
                 font=(None, font_size, "bold"),
-                fill="#FFC903", tag="gameover",
+                fill="#FFC903", tags="gameover",
                 justify=tkinter.CENTER, anchor=tkinter.CENTER)
 
 
@@ -962,12 +957,12 @@ class TkApplication:
         self.draw_end_of_game("GAME OVER\nDRAW!")
 
     def clear(self):
-        self.ui.game_canvas.delete(tkinter.ALL)
+        self.ui_game_canvas.delete(tkinter.ALL)
 
     def draw_food(self, game_state):
 #        if not self.size_changed:
 #            return
-        self.ui.game_canvas.delete("food")
+        self.ui_game_canvas.delete("food")
         self.food_items = {}
         max_food_age = game_state["max_food_age"]
         for position in game_state['food']:
@@ -979,13 +974,13 @@ class TkApplication:
                 food_age=food_age,
                 max_food_age=max_food_age,
             )
-            food_item.draw(self.ui.game_canvas, show_lifetime=False)
+            food_item.draw(self.ui_game_canvas, show_lifetime=False)
             self.food_items[position] = food_item
 
     def draw_maze(self, game_state):
         if not self.size_changed:
             return
-        self.ui.game_canvas.delete("wall")
+        self.ui_game_canvas.delete("wall")
         # we keep all wall items stored in a list
         # some versions of Python seem to forget about drawing
         # them otherwise
@@ -998,19 +993,19 @@ class TkApplication:
                               for dy in [-1, 0, 1]
                               if (model_x + dx, model_y + dy) in game_state['walls']]
             wall_item = Wall(self.mesh_graph, wall_neighbors=wall_neighbors, position=(model_x, model_y))
-            wall_item.draw(self.ui.game_canvas)
+            wall_item.draw(self.ui_game_canvas)
             self.wall_items.append(wall_item)
             num += 1
 
     def init_bot_sprites(self, bot_positions):
         for sprite in self.bot_sprites.values():
-            sprite.delete(self.ui.game_canvas)
+            sprite.delete(self.ui_game_canvas)
         self.bot_sprites = {
             idx: BotSprite(self.mesh_graph, team=idx % 2, bot_id=idx, position=bot)
             for idx, bot in enumerate(bot_positions)
         }
         for sprite in self.shadow_sprites.values():
-            sprite.delete(self.ui.game_canvas)
+            sprite.delete(self.ui_game_canvas)
         self.shadow_sprites = {
             idx: BotSprite(self.mesh_graph, team=idx % 2, bot_id=idx, position=None, shadow=True)
             for idx, bot in enumerate(bot_positions)
@@ -1020,7 +1015,7 @@ class TkApplication:
         if game_state['turn'] is None:
             return
 
-        self.ui.game_canvas.delete("arrow")
+        self.ui_game_canvas.delete("arrow")
         # we keep all arrow items stored in a list
         # some versions of Python seem to forget about drawing
         # them otherwise
@@ -1046,13 +1041,13 @@ class TkApplication:
                             req_pos=game_state['requested_moves'][bot]['requested_position'],
                             success=True,
                             head=False)
-            arrow_item1.draw(self.ui.game_canvas)
+            arrow_item1.draw(self.ui_game_canvas)
 
             arrow_item2 = Arrow(self.mesh_graph,
                             position=game_state['requested_moves'][bot]['requested_position'],
                             req_pos=game_state['bots'][bot],
                             success=True)
-            arrow_item2.draw(self.ui.game_canvas)
+            arrow_item2.draw(self.ui_game_canvas)
 
             self.arrow_items.append(arrow_item1)
             self.arrow_items.append(arrow_item2)
@@ -1061,7 +1056,7 @@ class TkApplication:
                             position=old_pos,
                             req_pos=game_state['bots'][bot],
                             success=game_state['requested_moves'][bot]['success'])
-            arrow_item.draw(self.ui.game_canvas)
+            arrow_item.draw(self.ui_game_canvas)
             self.arrow_items.append(arrow_item)
 
 
@@ -1074,7 +1069,7 @@ class TkApplication:
         for bot_id, bot_sprite in self.bot_sprites.items():
             say = game_state and game_state["say"][bot_id]
             bot_sprite.move_to(game_state["bots"][bot_sprite.bot_id],
-                               self.ui.game_canvas,
+                               self.ui_game_canvas,
                                game_state,
                                force=self.size_changed,
                                say=say,
@@ -1100,10 +1095,10 @@ class TkApplication:
                 shadow_bots = None
 
             if shadow_bots is None or shadow_bots[bot_id] is None:
-                bot_sprite.delete(self.ui.game_canvas)
+                bot_sprite.delete(self.ui_game_canvas)
             else:
                 bot_sprite.move_to(shadow_bots[bot_id],
-                                    self.ui.game_canvas,
+                                    self.ui_game_canvas,
                                     game_state,
                                     force=self.size_changed,
                                     show_id=self._grid_enabled)
@@ -1229,12 +1224,12 @@ class TkApplication:
 
     def _check_speed_button_state(self):
         try:
-            # self.ui.button_game_speed_faster
+            # self.ui_button_game_speed_faster
             # may not be available yet (or may be None).
             # If this is the case, we’ll do nothing at all.
             if self._delay <= self._min_delay:
-                self.ui.button_game_speed_faster.config(state=tkinter.DISABLED)
+                self.ui_button_game_speed_faster.config(state=tkinter.DISABLED)
             else:
-                self.ui.button_game_speed_faster.config(state=tkinter.NORMAL)
+                self.ui_button_game_speed_faster.config(state=tkinter.NORMAL)
         except AttributeError:
             pass

--- a/pelita/ui/tk_canvas.py
+++ b/pelita/ui/tk_canvas.py
@@ -538,6 +538,9 @@ class TkApplication:
                 for pos in overlay.get("pos", []):
                     draw_box(pos, fill_col)
 
+        self.ui_game_canvas.tag_lower("overlay")
+        self.ui_game_canvas.tag_raise("wall")
+
     def draw_line_of_sight(self, game_state):
         self.ui_game_canvas.delete("line_of_sight")
         if not self._grid_enabled:

--- a/pelita/ui/tk_canvas.py
+++ b/pelita/ui/tk_canvas.py
@@ -263,7 +263,7 @@ class TkApplication:
 
         self.ui_status_fps_info = tkinter.Label(self.ui_status_20,
             text="",
-            font=(None, 8),
+            font=(self._default_font, 8),
             foreground="black",
             background="white",
             justify=tkinter.CENTER)
@@ -271,7 +271,7 @@ class TkApplication:
 
         self.ui_status_selected = tkinter.Label(self.ui_status_22,
             text="",
-            font=(None, 8),
+            font=(self._default_font, 8),
             foreground="black",
             background="white",
             justify=tkinter.CENTER)
@@ -319,7 +319,7 @@ class TkApplication:
         for idx in range(4):
             spacing = 10
             x0, y0 = 2.5 + idx * spacing, 13
-            circle = self.ui_bot_traffic_lights_canvas.create_text(x0, y0, text=layout.BOT_I2N[idx], font=(None, 11), fill="black")
+            circle = self.ui_bot_traffic_lights_canvas.create_text(x0, y0, text=layout.BOT_I2N[idx], font=(self._default_font, 11), fill="black")
             self.ui_bot_traffic_lights_c.append(circle)
 
         self.ui_status_round_info = tkinter.Label(self.ui_status_02, text="", background="white")
@@ -836,15 +836,15 @@ class TkApplication:
         top = 15
         spacer = 3
 
-        middle_colon = self.ui_header_canvas.create_text(center, top, text=":", font=(None, font_size), tags="title", anchor=tkinter.CENTER)
+        middle_colon = self.ui_header_canvas.create_text(center, top, text=":", font=(self._default_font, font_size), tags="title", anchor=tkinter.CENTER)
         middle_colon_bottom = self.ui_header_canvas.bbox(middle_colon)[3]
         spacer = (self.ui_header_canvas.bbox(middle_colon)[3] - self.ui_header_canvas.bbox(middle_colon)[1]) / 2
 
-        self.ui_header_canvas.create_text(center, top, text=left_team, font=(None, font_size), fill=BLUE, tags="title", anchor=tkinter.E)
-        self.ui_header_canvas.create_text(center+2, top, text=right_team, font=(None, font_size), fill=RED, tags="title", anchor=tkinter.W)
+        self.ui_header_canvas.create_text(center, top, text=left_team, font=(self._default_font, font_size), fill=BLUE, tags="title", anchor=tkinter.E)
+        self.ui_header_canvas.create_text(center+2, top, text=right_team, font=(self._default_font, font_size), fill=RED, tags="title", anchor=tkinter.W)
 
-        bottom_text = self.ui_header_canvas.create_text(0 + 5, 20 + font_size, text=" " + left_status, font=(None, status_font_size), tags="title", anchor=tkinter.W)
-        self.ui_header_canvas.create_text(self.ui_header_canvas.winfo_width() - 5, 20 + font_size, text=right_status + " ", font=(None, status_font_size), tags="title", anchor=tkinter.E)
+        bottom_text = self.ui_header_canvas.create_text(0 + 5, 20 + font_size, text=" " + left_status, font=(self._default_font, status_font_size), tags="title", anchor=tkinter.W)
+        self.ui_header_canvas.create_text(self.ui_header_canvas.winfo_width() - 5, 20 + font_size, text=right_status + " ", font=(self._default_font, status_font_size), tags="title", anchor=tkinter.E)
 
     def draw_status_info(self, game_state):
         round = "–" if game_state["round"] is None else game_state["round"]
@@ -933,13 +933,13 @@ class TkApplication:
             for j in [-2, -1, 0, 1, 2]:
                 self.ui_game_canvas.create_text(center[0] - i, center[1] - j,
                         text=display_string,
-                        font=(None, font_size, "bold"),
+                        font=(self._default_font, font_size, "bold"),
                         fill="#ED1B22", tags="gameover",
                         justify=tkinter.CENTER, anchor=tkinter.CENTER)
 
         self.ui_game_canvas.create_text(center[0] , center[1] ,
                 text=display_string,
-                font=(None, font_size, "bold"),
+                font=(self._default_font, font_size, "bold"),
                 fill="#FFC903", tags="gameover",
                 justify=tkinter.CENTER, anchor=tkinter.CENTER)
 
@@ -1001,13 +1001,13 @@ class TkApplication:
         for sprite in self.bot_sprites.values():
             sprite.delete(self.ui_game_canvas)
         self.bot_sprites = {
-            idx: BotSprite(self.mesh_graph, team=idx % 2, bot_id=idx, position=bot)
+            idx: BotSprite(self.mesh_graph, team=idx % 2, bot_id=idx, position=bot, font=self._default_font)
             for idx, bot in enumerate(bot_positions)
         }
         for sprite in self.shadow_sprites.values():
             sprite.delete(self.ui_game_canvas)
         self.shadow_sprites = {
-            idx: BotSprite(self.mesh_graph, team=idx % 2, bot_id=idx, position=None, shadow=True)
+            idx: BotSprite(self.mesh_graph, team=idx % 2, bot_id=idx, position=None, shadow=True, font=self._default_font)
             for idx, bot in enumerate(bot_positions)
         }
 

--- a/pelita/ui/tk_canvas.py
+++ b/pelita/ui/tk_canvas.py
@@ -454,6 +454,7 @@ class TkApplication:
         self.mesh_graph.num_y = game_state['shape'][1]
 
         self.draw_grid()
+        self.draw_overlay(game_state.get('overlays', []))
         self.draw_selected(game_state)
         self.draw_line_of_sight(game_state)
         self.draw_bot_shadow(game_state)
@@ -522,6 +523,26 @@ class TkApplication:
         x_pos = self.mesh_graph.mesh_to_screen_x(0, -1) - label_size
         y_pos = self.mesh_graph.mesh_to_screen_y(self.mesh_graph.mesh_height, -0.7)
         self.ui_game_canvas.create_text(x_pos, y_pos, text="y", **label_style)
+
+    def draw_overlay(self, overlays):
+        """ Draws a light grid on the background.
+        """
+        self.ui_game_canvas.delete("overlay")
+        if not self._grid_enabled:
+            return
+
+        def draw_box(pos, fill_col):
+            ul = self.mesh_graph.mesh_to_screen(pos, (-1, -1))
+            ur = self.mesh_graph.mesh_to_screen(pos, (1, -1))
+            ll = self.mesh_graph.mesh_to_screen(pos, (-1, 1))
+            lr = self.mesh_graph.mesh_to_screen(pos, (1, 1))
+
+            self.ui_game_canvas.create_rectangle(*ul, *lr, width=0, fill=fill_col, tags=("overlay",))
+
+        for overlay in overlays:
+            if fill_col := overlay.get("fill"):
+                for pos in overlay.get("pos", []):
+                    draw_box(pos, fill_col)
 
     def draw_line_of_sight(self, game_state):
         self.ui_game_canvas.delete("line_of_sight")

--- a/pelita/ui/tk_canvas.py
+++ b/pelita/ui/tk_canvas.py
@@ -65,6 +65,11 @@ class MeshGraph:
         self.screen_width = screen_width
         self.padding = 10
 
+    def update_mesh_shape(self, shape):
+        mesh_width, mesh_height = shape
+        self.mesh_width = mesh_width
+        self.mesh_height = mesh_height
+
     @property
     def rect_width(self):
         """ The width of a single field.
@@ -170,15 +175,22 @@ class TkApplication:
 
         self.game_finish_overlay = lambda: None
 
-        self.mesh_graph = None
         self.geometry = geometry
+        if self.geometry is None:
+            screensize = (
+                max(250, self.window.winfo_screenwidth() - 100),
+                max(250, self.window.winfo_screenheight() - 100)
+                )
+        else:
+            screensize = self.geometry
+
+        self.mesh_graph = MeshGraph(0, 0, screensize[0], screensize[1])
+
         self.fullscreen = fullscreen
         self._fullscreen_enabled = fullscreen
 
         self._default_font = tkinter.font.nametofont("TkDefaultFont")
         self._default_font_size = self._default_font.cget('size')
-
-        self.size_changed = True
 
         self._grid_enabled = False
 
@@ -186,12 +198,11 @@ class TkApplication:
         self._fps = None
         self.selected = None
 
-        self.game_uuid = None
         self.bot_sprites = {}
         self.shadow_sprites = {}
+        self.init_bot_sprites([None] * 4)
 
-        self._universe = None
-        self._game_state = None
+        self._game_state = {}
 
         self.ui_header_canvas = tkinter.Canvas(window, height=50)
         self.ui_header_canvas.config(background="white", bd=0, highlightthickness=0, relief='ridge')
@@ -363,25 +374,7 @@ class TkApplication:
         if self.controller_socket:
             self.window.after_idle(self.request_initial)
 
-
-    def init_mesh(self, game_state):
-        width, height = game_state['shape']
-
-        if self.geometry is None:
-            screensize = (
-                max(250, self.window.winfo_screenwidth() - 100),
-                max(250, self.window.winfo_screenheight() - 100)
-                )
-        else:
-            screensize = self.geometry
-        scale_x = screensize[0] / width
-        scale_y = screensize[1] / height
-        scale = int(min(scale_x, scale_y, 50))
-
-        self.mesh_graph = MeshGraph(width, height, scale * width, scale * height)
-        self.init_bot_sprites(game_state['bots'])
-
-    def update(self, game_state=None):
+    def update(self, game_state=None, redraw=False):
         # Update the times for the fps calculation (if we are running)
         # Our fps is only relevant for how often the bots update our viewer.
         # When the viewer updates itself, we do not count it.
@@ -401,20 +394,22 @@ class TkApplication:
                 self._times = self._times[-3:]
 
         if game_state is not None:
+            if self._game_state.get("shape") != game_state.get("shape"):
+                redraw = True
+            if self._game_state.get("walls") != game_state.get("walls"):
+                redraw = True
+
             self._game_state = game_state
         game_state = self._game_state
         if not game_state:
             return
 
-        #if game_state['game_uuid'] != self.game_uuid:
-        if not self.game_uuid:
-            #self.game_uuid = game_state['game_uuid']
-            self.game_uuid = 1
-            self.init_mesh(game_state)
+        self.mesh_graph.update_mesh_shape(game_state['shape'])
 
+        # Check and adjust sizes
         if ((self.mesh_graph.screen_width, self.mesh_graph.screen_height)
             != (self.ui_game_canvas.winfo_width(), self.ui_game_canvas.winfo_height())):
-            self.size_changed = True
+            redraw = True
 
         self.mesh_graph.screen_width = self.ui_game_canvas.winfo_width()
         self.mesh_graph.screen_height = self.ui_game_canvas.winfo_height()
@@ -426,7 +421,8 @@ class TkApplication:
             if self._default_font.cget('size') != self._default_font_size:
                 self._default_font.configure(size=self._default_font_size)
 
-        self.draw_universe(game_state)
+
+        self.draw_universe(game_state, redraw=redraw)
 
         eaten_food = []
         for food_pos, food_item in self.food_items.items():
@@ -437,7 +433,6 @@ class TkApplication:
         for food_pos in eaten_food:
             del self.food_items[food_pos]
 
-
         winning_team_idx = game_state.get("whowins")
         if winning_team_idx is None:
             self.draw_end_of_game(None)
@@ -447,33 +442,32 @@ class TkApplication:
         elif winning_team_idx == 2:
             self.draw_game_draw()
 
-        self.size_changed = False
 
-    def draw_universe(self, game_state):
+    def draw_universe(self, game_state, redraw):
         self.mesh_graph.num_x = game_state['shape'][0]
         self.mesh_graph.num_y = game_state['shape'][1]
 
-        self.draw_grid()
         self.draw_overlay(game_state.get('overlays', []))
+        self.draw_grid(redraw=redraw)
         self.draw_selected(game_state)
         self.draw_line_of_sight(game_state)
         self.draw_bot_shadow(game_state)
-        self.draw_background()
-        self.draw_maze(game_state)
+        self.draw_background(redraw=redraw)
+        self.draw_maze(game_state, redraw=redraw)
         self.draw_food(game_state)
 
         self.draw_title(game_state)
-        self.draw_shadow_bots(game_state)
-        self.draw_bots(game_state)
+        self.draw_shadow_bots(game_state, redraw=redraw)
+        self.draw_bots(game_state, redraw=redraw)
 
         self.draw_moves(game_state)
 
         self.draw_status_info(game_state)
 
-    def draw_grid(self):
+    def draw_grid(self, redraw):
         """ Draws a light grid on the background.
         """
-        if not self.size_changed:
+        if not redraw:
             return
         self.ui_game_canvas.delete("grid")
 
@@ -549,6 +543,11 @@ class TkApplication:
         if not self._grid_enabled:
             return
 
+        bot = game_state.get('turn')
+        if bot is None:
+            # game has not started yet or we are in layout-only mode
+            return
+
         scale = self.mesh_graph.half_scale_x * 0.1
 
         def draw_box(pos):
@@ -558,11 +557,6 @@ class TkApplication:
             lr = self.mesh_graph.mesh_to_screen(pos, (1, 1))
 
             self.ui_game_canvas.create_rectangle(*ul, *lr, width=2, outline='#111', tags=("line_of_sight",))
-
-        bot = game_state['turn']
-        if bot is None:
-            # game has not started yet
-            return
 
         line_col = STRONG_BLUE if bot % 2 == 0 else STRONG_RED
         fill_col = LIGHT_BLUE if bot % 2 == 0 else LIGHT_RED
@@ -648,6 +642,11 @@ class TkApplication:
         if not self._grid_enabled:
             return
 
+        bot = game_state.get('turn')
+        if bot is None:
+            # game has not started yet or we are in layout-only mode
+            return
+
         border_col = "#000"
         fill_col = LIGHT_GREY
 
@@ -660,11 +659,6 @@ class TkApplication:
             lr = self.mesh_graph.mesh_to_screen(pos, (1, 1))
 
             self.ui_game_canvas.create_rectangle(*ul, *lr, width=2, outline='#111', tags=("bot_shadow",))
-
-        bot = game_state['turn']
-        if bot is None:
-            # game has not started yet
-            return
 
         try:
             old_pos = tuple(game_state['requested_moves'][bot]['previous_position'])
@@ -758,18 +752,16 @@ class TkApplication:
 
     def toggle_grid(self):
         self._grid_enabled = not self._grid_enabled
-        self.size_changed = True
         self._check_grid_toggle_state()
-        self.update()
+        self.update(redraw=True)
 
     def toggle_fullscreen(self):
         self._fullscreen_enabled = not self._fullscreen_enabled
-        self.size_changed = True
         if self._fullscreen_enabled:
             self.window.attributes('-fullscreen',True)
         else:
             self.window.attributes('-fullscreen',False)
-        self.update()
+        self.update(redraw=True)
 
     def _check_grid_toggle_state(self):
         if self._grid_enabled:
@@ -786,10 +778,10 @@ class TkApplication:
             self.selected = selected
         self.update()
 
-    def draw_background(self):
+    def draw_background(self, redraw):
         """ Draws a line between blue and red team.
         """
-        if not self.size_changed:
+        if not redraw:
             return
         self.ui_game_canvas.delete("background")
 
@@ -805,6 +797,9 @@ class TkApplication:
 
     def draw_title(self, game_state):
         self.ui_header_canvas.delete("title")
+
+        if "team_names" not in game_state:
+            return
 
         center = self.ui_header_canvas.winfo_width() // 2
 
@@ -868,27 +863,28 @@ class TkApplication:
         self.ui_header_canvas.create_text(self.ui_header_canvas.winfo_width() - 5, 20 + font_size, text=right_status + " ", font=(self._default_font, status_font_size), tags="title", anchor=tkinter.E)
 
     def draw_status_info(self, game_state):
-        round = "–" if game_state["round"] is None else game_state["round"]
-        max_rounds = "–" if game_state["max_rounds"] is None else game_state["max_rounds"]
-        turn = "–" if game_state["turn"] is None else game_state["turn"]
-        layout_name = "–" if game_state["layout_name"] is None else game_state["layout_name"]
+        if "round" in game_state:
+            round = "–" if game_state["round"] is None else game_state["round"]
+            max_rounds = "–" if game_state["max_rounds"] is None else game_state["max_rounds"]
+            turn = "–" if game_state["turn"] is None else game_state["turn"]
 
-        round_info = f"Round {round:>3}/{max_rounds}"
-        self.ui_status_round_info.config(text=round_info)
+            round_info = f"Round {round:>3}/{max_rounds}"
+            self.ui_status_round_info.config(text=round_info)
 
-        if self._fps is not None:
-            fps_info = "%.f fps" % self._fps
-        else:
-            fps_info = "– fps"
-        self.ui_status_fps_info.config(text=fps_info)
-
-        bot_colors = [BLUE, RED, BLUE, RED]
-        for idx, circle in enumerate(self.ui_bot_traffic_lights_c):
-            if turn == idx:
-                self.ui_bot_traffic_lights_canvas.itemconfig(circle, fill=bot_colors[idx])
+            if self._fps is not None:
+                fps_info = "%.f fps" % self._fps
             else:
-                self.ui_bot_traffic_lights_canvas.itemconfig(circle, fill="#bbb")
+                fps_info = "– fps"
+            self.ui_status_fps_info.config(text=fps_info)
 
+            bot_colors = [BLUE, RED, BLUE, RED]
+            for idx, circle in enumerate(self.ui_bot_traffic_lights_c):
+                if turn == idx:
+                    self.ui_bot_traffic_lights_canvas.itemconfig(circle, fill=bot_colors[idx])
+                else:
+                    self.ui_bot_traffic_lights_canvas.itemconfig(circle, fill="#bbb")
+
+        layout_name = "–" if game_state.get("layout_name") is None else game_state.get("layout_name")
         self.ui_status_layout_info.config(text=layout_name)
 
     def draw_selected(self, game_state):
@@ -981,11 +977,9 @@ class TkApplication:
         self.ui_game_canvas.delete(tkinter.ALL)
 
     def draw_food(self, game_state):
-#        if not self.size_changed:
-#            return
         self.ui_game_canvas.delete("food")
         self.food_items = {}
-        max_food_age = game_state["max_food_age"]
+        max_food_age = game_state.get("max_food_age")
         for position in game_state['food']:
             model_x, model_y = position
             food_age = game_state['food_age'].get(position, 0)
@@ -998,9 +992,10 @@ class TkApplication:
             food_item.draw(self.ui_game_canvas, show_lifetime=False)
             self.food_items[position] = food_item
 
-    def draw_maze(self, game_state):
-        if not self.size_changed:
+    def draw_maze(self, game_state, redraw):
+        if not redraw:
             return
+
         self.ui_game_canvas.delete("wall")
         # we keep all wall items stored in a list
         # some versions of Python seem to forget about drawing
@@ -1033,10 +1028,11 @@ class TkApplication:
         }
 
     def draw_moves(self, game_state):
-        if game_state['turn'] is None:
+        self.ui_game_canvas.delete("arrow")
+
+        if game_state.get('turn') is None:
             return
 
-        self.ui_game_canvas.delete("arrow")
         # we keep all arrow items stored in a list
         # some versions of Python seem to forget about drawing
         # them otherwise
@@ -1081,26 +1077,29 @@ class TkApplication:
             self.arrow_items.append(arrow_item)
 
 
-    def draw_bots(self, game_state):
+    def draw_bots(self, game_state, redraw):
         if game_state:
-            for bot_id, was_killed in enumerate(game_state["bot_was_killed"]):
+            for bot_id, was_killed in enumerate(game_state.get("bot_was_killed", [])):
                 if was_killed:
                     self.bot_sprites[bot_id].position = None
 
         for bot_id, bot_sprite in self.bot_sprites.items():
-            say = game_state and game_state["say"][bot_id]
+            if game_state and "say" in game_state:
+                say = game_state["say"][bot_id]
+            else:
+                say = ""
             bot_sprite.move_to(game_state["bots"][bot_sprite.bot_id],
                                self.ui_game_canvas,
                                game_state,
-                               force=self.size_changed,
+                               force=redraw,
                                say=say,
                                show_id=self._grid_enabled)
 
-    def draw_shadow_bots(self, game_state):
+    def draw_shadow_bots(self, game_state, redraw):
         # Draw the shadowbots when debug mode (grid) is enabled
         # Otherwise make sure that they are deleted
 
-        if game_state['turn'] is None:
+        if game_state.get('turn') is None:
             # We cannot show shadow bots before the first turn has been played,
             # as we would only see the bots from the set_initial phase, and
             # only the blue bots (those that were shown to the second, red, player).
@@ -1121,7 +1120,7 @@ class TkApplication:
                 bot_sprite.move_to(shadow_bots[bot_id],
                                     self.ui_game_canvas,
                                     game_state,
-                                    force=self.size_changed,
+                                    force=redraw,
                                     show_id=self._grid_enabled)
 
     def toggle_running(self):
@@ -1174,28 +1173,34 @@ class TkApplication:
             self._delay = self._min_delay
         self.request_step()
 
-    def observe(self, game_state):
-        step = (game_state['round'], game_state['turn'])
-        if step in self._observed_steps:
-            skip_request = True
+    def observe(self, game_state, standalone_mode=False):
+        # If in standalone mode, we will simply display everything that we receive
+
+        if standalone_mode:
+            self.running = False
         else:
-            skip_request = False
-            self._observed_steps.add(step)
+            step = (game_state['round'], game_state['turn'])
+            if step in self._observed_steps:
+                skip_request = True
+            else:
+                skip_request = False
+                self._observed_steps.add(step)
+
         # ensure walls, foods and bots positions are list of tuples
         game_state['walls'] = _ensure_list_tuples(game_state['walls'])
         game_state['food'] = _ensure_list_tuples(game_state['food'])
         game_state['bots'] = _ensure_list_tuples(game_state['bots'])
         game_state['shape'] = tuple(game_state['shape'])
-        game_state['food_age'] = {tuple(pos): food_age for pos, food_age in game_state['food_age']}
+        game_state['food_age'] = {tuple(pos): food_age for pos, food_age in game_state.get('food_age', [])}
 
         # check if a bot has been killed in the last round
         # gs.bot_was_killed does not reset the True state for a killed bot
         # until a whole round is over, so we have to cache previous values
         bot_was_killed = False
-        for last, now in zip(self._last_bot_was_killed, game_state['bot_was_killed']):
+        for last, now in zip(self._last_bot_was_killed, game_state.get('bot_was_killed', [])):
             if now and not last:
                 bot_was_killed = True
-        self._last_bot_was_killed = game_state['bot_was_killed']
+        self._last_bot_was_killed = game_state.get('bot_was_killed', [])
 
         if self._stop_after_kill and bot_was_killed:
             self.running = False

--- a/pelita/ui/tk_sprites.py
+++ b/pelita/ui/tk_sprites.py
@@ -144,11 +144,11 @@ class BotSprite(TkSprite):
 
         canvas.delete("speak"+self.tag)
         # We increase readability with a white border around the text.
-        canvas.create_text(self.bounding_box()[0][0]-1, self.bounding_box()[0][1], text=say, font=(None, 12), fill="white", tag="speak"+self.tag)
-        canvas.create_text(self.bounding_box()[0][0]+1, self.bounding_box()[0][1], text=say, font=(None, 12), fill="white", tag="speak"+self.tag)
-        canvas.create_text(self.bounding_box()[0][0], self.bounding_box()[0][1]-1, text=say, font=(None, 12), fill="white", tag="speak"+self.tag)
-        canvas.create_text(self.bounding_box()[0][0], self.bounding_box()[0][1]+1, text=say, font=(None, 12), fill="white", tag="speak"+self.tag)
-        canvas.create_text(self.bounding_box()[0][0], self.bounding_box()[0][1], text=say, font=(None, 12), fill="black", tag="speak"+self.tag)
+        canvas.create_text(self.bounding_box()[0][0]-1, self.bounding_box()[0][1], text=say, font=(None, 12), fill="white", tags="speak"+self.tag)
+        canvas.create_text(self.bounding_box()[0][0]+1, self.bounding_box()[0][1], text=say, font=(None, 12), fill="white", tags="speak"+self.tag)
+        canvas.create_text(self.bounding_box()[0][0], self.bounding_box()[0][1]-1, text=say, font=(None, 12), fill="white", tags="speak"+self.tag)
+        canvas.create_text(self.bounding_box()[0][0], self.bounding_box()[0][1]+1, text=say, font=(None, 12), fill="white", tags="speak"+self.tag)
+        canvas.create_text(self.bounding_box()[0][0], self.bounding_box()[0][1], text=say, font=(None, 12), fill="black", tags="speak"+self.tag)
 
         canvas.delete("show_id" + self.tag)
         # we print the bot_id in the lower left corner
@@ -156,11 +156,11 @@ class BotSprite(TkSprite):
             bot_name = layout.BOT_I2N[self.bot_id ]
             shift_x = 5
             shift_y = 8
-            canvas.create_text(self.bounding_box()[0][0]-1 + shift_x, self.bounding_box()[1][1] - shift_y, text=bot_name, font=(None, 12), fill="white", tag="show_id"+self.tag)
-            canvas.create_text(self.bounding_box()[0][0]+1 + shift_x, self.bounding_box()[1][1] - shift_y, text=bot_name, font=(None, 12), fill="white", tag="show_id"+self.tag)
-            canvas.create_text(self.bounding_box()[0][0] + shift_x, self.bounding_box()[1][1]-1 - shift_y, text=bot_name, font=(None, 12), fill="white", tag="show_id"+self.tag)
-            canvas.create_text(self.bounding_box()[0][0] + shift_x, self.bounding_box()[1][1]+1 - shift_y, text=bot_name, font=(None, 12), fill="white", tag="show_id"+self.tag)
-            canvas.create_text(self.bounding_box()[0][0] + shift_x, self.bounding_box()[1][1] - shift_y, text=bot_name, font=(None, 12), fill="black", tag="show_id"+self.tag)
+            canvas.create_text(self.bounding_box()[0][0]-1 + shift_x, self.bounding_box()[1][1] - shift_y, text=bot_name, font=(None, 12), fill="white", tags="show_id"+self.tag)
+            canvas.create_text(self.bounding_box()[0][0]+1 + shift_x, self.bounding_box()[1][1] - shift_y, text=bot_name, font=(None, 12), fill="white", tags="show_id"+self.tag)
+            canvas.create_text(self.bounding_box()[0][0] + shift_x, self.bounding_box()[1][1]-1 - shift_y, text=bot_name, font=(None, 12), fill="white", tags="show_id"+self.tag)
+            canvas.create_text(self.bounding_box()[0][0] + shift_x, self.bounding_box()[1][1]+1 - shift_y, text=bot_name, font=(None, 12), fill="white", tags="show_id"+self.tag)
+            canvas.create_text(self.bounding_box()[0][0] + shift_x, self.bounding_box()[1][1] - shift_y, text=bot_name, font=(None, 12), fill="black", tags="show_id"+self.tag)
 
     def draw_bot(self, canvas, is_blue=True):
         direction = self.direction
@@ -177,7 +177,7 @@ class BotSprite(TkSprite):
 
         # bot body
         canvas.create_arc(self.bounding_box(), start=rotate(20, direction), extent=320, style="pieslice",
-                          width=0, outline=self.outline_col, fill=self.col, tag=self.tag)
+                          width=0, outline=self.outline_col, fill=self.col, tags=self.tag)
 
         # bot eye
         # first locate eye in the center
@@ -191,7 +191,7 @@ class BotSprite(TkSprite):
         # rotate based on direction
         eye_box = [cmath.exp(1j * math.radians(-direction)) * item for item in eye_box]
         eye_box = [self.screen((item.real, item.imag)) for item in eye_box]
-        canvas.create_oval(eye_box, fill=self.eye_col, width=0, tag=self.tag)
+        canvas.create_oval(eye_box, fill=self.eye_col, width=0, tags=self.tag)
 
     def draw(self, canvas, game_state):
         self.is_harvester = self.is_harvester_at(self.position)
@@ -212,7 +212,7 @@ class BotSprite(TkSprite):
 
         # ghost head
         canvas.create_arc((box_ll, box_tr), start=0, extent=180, style="pieslice" if not self.shadow else "arc",
-                          width=1, outline=self.outline_col, fill=self.col, tag=self.tag)
+                          width=1, outline=self.outline_col, fill=self.col, tags=self.tag)
 
         # ghost body
         box_ll = box_ll[0], box_ll[1] + (box_tr[1]-box_ll[1])/2.
@@ -235,9 +235,9 @@ class BotSprite(TkSprite):
 
         points = list(zip(x,y))
         if self.shadow:
-            canvas.create_line(points, width=1, fill=self.outline_col, tag=self.tag)
+            canvas.create_line(points, width=1, fill=self.outline_col, tags=self.tag)
         else:
-            canvas.create_polygon(points, width=1, outline=self.outline_col, fill=self.col, tag=self.tag)
+            canvas.create_polygon(points, width=1, outline=self.outline_col, fill=self.col, tags=self.tag)
 
         # ghost eyes
         eye_size = 0.15
@@ -245,11 +245,11 @@ class BotSprite(TkSprite):
         # right eye
         eye_box_r = [item+ 0.4 - 0.5j for item in eye_box]
         eye_box_r = [self.screen((item.real, item.imag)) for item in eye_box_r]
-        canvas.create_oval(eye_box_r, fill=self.eye_col, width=0, tag=self.tag)
+        canvas.create_oval(eye_box_r, fill=self.eye_col, width=0, tags=self.tag)
         # left eye
         eye_box_l = [item- 0.4 - 0.5j for item in eye_box]
         eye_box_l = [self.screen((item.real, item.imag)) for item in eye_box_l]
-        canvas.create_oval(eye_box_l, fill=self.eye_col, width=0, tag=self.tag)
+        canvas.create_oval(eye_box_l, fill=self.eye_col, width=0, tags=self.tag)
 
 class Wall(TkSprite):
     def __init__(self, mesh, wall_neighbors=None, **kwargs):
@@ -271,7 +271,7 @@ class Wall(TkSprite):
             # draw only a small dot.
             # TODO add diagonal lines
             canvas.create_line(self.screen((-0.3, 0)), self.screen((+0.3, 0)), fill=BROWN,
-                               width=scale, tag=(self.tag, "wall"), capstyle="round")
+                               width=scale, tags=(self.tag, "wall"), capstyle="round")
         else:
             neighbours = [(-1, -1), (0, -1), (1, -1), (1, 0), (1, 1), (0, 1), (-1, 1), (-1, 0)]
             for dx in [-1, 0, 1]:
@@ -287,14 +287,14 @@ class Wall(TkSprite):
                             pass
                         else:
                             canvas.create_line(self.screen((0, 0)), self.screen((2*dx, 2*dy)), fill=BROWN,
-                                               width=scale, tag=(self.tag, "wall"), capstyle="round")
+                                               width=scale, tags=(self.tag, "wall"), capstyle="round")
 
             # if we are drawing a closed square, fill in the internal part
             # detect the square when we are on the bottom-left vertex of it
             square_neighbors = {(0,0), (0,-1), (1,0),(1,-1)}
             if square_neighbors <= set(self.wall_neighbors):
                 canvas.create_line(self.screen((1,0)), self.screen((1,-2)), fill=BROWN,
-                                   width=scale, tag=(self.tag, "wall"))
+                                   width=scale, tags=(self.tag, "wall"))
 
 
 class Food(TkSprite):
@@ -322,16 +322,16 @@ class Food(TkSprite):
         if food_age and food_age + FOOD_WARNING_TIME > self.max_food_age:
             fill_col = GREY
             text_col = YELLOW
-        canvas.create_oval(self.bounding_box(0.4), fill=fill_col, width=0, tag=(self.tag, self.food_pos_tag(self.position), "food"))
+        canvas.create_oval(self.bounding_box(0.4), fill=fill_col, width=0, tags=(self.tag, self.food_pos_tag(self.position), "food"))
 
         canvas.delete("show_food_age" + str(self.position))
 
         # we print the bot_id in the lower left corner
         if food_age and show_lifetime:
-            tag=(self.tag, "show_food_age" + str(self.position), "food")
+            tags=(self.tag, "show_food_age" + str(self.position), "food")
 
             center = self.screen()
-            canvas.create_text(*center, text=food_age, font=(None, 10), fill=text_col, tag=tag)
+            canvas.create_text(*center, text=food_age, font=(None, 10), fill=text_col, tags=tag)
 
 class Arrow(TkSprite):
     def __init__(self, mesh, req_pos, success, head=True, **kwargs):
@@ -350,19 +350,19 @@ class Arrow(TkSprite):
                 self.screen((0.3, -0.3))
             ]
             canvas.create_line(points,
-                            fill=BROWN, width=scale, tag=(self.tag, "arrow"), capstyle="round")
+                            fill=BROWN, width=scale, tags=(self.tag, "arrow"), capstyle="round")
 
             points = [
                 self.screen((-0.3, -0.3)),
                 self.screen(( 0.3, 0.3))
             ]
             canvas.create_line(points,
-                            fill=BROWN, width=scale, tag=(self.tag, "arrow"), capstyle="round")
+                            fill=BROWN, width=scale, tags=(self.tag, "arrow"), capstyle="round")
 
         dist = manhattan_dist(self.req_pos, self.position)
         if dist == 0:
             canvas.create_arc(self.bounding_box(0.6), start=110, extent=320, style="arc", outline=BROWN,
-                                                width=scale, tag=(self.tag, "arrow"))
+                                                width=scale, tags=(self.tag, "arrow"))
             # arrow head
             head = cmath.rect(0.6, -110 * cmath.pi / 180)
             head_rotation = (-110 + 90) * cmath.pi / 180
@@ -380,7 +380,7 @@ class Arrow(TkSprite):
                 self.screen((head_right.real, head_right.imag))
             ]
             canvas.create_line(points,
-                            fill=BROWN, width=scale, tag=(self.tag, "arrow"), capstyle="round")
+                            fill=BROWN, width=scale, tags=(self.tag, "arrow"), capstyle="round")
 
         else:
             # dx, dy has to be duplicated because the self.screen coordinates go from -1 to 1
@@ -388,7 +388,7 @@ class Arrow(TkSprite):
             dx = (self.req_pos[0] - self.position[0]) * 2
             dy = (self.req_pos[1] - self.position[1]) * 2
             canvas.create_line(self.screen((0, 0)), self.screen((dx, dy)), fill=BROWN,
-                                                width=scale, tag=(self.tag, "arrow"), capstyle="round")
+                                                width=scale, tags=(self.tag, "arrow"), capstyle="round")
             # arrow head
             vector = dx + dy * 1j
             phase = cmath.phase(vector)
@@ -403,5 +403,5 @@ class Arrow(TkSprite):
             ]
             if self.head:
                 canvas.create_line(points,
-                                fill=BROWN, width=scale, tag=(self.tag, "arrow"), capstyle="round")
+                                fill=BROWN, width=scale, tags=(self.tag, "arrow"), capstyle="round")
 

--- a/pelita/ui/tk_sprites.py
+++ b/pelita/ui/tk_sprites.py
@@ -37,12 +37,13 @@ def pos_to_complex(pos):
     return x - y * 1j
 
 class TkSprite:
-    def __init__(self, mesh, *, position=None, _tag=None):
+    def __init__(self, mesh, *, position=None, _tag=None, font=None):
         self.mesh = mesh
 
         self._position = position
         self._direction = None
         self._tag = _tag
+        self._font = font
 
     @property
     def direction(self):
@@ -144,11 +145,11 @@ class BotSprite(TkSprite):
 
         canvas.delete("speak"+self.tag)
         # We increase readability with a white border around the text.
-        canvas.create_text(self.bounding_box()[0][0]-1, self.bounding_box()[0][1], text=say, font=(None, 12), fill="white", tags="speak"+self.tag)
-        canvas.create_text(self.bounding_box()[0][0]+1, self.bounding_box()[0][1], text=say, font=(None, 12), fill="white", tags="speak"+self.tag)
-        canvas.create_text(self.bounding_box()[0][0], self.bounding_box()[0][1]-1, text=say, font=(None, 12), fill="white", tags="speak"+self.tag)
-        canvas.create_text(self.bounding_box()[0][0], self.bounding_box()[0][1]+1, text=say, font=(None, 12), fill="white", tags="speak"+self.tag)
-        canvas.create_text(self.bounding_box()[0][0], self.bounding_box()[0][1], text=say, font=(None, 12), fill="black", tags="speak"+self.tag)
+        canvas.create_text(self.bounding_box()[0][0]-1, self.bounding_box()[0][1], text=say, font=(self._font, 12), fill="white", tags="speak"+self.tag)
+        canvas.create_text(self.bounding_box()[0][0]+1, self.bounding_box()[0][1], text=say, font=(self._font, 12), fill="white", tags="speak"+self.tag)
+        canvas.create_text(self.bounding_box()[0][0], self.bounding_box()[0][1]-1, text=say, font=(self._font, 12), fill="white", tags="speak"+self.tag)
+        canvas.create_text(self.bounding_box()[0][0], self.bounding_box()[0][1]+1, text=say, font=(self._font, 12), fill="white", tags="speak"+self.tag)
+        canvas.create_text(self.bounding_box()[0][0], self.bounding_box()[0][1], text=say, font=(self._font, 12), fill="black", tags="speak"+self.tag)
 
         canvas.delete("show_id" + self.tag)
         # we print the bot_id in the lower left corner
@@ -156,11 +157,11 @@ class BotSprite(TkSprite):
             bot_name = layout.BOT_I2N[self.bot_id ]
             shift_x = 5
             shift_y = 8
-            canvas.create_text(self.bounding_box()[0][0]-1 + shift_x, self.bounding_box()[1][1] - shift_y, text=bot_name, font=(None, 12), fill="white", tags="show_id"+self.tag)
-            canvas.create_text(self.bounding_box()[0][0]+1 + shift_x, self.bounding_box()[1][1] - shift_y, text=bot_name, font=(None, 12), fill="white", tags="show_id"+self.tag)
-            canvas.create_text(self.bounding_box()[0][0] + shift_x, self.bounding_box()[1][1]-1 - shift_y, text=bot_name, font=(None, 12), fill="white", tags="show_id"+self.tag)
-            canvas.create_text(self.bounding_box()[0][0] + shift_x, self.bounding_box()[1][1]+1 - shift_y, text=bot_name, font=(None, 12), fill="white", tags="show_id"+self.tag)
-            canvas.create_text(self.bounding_box()[0][0] + shift_x, self.bounding_box()[1][1] - shift_y, text=bot_name, font=(None, 12), fill="black", tags="show_id"+self.tag)
+            canvas.create_text(self.bounding_box()[0][0]-1 + shift_x, self.bounding_box()[1][1] - shift_y, text=bot_name, font=(self._font, 12), fill="white", tags="show_id"+self.tag)
+            canvas.create_text(self.bounding_box()[0][0]+1 + shift_x, self.bounding_box()[1][1] - shift_y, text=bot_name, font=(self._font, 12), fill="white", tags="show_id"+self.tag)
+            canvas.create_text(self.bounding_box()[0][0] + shift_x, self.bounding_box()[1][1]-1 - shift_y, text=bot_name, font=(self._font, 12), fill="white", tags="show_id"+self.tag)
+            canvas.create_text(self.bounding_box()[0][0] + shift_x, self.bounding_box()[1][1]+1 - shift_y, text=bot_name, font=(self._font, 12), fill="white", tags="show_id"+self.tag)
+            canvas.create_text(self.bounding_box()[0][0] + shift_x, self.bounding_box()[1][1] - shift_y, text=bot_name, font=(self._font, 12), fill="black", tags="show_id"+self.tag)
 
     def draw_bot(self, canvas, is_blue=True):
         direction = self.direction
@@ -331,7 +332,7 @@ class Food(TkSprite):
             tags=(self.tag, "show_food_age" + str(self.position), "food")
 
             center = self.screen()
-            canvas.create_text(*center, text=food_age, font=(None, 10), fill=text_col, tags=tag)
+            canvas.create_text(*center, text=food_age, font=(self._font, 10), fill=text_col, tags=tag)
 
 class Arrow(TkSprite):
     def __init__(self, mesh, req_pos, success, head=True, **kwargs):

--- a/pelita/ui/tk_viewer.py
+++ b/pelita/ui/tk_viewer.py
@@ -71,7 +71,9 @@ class TkViewer:
     app : The TkApplication class
 
     """
-    def __init__(self, address, controller_address=None, geometry=None, delay=1, stop_after=None, stop_after_kill=False, fullscreen=False):
+    def __init__(self, address, controller_address=None, standalone_mode=False,
+                       geometry=None, delay=1, stop_after=None, stop_after_kill=False,
+                       fullscreen=False):
         self.address = address
         self.controller_address = controller_address
         self.delay = delay
@@ -79,11 +81,15 @@ class TkViewer:
         self.fullscreen = fullscreen
         self.stop_after = stop_after
         self.stop_after_kill = stop_after_kill
+        self.standalone_mode = standalone_mode
 
         self.context = zmq.Context()
         self.socket = self.context.socket(zmq.SUB)
         self.socket.setsockopt_unicode(zmq.SUBSCRIBE, "")
-        self.socket.connect(self.address)
+        if self.standalone_mode:
+            self.socket.bind(self.address)
+        else:
+            self.socket.connect(self.address)
         self.poll = zmq.Poller()
         self.poll.register(self.socket, zmq.POLLIN)
 
@@ -150,7 +156,7 @@ class TkViewer:
             self._delay = 2
             self._after(2, self.read_queue)
         except zmq.Again as e:
-            _logger.debug('Nothing received. Waiting %.3d seconds.', self._delay)
+            _logger.debug('Nothing received. Waiting %0.3d milliseconds.', self._delay)
             self._after(self._delay, self.read_queue)
             self._delay = self._delay * 2
         except zmq.ZMQError as e:

--- a/pelita/ui/tk_viewer.py
+++ b/pelita/ui/tk_viewer.py
@@ -151,7 +151,7 @@ class TkViewer:
             # we currently don’t care about the action
             game_state = message["__data__"]
             if game_state:
-                self.app.observe(game_state)
+                self.app.observe(game_state, self.standalone_mode)
 
             self._delay = 2
             self._after(2, self.read_queue)


### PR DESCRIPTION
I hope to have a beta ready until tomorrow. The basic idea is that in one window, one starts a Tk viewer as:

    pelita-tkviewer --standalone-mode tcp://127.0.0.1:8888

which binds to port 8888 and will display any layout that is sent to it. This means that one should keep this window opened but can quickly send layout snapshots from for example an open ipython session.

In addition, I added a small overlay protocol that can (currently) colourise the background of the individual cells. Nothing fancy but we can now have a different colour for each chamber, for example.

<img width="931" alt="image" src="https://github.com/user-attachments/assets/8d1765d7-0b47-42bd-8469-6d3cd1de1369" />

The feature is currently Pelita-developer oriented. Not for users.

Closes #854 .