### PR TITLE
Add Bot.__repr__ (useful in Pytest error contexts)

### DIFF
--- a/pelita/team.py
+++ b/pelita/team.py
@@ -726,6 +726,9 @@ class Bot:
             out.write(footer)
             return out.getvalue()
 
+    def __repr__(self):
+        return f'<Bot: {self.char} ({"blue" if self.is_blue else "red"}), {self.position}, turn: {self.turn}, round: {self.round}>'
+
 
 # def __init__(self, *, bot_index, position, initial_position, walls, homezone, food, is_noisy, score, random, round, is_blue):
 def make_bots(*, walls, shape, initial_positions, homezone, team, enemy, round, bot_turn, rng, graph):

--- a/test/test_team.py
+++ b/test/test_team.py
@@ -695,3 +695,34 @@ def test_bot_html_repr():
     # check that all is good
     assert state['fatal_errors'] == [[], []]
 
+
+def test_bot_repr():
+    test_layout = """
+        ##################
+        #.#... .##.     y#
+        # # #  .  .### #x#
+        # ####.   .      #
+        #      .   .#### #
+        #a# ###.  .  # # #
+        #b     .##. ...#.#
+        ##################
+    """
+
+    parsed = parse_layout(test_layout)
+
+    def asserting_team(bot, state):
+        bot_repr = repr(bot)
+        if bot.is_blue and bot.round == 1:
+            assert bot_repr == f"<Bot: {bot.char} (blue), {bot.position}, turn: {bot.turn}, round: 1>"
+        elif not bot.is_blue and bot.round == 1:
+            assert bot_repr == f"<Bot: {bot.char} (red), {bot.position}, turn: {bot.turn}, round: 1>"
+        else:
+            assert False, "Should never be here."
+
+        return bot.position
+
+    state = run_game([asserting_team, asserting_team], max_rounds=1, layout_dict=parsed,
+                     allow_exceptions=True)
+    # assertions might have been caught in run_game
+    # check that all is good
+    assert state['fatal_errors'] == [[], []]


### PR DESCRIPTION
Now, when Pytest is run with the `-l` flag and a bot object is in scope, it will be shown as

    bot        = <Bot: a (blue), (5, 2), turn: 0, round: None>

Closes #847 
