### PR TITLE
Choose to draw a ghost or a pacmen dynamically depending on mesh size

### DIFF
--- a/pelita/ui/tk_sprites.py
+++ b/pelita/ui/tk_sprites.py
@@ -96,7 +96,6 @@ class BotSprite(TkSprite):
     def __init__(self, mesh, team=0, bot_id=0, shadow=False, **kwargs):
         self.bot_id = bot_id
         self.team = team
-        self.width = mesh.mesh_width
 
         self.shadow = shadow
 
@@ -115,9 +114,9 @@ class BotSprite(TkSprite):
 
     def is_harvester_at(self, pos):
         if self.team == 0:
-            return pos[0] >= self.width // 2
+            return pos[0] >= self.mesh.mesh_width // 2
         elif self.team == 1:
-            return pos[0] < self.width // 2
+            return pos[0] < self.mesh.mesh_width // 2
 
     def delete(self, canvas):
         canvas.delete("speak" + self.tag)


### PR DESCRIPTION
use the mesh_width dynamically for deciding if a bot must be drawn as ghost or pacmen. At init time the BotSprite could be initialized on an still empty maze.

Fixes: #865

As an alternative to #866 