### PR TITLE
Do not raise in main()

### DIFF
--- a/pelita/scripts/pelita_main.py
+++ b/pelita/scripts/pelita_main.py
@@ -14,8 +14,6 @@ from rich.prompt import Prompt
 
 import pelita
 from pelita.network import PELITA_PORT
-# TODO: The check_team option
-from pelita.tournament import check_team
 
 from .script_utils import start_logging
 
@@ -325,7 +323,7 @@ def main():
         start_logging(args.log)
 
     if args.rounds < 1:
-        raise ValueError(f"Must play at least one round (rounds={args.rounds}).")
+        parser.error(f"Must play at least one round (rounds={args.rounds}).")
 
     if args.viewer == 'null':
         viewers = []
@@ -386,9 +384,9 @@ def main():
     if len(team_specs) == 0:
         team_specs = ('0', '1')
     if len(team_specs) == 1:
-        raise RuntimeError("Not enough teams given. Must be {}".format(num_teams))
+        parser.error("Not enough teams given. Must be {}".format(num_teams))
     if len(team_specs) > num_teams:
-        raise RuntimeError("Too many teams given. Must be < {}.".format(num_teams))
+        parser.error("Too many teams given. Must be < {}.".format(num_teams))
 
     for idx, team_spec in enumerate(team_specs):
         if team_spec == "SCAN":
@@ -423,7 +421,7 @@ def main():
             layout_string = layout_path.read_text()
             layout_dict = pelita.layout.parse_layout(layout_string)
         else:
-            raise FileNotFoundError(f'Layout file "{layout_path}" does not exist.')
+            parser.error(f'Layout file "{layout_path}" does not exist.')
     else:
         width, height = args.size
 
@@ -432,7 +430,7 @@ def main():
         elif (width, height) in pelita.game.NFOOD:
             trapped_food, total_food = pelita.game.NFOOD[(width, height)]
         else:
-            raise ValueError('--food option must be specified if a custom maze size is set')
+            parser.error('--food option must be specified if a custom maze size is set')
 
         layout_dict = pelita.maze_generator.generate_maze(trapped_food=trapped_food,
                                                           total_food=total_food,

--- a/pelita/scripts/pelita_main.py
+++ b/pelita/scripts/pelita_main.py
@@ -215,8 +215,6 @@ parser.add_argument('--replay', help=long_help('Replay a dumped game'),
                     metavar='REPLAYFILE', dest='replayfile', const='pelita.dump', nargs='?')
 parser.add_argument('--store-output', help=long_help('Write all player’s stdout/stderr to the given folder (must exist)'),
                     metavar='FOLDER')
-parser.add_argument('--check-team', action="store_true",
-                    help=long_help('Check that the team is valid (on first sight) and print its name.'))
 parser.add_argument('--append-blue', type=str, metavar='INFO', default=None,
                     help=long_help('Append info about the blue team (such as group id).'))
 parser.add_argument('--append-red', type=str, metavar='INFO', default=None,
@@ -328,21 +326,6 @@ def main():
 
     if args.rounds < 1:
         raise ValueError(f"Must play at least one round (rounds={args.rounds}).")
-
-    if args.check_team:
-        if not args.team_specs:
-            raise ValueError("No teams specified.")
-        for team_spec in args.team_specs:
-            try:
-                team_name = check_team(team_spec, timeout=args.initial_timeout_length)
-                print("NAME:", team_name)
-            except pelita.network.RemotePlayerFailure as e:
-                if e.error_type == 'ModuleNotFoundError':
-                    #print(f"{e.message}")
-                    pass
-                else:
-                    raise
-        sys.exit(0)
 
     if args.viewer == 'null':
         viewers = []


### PR DESCRIPTION
There is not really a use in catching these errors or see the stack trace so we should default to `parser.error`.