### PR TITLE
Add game_uuid to game state

### DIFF
--- a/pelita/game.py
+++ b/pelita/game.py
@@ -6,6 +6,7 @@ import os
 import subprocess
 import sys
 import time
+import uuid
 from warnings import warn
 
 import zmq
@@ -343,6 +344,9 @@ def setup_game(team_specs, *, layout_dict, max_rounds=300, rng=None,
     # Initialize the game state.
 
     game_state = dict(
+        #: UUID
+        game_uuid=str(uuid.uuid4()),
+
         ### The layout attributes
         #: Walls. Set of (int, int)
         walls=set(layout_dict['walls']),


### PR DESCRIPTION
Adding a unique identifier to each game. This is not passed to the bots (yet?) but viewers can use it as a game reference number.