### PR TITLE
Retry maze generation if we fail to distribute food using default values for size and food

### DIFF
--- a/pelita/exceptions.py
+++ b/pelita/exceptions.py
@@ -17,3 +17,7 @@ class PlayerDisconnected(FatalException):
 class NoFoodWarning(Warning):
     """ Warns when a layout has no food during setup. """
     pass
+
+class CannotFitFood(ValueError):
+    """Can not distribute food in the maze"""
+    pass

--- a/pelita/maze_generator.py
+++ b/pelita/maze_generator.py
@@ -38,7 +38,7 @@ import networkx as nx
 
 from .base_utils import default_rng
 from .team import walls_to_graph
-
+from .exceptions import CannotFitFood
 
 def mirror(nodes, width, height):
     nodes = set(nodes)
@@ -93,7 +93,7 @@ def distribute_food(all_tiles, chamber_tiles, trapped_food, total_food, rng=None
         )
 
     if total_food > len(all_tiles):
-        raise ValueError(
+        raise CannotFitFood(
             f"number of total food ({total_food}) exceeds available tiles in maze ({len(all_tiles)})"
         )
 

--- a/test/test_maze_generation.py
+++ b/test/test_maze_generation.py
@@ -5,6 +5,7 @@ import pytest
 import pelita.layout as pl
 import pelita.maze_generator as mg
 import pelita.team as pt
+import pelita.game as pg
 
 SEED = 103525239
 
@@ -295,3 +296,13 @@ def test_reproducer_for_issue_893():
     trapped_food = 0
     ld = mg.generate_maze(trapped_food, total_food, width, height, rng = SEED)
     assert len(ld['walls']) >= (2*width + 2*(height-2))
+
+@pytest.mark.parametrize('iteration', range(100))
+def test_default_food_is_fitting(iteration):
+    local_seed = SEED + iteration
+    rng = Random(local_seed)
+
+    for width, height in pg.MSIZE.values():
+        trapped_food, total_food = pg.NFOOD[(width, height)]
+        mg.generate_maze(trapped_food, total_food, width, height, rng=rng)
+


### PR DESCRIPTION
Fixes: #895 