### PR TITLE
BLD: v2.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Pelita changelog
 
+  * v2.5.3 (28. May 2025)
+
+    - Redesigned status area
+    - Tkinter buttons and backgrounds are not colourised anymore on macOS
+
   * v2.5.2 (5. May 2025)
 
     - On-the-fly layout generation

--- a/pelita/__init__.py
+++ b/pelita/__init__.py
@@ -2,4 +2,4 @@
 
 from . import game, layout, maze_generator, network, viewer
 
-__version__ = '2.5.2'
+__version__ = '2.5.3'


### PR DESCRIPTION
- Redesigned status area
- Tkinter buttons and backgrounds are not colourised anymore on macOS