### PR TITLE
Make returning an illegal position a fatal error

### DIFF
--- a/pelita/game.py
+++ b/pelita/game.py
@@ -1047,6 +1047,9 @@ def split_food(width, food):
     return team_food
 
 
+unicode_to_ascii = {
+        '➔' : '->'
+        }
 def game_print(turn, msg):
     allow_unicode = not _mswindows
     if turn % 2 == 0:
@@ -1055,4 +1058,7 @@ def game_print(turn, msg):
     elif turn % 2 == 1:
         pie = ('\033[91m' + 'ᗧ' + '\033[0m' + ' ') if allow_unicode else ''
         pie += f'red team, bot {turn // 2}'
+    if not allow_unicode:
+        for uchar, achar in unicode_to_ascii.items():
+            msg = msg.replace(uchar, achar)
     print(f'{pie}: {msg}')

--- a/test/test_game.py
+++ b/test/test_game.py
@@ -182,8 +182,7 @@ def test_play_turn_apply_error(turn):
     """check that quits when there are too many errors"""
     game_state = setup_random_basic_gamestate()
     error_dict = {
-        "reason": 'illegal move',
-        "bot_position": (1, 2)
+        "type": 'PlayerTimeout',
     }
     game_state["turn"] = turn
     team = turn % 2
@@ -192,13 +191,32 @@ def test_play_turn_apply_error(turn):
     # we pretend that two rounds have already been played
     # so that the error dictionaries are sane
     game_state["round"] = 3
+    # add a timeout to the current bot
+    game_state["errors"][team][(3, turn%2)] = error_dict
+    game_state_new = apply_move(game_state, game_state["bots"][turn])
+    assert game_state_new["gameover"]
+    assert len(game_state_new["errors"][team]) == 5
+    assert game_state_new["whowins"] == int(not team)
+    assert game_state_new["errors"][team][(3, turn%2)] == error_dict
+
+
+@pytest.mark.parametrize('turn', (0, 1, 2, 3))
+def test_illegal_position_is_fatal(turn):
+    """check that quits when illegal position"""
+    game_state = setup_random_basic_gamestate()
+    game_state["turn"] = turn
+    team = turn % 2
+    # we pretend that two rounds have already been played
+    game_state["round"] = 3
 
     illegal_position = (0, 0) # should always be a wall
     game_state_new = apply_move(game_state, illegal_position)
     assert game_state_new["gameover"]
-    assert len(game_state_new["errors"][team]) == 5
+    assert len(game_state_new["fatal_errors"][team]) == 1
     assert game_state_new["whowins"] == int(not team)
-    assert set(game_state_new["errors"][team][(3, turn)].keys()) == set(["reason", "bot_position"])
+    assert game_state_new["fatal_errors"][team][0]['type'] == 'IllegalPosition'
+    assert '(0, 0)' in game_state_new["fatal_errors"][team][0]['description']
+
 
 @pytest.mark.parametrize('turn', (0, 1, 2, 3))
 def test_play_turn_fatal(turn):
@@ -214,17 +232,6 @@ def test_play_turn_fatal(turn):
     assert game_state_new["gameover"]
     assert game_state_new["whowins"] == int(not team)
 
-@pytest.mark.parametrize('turn', (0, 1, 2, 3))
-def test_play_turn_illegal_position(turn):
-    """check that illegal moves are added to error dict and bot still takes move"""
-    game_state = setup_random_basic_gamestate()
-    game_state["turn"] = turn
-    team = turn % 2
-    illegal_position = (0, 0) # should always be a wall
-    game_state_new = apply_move(game_state, illegal_position)
-    assert len(game_state_new["errors"][team]) == 1
-    assert game_state_new["errors"][team][(1, turn)].keys() == set(["reason", "bot_position"])
-    assert game_state_new["bots"][turn] in get_legal_positions(game_state["walls"], game_state["shape"], game_state["bots"][turn])
 
 @pytest.mark.parametrize('turn', (0, 1, 2, 3))
 @pytest.mark.parametrize('which_food', (0, 1))
@@ -1017,7 +1024,7 @@ def test_minimal_game():
     assert final_state['score'] == [0, 0]
     assert final_state['round'] == 20
 
-def test_minimal_losing_game_has_one_error():
+def test_minimal_losing_game_has_one_fatal_error():
     def move0(b, s):
         if b.round == 1 and b._bot_index == 0:
             # trigger a bad move in the first round
@@ -1032,9 +1039,9 @@ def test_minimal_losing_game_has_one_error():
     final_state = run_game([move0, move1], max_rounds=20, layout_dict=l)
     assert final_state['gameover'] is True
     assert final_state['score'] == [0, 0]
-    assert len(final_state['errors'][0]) == 1
-    assert len(final_state['errors'][1]) == 0
-    assert final_state['round'] == 20
+    assert len(final_state['fatal_errors'][0]) == 1
+    assert len(final_state['fatal_errors'][1]) == 0
+    assert final_state['round'] == 1
 
 
 def test_minimal_remote_game():

--- a/test/test_game.py
+++ b/test/test_game.py
@@ -335,7 +335,7 @@ def test_multiple_enemies_killing():
     ########
     """
     # dummy bots
-    stopping = lambda bot, s: (bot.position, s)
+    stopping = lambda bot, s: bot.position
 
     parsed_l0 = layout.parse_layout(l0, bots={'y':(3,2)})
     for bot in (0, 2):
@@ -383,7 +383,7 @@ def test_suicide():
     ########
     """
     # dummy bots
-    stopping = lambda bot, s: (bot.position, s)
+    stopping = lambda bot, s: bot.position
 
     parsed_l0 = layout.parse_layout(l0)
     for bot in (1, 3):
@@ -815,7 +815,7 @@ def setup_random_basic_gamestate(*, round=1, turn=0):
     """helper function for testing play turn"""
     parsed_l = layout.parse_layout(small_layout)
 
-    stopping = lambda bot, s: (bot.position, s)
+    stopping = lambda bot, s: bot.position
 
     game_state = setup_game([stopping, stopping], layout_dict=parsed_l)
     game_state['round'] = round
@@ -837,7 +837,7 @@ def setup_specific_basic_gamestate(round=0, turn=0):
 """
     parsed_l = layout.parse_layout(l)
 
-    stopping = lambda bot, s: (bot.position, s)
+    stopping = lambda bot, s: bot.position
 
     game_state = setup_game([stopping, stopping], layout_dict=parsed_l)
     game_state['round'] = round

--- a/test/test_player_base.py
+++ b/test/test_player_base.py
@@ -154,7 +154,7 @@ class TestRandomPlayerSeeds:
             player_rngs = []
             def rng_test(bot, state):
                 player_rngs.append(bot.random)
-                return bot.position, state
+                return bot.position
             team = [
                 rng_test,
                 rng_test


### PR DESCRIPTION
This is the minimal implementation of making illegal moves a fatal error.

Given that the only other possible non-fatal error are timeouts, it may be worth it to refactor the error handling. I decided not to try this in this PR, because it would be a lot of work and I'd like this minimal implementation to go into the next release, so that we can start seeing the benefits right away. After all the error handling is not a user-facing feature.

In the process I fixed some tests that were still using the old API for the move function and were working because of the side effect of having `error_limit=5`, but these bots were returning invalid positions all along...

If and when this PR is merged I'll have a go at updating the docs in pelita_template.

Fixes: #832