### PR TITLE
WIP: Experiments with scalable canvas

### DIFF
--- a/pelita/ui/tk_viewer.py
+++ b/pelita/ui/tk_viewer.py
@@ -98,6 +98,11 @@ class TkViewer:
     def run(self):
         try:
             self.root = tkinter.Tk()
+            # self.root.tk.call('tk', 'scaling', 4.0)
+            font = tkinter.font.Font(size=10)
+            text_width = font.measure("m")
+            scale = text_width / 13
+            print(text_width)
         except tkinter.TclError as e:
             _logger.error('TclError: %s. Exiting.', e)
             if self.controller_address:
@@ -112,7 +117,7 @@ class TkViewer:
         if self.fullscreen:
             self.root.attributes('-fullscreen',True)
         else:
-            root_geometry = str(self.geometry[0])+'x'+str(self.geometry[1])
+            root_geometry = f"{(self.geometry[0] * scale):.0f}x{(self.geometry[1] * scale):.0f}"
             # put the root window in some sensible position
             self.root.geometry(root_geometry+'+40+40')
 


### PR DESCRIPTION
Workable solution for #820. Still needs adjustments. Unclear, if the tk internal scaling for widgets(?) `self.root.tk.call('tk', 'scaling', xxx)` will be needed.

How does it work: We can use Tk to measure the pixel width of a text with a given font size. The result will be in raw pixels (on Linux). On macOS the number is resolution independent (which is good: on macOS it already works as it should). I could not test with Windows yet.

This number will then scale the geometry of the Window and then our own scaling mechanics will resize the canvas to make everything fit.

Screen is set to scale to 225%. Without the fix:

<img width="3840" height="2160" alt="Screenshot From 2025-08-15 17-22-04" src="https://github.com/user-attachments/assets/7d9cfa28-9ffe-4eb2-b51a-1492f6a90558" />

With the fix:

<img width="3840" height="2160" alt="Screenshot From 2025-08-15 17-21-45" src="https://github.com/user-attachments/assets/868c39ae-31a3-4621-960a-42b21f7972e1" />

Note that the font and hard-coded numbers for the positioning of the header are currently not scaled, which is why they do look off. Work also needs to be done for the debug mode whose 1px grid lines look very tiny on higher scaling factors.