### PR TITLE
Move initialization of bot sprites into update method

### DIFF
--- a/pelita/ui/tk_canvas.py
+++ b/pelita/ui/tk_canvas.py
@@ -200,7 +200,6 @@ class TkApplication:
 
         self.bot_sprites = {}
         self.shadow_sprites = {}
-        self.init_bot_sprites([None] * 4)
 
         self._game_state = {}
 
@@ -405,6 +404,7 @@ class TkApplication:
             return
 
         self.mesh_graph.update_mesh_shape(game_state['shape'])
+        self.init_bot_sprites(game_state["bots"])
 
         # Check and adjust sizes
         if ((self.mesh_graph.screen_width, self.mesh_graph.screen_height)


### PR DESCRIPTION
This PR fixes #865.

In 230d01b52ffb768d62ff5c7eca25407c5e318cf7, in module `pelita.ui.tk_canvas`,

- the initialization of bot sprites was moved from the `TkApplication.update` into the `TkApplication.__init__` and
- `MeshGraph` gets instanciated in `TkApplication.__init__` with mesh width and height of 0 instead of with values from the game state since there is no game state yet to pull the maze shape information from.

This results in the bot sprites having a `width` attribute of 0 as well, which never gets updated.
`pelita.ui.tk_sprites.BotSprite.is_harvester_at` gives thereby `True` for the blue team at start positions.

Moving `TkApplication.init_bot_sprites` into `TkApplication.update` resolves issue #865.

Not sure however if this breaks something else, like the standalone viewer introduced in #860?