### PR TITLE
NF: Allow for multiline speech when {} is present in speaker

### DIFF
--- a/pelita/tournament/__init__.py
+++ b/pelita/tournament/__init__.py
@@ -335,10 +335,16 @@ class Config:
 
             tmp.write(string+'\n')
             tmp.flush()
-            cmd = shlex.split(self.speaker)
-            full_cmd = [*cmd, tmp.name]
+
+            if '{}' in self.speaker:
+                full_cmd = self.speaker.replace('{}', tmp.name)
+                shell = True
+            else:
+                cmd = shlex.split(self.speaker)
+                full_cmd = [*cmd, tmp.name]
+                shell = False
             try:
-                _speaker_proc = subprocess.run(full_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=True)
+                _speaker_proc = subprocess.run(full_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=True, shell=shell)
             except FileNotFoundError:
                 # If we could not find the executable then there is not need to keep on trying.
                 # Disabling speak. (Although self.say() will still attempt to speak.)


### PR DESCRIPTION
Use case: On macOS `flite` cannot output to the speaker, but `afplay` can. Having shell mode allows us to run two commands after another.

    speaker: ./flite/bin/flite -f {} out.wav ; afplay out.wav

Not really sure I like it. Maybe I should just add a shell script wrapper to flite that does the same thing?