### PR TITLE
Hexagonal ⬡ Pelita

### DIFF
--- a/pelita/layout.py
+++ b/pelita/layout.py
@@ -319,12 +319,19 @@ def get_legal_positions(walls, shape, bot_position):
         raise ValueError(f"Position {bot_position} not inside maze ({width}x{height}).")
     if bot_position in walls:
         raise ValueError(f"Position {bot_position} is on a wall.")
+
     north = (0, -1)
     south = (0, 1)
     east = (1, 0)
     west = (-1, 0)
     stop = (0, 0)
-    directions = [north, east, west, south, stop]
+    if bot_position[0] % 2 == 0:
+        # even col
+        directions = [north, east, west, south, stop, (-1, -1), (+1, -1)]
+    else:
+        # odd col
+        directions = [north, east, west, south, stop, (+1, +1), (-1, +1)]
+
     potential_moves = [(i[0] + bot_position[0], i[1] + bot_position[1]) for i in directions]
     possible_moves = [i for i in potential_moves if i not in walls]
     return possible_moves

--- a/pelita/maze_generator.py
+++ b/pelita/maze_generator.py
@@ -332,7 +332,39 @@ def generate_maze(trapped_food=10, total_food=30, width=32, height=16, rng=None)
     # generation, or our algorithm to find chambers would get confused
     # Note: this only works because in the right side of the maze we have no walls
     # except for the surrounding ones.
-    graph = walls_to_graph(walls, shape=(width//2+1, height))
+    graph: nx.Graph = walls_to_graph(walls, shape=(width//2+1, height))
+
+    for _ in range(3):
+        # Fill nodes with 5 or 6 spaces around them with a certain chance
+        inner_nodes = []
+        for node in graph:
+            if len(graph.edges(node)) >= 6:
+                inner_nodes.append(node)
+
+        for node in inner_nodes:
+            if node[0] >= width // 2:
+                continue
+            if len(graph.edges(node)) < 6:
+                continue
+            if rng.random() < 0.8:
+                continue
+            graph.remove_node(node)
+            walls.add(node)
+
+
+    # Fill nodes with all-space around them with a 0.5 chance
+    inner_nodes = []
+    for node in graph:
+        if len(graph.edges(node)) == 7:
+            inner_nodes.append(node)
+
+    for node in inner_nodes:
+        if node[0] >= width // 2:
+            continue
+        if rng.random() < 0.5:
+            continue
+        graph.remove_node(node)
+        walls.add(node)
 
     # the algorithm should actually guarantee this, but just to make sure, let's
     # fail if the graph is not fully connected

--- a/pelita/scripts/pelita_main.py
+++ b/pelita/scripts/pelita_main.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from pelita.team import walls_to_graph
 
 import argparse
 import json
@@ -8,6 +9,7 @@ import sys
 from pathlib import Path
 from urllib.parse import urlparse
 
+import networkx as nx
 import zmq
 from rich.console import Console
 from rich.prompt import Prompt
@@ -451,10 +453,22 @@ def main():
         else:
             raise ValueError('--food option must be specified if a custom maze size is set')
 
-        layout_dict = pelita.maze_generator.generate_maze(trapped_food=trapped_food,
+        for i in range(10):
+            try:
+                layout_dict = pelita.maze_generator.generate_maze(trapped_food=trapped_food,
                                                           total_food=total_food,
                                                           width=width,
                                                           height=height, rng=rng)
+                graph = walls_to_graph(layout_dict['walls'], layout_dict['shape'])
+                if not nx.is_connected(graph):
+                    raise ValueError("Generated maze is not fully connected, try a different random seed")
+                break
+
+            except ValueError:
+                print("Error in maze generation. Trying again.")
+
+        else:
+            raise ValueError("Generated maze is not fully connected after 10 tries.")
 
     if args.layoutfile:
         # We only want to print this, when no seed has been given.

--- a/pelita/team.py
+++ b/pelita/team.py
@@ -16,7 +16,7 @@ import zmq
 
 from . import layout
 from .base_utils import default_zmq_context
-from .layout import BOT_I2N, layout_as_str, wall_dimensions
+from .layout import BOT_I2N, layout_as_str, wall_dimensions, get_legal_positions
 from .network import PELITA_PORT, RemotePlayerConnection, RemotePlayerRecvTimeout, RemotePlayerSendError
 
 _logger = logging.getLogger(__name__)
@@ -80,11 +80,9 @@ def walls_to_graph(walls, shape=None):
                 # this is a free position, get its neighbors
                 # Only positive neighbours are needed as we are iterating
                 # all fields
-                for delta_x, delta_y in [(1, 0), (0, 1)]:
-                    neighbor = (x + delta_x, y + delta_y)
-                    # we don't need to check for getting neighbors out of the maze
-                    # because our mazes are all surrounded by walls, i.e. our
-                    # deltas will not put us out of the maze
+                for neighbor in get_legal_positions(walls, (width, height), (x, y)):
+                    if neighbor == (0, 0):
+                        continue
                     if neighbor not in walls:
                         # this is a genuine neighbor, add an edge in the graph
                         graph.add_edge((x, y), neighbor)
@@ -716,7 +714,12 @@ class Bot:
         # including the current position.
         self.legal_positions = []
 
-        for direction in [(0, 0), (-1, 0), (1, 0), (0, 1), (0, -1)]:
+        if position[0] % 2 == 0:
+            directions = [(0, 0), (-1, 0), (1, 0), (0, 1), (0, -1), (-1, -1), (+1, -1)]
+        else:
+            directions = [(0, 0), (-1, 0), (1, 0), (0, 1), (0, -1), (+1, +1), (-1, +1)]
+
+        for direction in directions:
             new_pos = (position[0] + direction[0],
                        position[1] + direction[1])
             if new_pos not in self.walls:

--- a/pelita/ui/tk_canvas.py
+++ b/pelita/ui/tk_canvas.py
@@ -33,7 +33,7 @@ from .tk_sprites import (
     Arrow,
     BotSprite,
     Food,
-    Wall
+    Wall, Empty
 )
 
 _logger = logging.getLogger(__name__)
@@ -205,7 +205,7 @@ class MeshGraph:
         coords_x, coords_y = coords
 
         real_x = self.mesh_to_screen_x(mesh_x, coords_x)
-        real_y = self.mesh_to_screen_y(mesh_y, coords_y)
+        real_y = self.mesh_to_screen_y(mesh_y, coords_y, col=mesh_x)
         return (real_x, real_y)
 
     def mesh_to_screen_x(self, mesh_x, model_x):
@@ -215,11 +215,12 @@ class MeshGraph:
         real_x = self.rect_width * (mesh_x + trafo_x) + self.padding + self.extra_x
         return real_x
 
-    def mesh_to_screen_y(self, mesh_y, model_y):
+    def mesh_to_screen_y(self, mesh_y, model_y, *, col):
         # coords are between -1 and +1: shift on [0, 1]
         trafo_y = (model_y + 1.0) / 2.0
+        down = 0 if col % 2 == 0 else 0.5
 
-        real_y = self.rect_height * (mesh_y + trafo_y) + self.padding + self.extra_y + self.top_margin
+        real_y = self.rect_height * (mesh_y + trafo_y + down) + self.padding + self.extra_y + self.top_margin
         return real_y
 
     def screen_to_mesh_coord(self, screen_x, screen_y):
@@ -514,18 +515,17 @@ class TkApplication:
         # we don’t use scaling for the grid width currently
         grid_width = 0.01
 
-        def draw_line(x0, y0, x1, y1):
+        def draw_hex(x0, y0, x1, y1):
             x0_ = self.mesh_graph.mesh_to_screen_x(x0, 0)
             y0_ = self.mesh_graph.mesh_to_screen_y(y0, 0)
             x1_ = self.mesh_graph.mesh_to_screen_x(x1, 0)
             y1_ = self.mesh_graph.mesh_to_screen_y(y1, 0)
             self.ui_game_canvas.create_line(x0_, y0_, x1_, y1_, width=grid_width, fill="#884488", tags="grid")
 
-        for x in range(self.mesh_graph.mesh_width + 1):
-            draw_line(x - 0.5, -0.5, x - 0.5, self.mesh_graph.mesh_height - 0.5)
 
-        for y in range(self.mesh_graph.mesh_height + 1):
-            draw_line(-0.5, y - 0.5, self.mesh_graph.mesh_width - 0.5, y - 0.5)
+        for x in range(self.mesh_graph.mesh_width):
+            for y in range(self.mesh_graph.mesh_height):
+                draw_hex(x, y)
 
         label_size = 7
         label_style = {
@@ -536,33 +536,34 @@ class TkApplication:
             "anchor": tkinter.CENTER
         }
 
-        for x in range(self.mesh_graph.mesh_width):
-            label = f"{x}"
 
-            x_pos = self.mesh_graph.mesh_to_screen_x(x, 0)
-            # the margin is not autoscaling, so we do the shift on the real grid
-            y_pos = self.mesh_graph.mesh_to_screen_y(0, -1) - label_size
-            self.ui_game_canvas.create_text(x_pos, y_pos, text=label, **label_style)
-            y_pos = self.mesh_graph.mesh_to_screen_y(self.mesh_graph.mesh_height, -1) + label_size
-            self.ui_game_canvas.create_text(x_pos, y_pos, text=label, **label_style)
+        # for x in range(self.mesh_graph.mesh_width):
+        #     label = f"{x}"
 
-        for y in range(self.mesh_graph.mesh_height):
-            label = f"{y}"
+        #     x_pos = self.mesh_graph.mesh_to_screen_x(x, 0)
+        #     # the margin is not autoscaling, so we do the shift on the real grid
+        #     y_pos = self.mesh_graph.mesh_to_screen_y(0, -1, col=x) - label_size
+        #     self.ui_game_canvas.create_text(x_pos, y_pos, text=label, **label_style)
+        #     y_pos = self.mesh_graph.mesh_to_screen_y(self.mesh_graph.mesh_height, -1, col=x) + label_size
+        #     self.ui_game_canvas.create_text(x_pos, y_pos, text=label, **label_style)
 
-            # the margin is not autoscaling, so we do the shift on the real grid
-            x_pos = self.mesh_graph.mesh_to_screen_x(0, -1) - label_size
-            y_pos = self.mesh_graph.mesh_to_screen_y(y, 0)
-            self.ui_game_canvas.create_text(x_pos, y_pos, text=label, **label_style)
-            x_pos = self.mesh_graph.mesh_to_screen_x(self.mesh_graph.mesh_width, -1) + label_size
-            self.ui_game_canvas.create_text(x_pos, y_pos, text=label, **label_style)
+        # for y in range(self.mesh_graph.mesh_height):
+        #     label = f"{y}"
 
-        x_pos = self.mesh_graph.mesh_to_screen_x(0, -0.7)
-        y_pos = self.mesh_graph.mesh_to_screen_y(0, -1) - label_size
-        self.ui_game_canvas.create_text(x_pos, y_pos, text="x", **label_style)
+        #     # the margin is not autoscaling, so we do the shift on the real grid
+        #     x_pos = self.mesh_graph.mesh_to_screen_x(0, -1) - label_size
+        #     y_pos = self.mesh_graph.mesh_to_screen_y(y, 0)
+        #     self.ui_game_canvas.create_text(x_pos, y_pos, text=label, **label_style)
+        #     x_pos = self.mesh_graph.mesh_to_screen_x(self.mesh_graph.mesh_width, -1) + label_size
+        #     self.ui_game_canvas.create_text(x_pos, y_pos, text=label, **label_style)
 
-        x_pos = self.mesh_graph.mesh_to_screen_x(0, -1) - label_size
-        y_pos = self.mesh_graph.mesh_to_screen_y(0, -0.7)
-        self.ui_game_canvas.create_text(x_pos, y_pos, text="y", **label_style)
+        # x_pos = self.mesh_graph.mesh_to_screen_x(0, -0.7)
+        # y_pos = self.mesh_graph.mesh_to_screen_y(0, -1) - label_size
+        # self.ui_game_canvas.create_text(x_pos, y_pos, text="x", **label_style)
+
+        # x_pos = self.mesh_graph.mesh_to_screen_x(0, -1) - label_size
+        # y_pos = self.mesh_graph.mesh_to_screen_y(0, -0.7)
+        # self.ui_game_canvas.create_text(x_pos, y_pos, text="y", **label_style)
 
     def draw_overlays(self, overlays):
         """ Draws overlays on top of cells at given coordinates.
@@ -825,10 +826,10 @@ class TkApplication:
 
         scale = self.mesh_graph.half_scale_x * 0.2
 
-        for color, x_orig in zip(cols, (center - 3, center + 3, center)):
-            y_top = self.mesh_graph.mesh_to_screen_y(0, 0)
-            y_bottom = self.mesh_graph.mesh_to_screen_y(self.mesh_graph.mesh_height - 1, 0)
-            self.ui_game_canvas.create_line(x_orig, y_top, x_orig, y_bottom, width=scale, fill=color, tags="background")
+        # for color, x_orig in zip(cols, (center - 3, center + 3, center)):
+        #     y_top = self.mesh_graph.mesh_to_screen_y(0, 0)
+        #     y_bottom = self.mesh_graph.mesh_to_screen_y(self.mesh_graph.mesh_height - 1, 0)
+        #     self.ui_game_canvas.create_line(x_orig, y_top, x_orig, y_bottom, width=scale, fill=color, tags="background")
 
     def draw_title(self, game_state):
         self.ui_game_canvas.delete("title")
@@ -1024,16 +1025,14 @@ class TkApplication:
         # them otherwise
         self.wall_items = []
         num = 0
-        for wall in game_state['walls']:
-            model_x, model_y = wall
-            wall_neighbors = [(dx, dy)
-                              for dx in [-1, 0, 1]
-                              for dy in [-1, 0, 1]
-                              if (model_x + dx, model_y + dy) in game_state['walls']]
-            wall_item = Wall(self.mesh_graph, wall_neighbors=wall_neighbors, position=(model_x, model_y))
-            wall_item.draw(self.ui_game_canvas)
-            self.wall_items.append(wall_item)
-            num += 1
+        for x in range(self.mesh_graph.mesh_width):
+            for y in range(self.mesh_graph.mesh_height):
+                if (x, y) in game_state['walls']:
+                    item = Wall(self.mesh_graph, wall_neighbors=[], position=(x, y))
+                else:
+                    item = Empty(self.mesh_graph, wall_neighbors=[], position=(x, y))
+                item.draw(self.ui_game_canvas)
+                self.wall_items.append(item)
 
     def init_bot_sprites(self, bot_positions):
         for sprite in self.bot_sprites.values():

--- a/pelita/ui/tk_sprites.py
+++ b/pelita/ui/tk_sprites.py
@@ -9,14 +9,18 @@ BLUE = '#5E9ED9'
 
 LIGHT_BLUE = '#B9D9F6'
 STRONG_BLUE = '#1E6BB1'
+LIGHTER_BLUE = '#e3f0fb'
 LIGHT_RED = '#FFB0B0'
 STRONG_RED = '#A91919'
+LIGHTER_RED = '#ffdfdf'
+
 
 YELLOW = '#FFE38B'
 GREY = '#505050'
 LIGHT_GREY = '#CDC7C2'
 SELECTED = '#C8C8C8'
 BROWN = '#301A16'
+ROSA = '#ffdddd'
 
 SHADOW_RED = '#B37373'
 SHADOW_BLUE = '#6D92B3'
@@ -27,9 +31,16 @@ def rotate(arc, rotation):
     """Helper for rotation normalisation."""
     return (arc + rotation) % 360
 
+def hex_to_pos(hex_pos):
+    down = 0 if hex_pos[0] % 2 == 0 else 0.5
+    return (hex_pos[0], hex_pos[1] + down)
+
 def pos_to_complex(pos):
     x, y = pos
     return x - y * 1j
+
+def hex_pos_to_complex(hex_pos):
+    return pos_to_complex(hex_to_pos(hex_pos))
 
 class TkSprite:
     def __init__(self, mesh, *, position=None, _tag=None, font=None):
@@ -62,7 +73,9 @@ class TkSprite:
 
         # automatic rotation
         if new_pos != old_pos:
-            self._direction = math.degrees(cmath.phase(pos_to_complex(new_pos) - pos_to_complex(old_pos)))
+
+            self._direction = math.degrees(cmath.phase(hex_pos_to_complex(new_pos) - hex_pos_to_complex(old_pos)))
+            # print(new_pos, '->', hex_to_pos(new_pos), old_pos, '->', hex_to_pos(old_pos), self._direction)
 
     def screen(self, shift=(0, 0)):
         x, y = self.position
@@ -119,6 +132,7 @@ class BotSprite(TkSprite):
         super().delete(canvas)
 
     def move_to(self, new_pos, canvas, game_state, force=None, say="", show_id=False):
+        force = True
         old_direction = self.direction
         old_position = self.position
 
@@ -165,27 +179,32 @@ class BotSprite(TkSprite):
             direction = 0 if is_blue else 180
 
         # ensure that our eyes are never on the bottom
-        if direction == 0:
+        if -50 <= direction <= 50:
             flip = True
         else:
             flip = False
 
         # bot body
-        canvas.create_arc(self.bounding_box(), start=rotate(20, direction), extent=320, style="pieslice",
+        canvas.create_arc(self.bounding_box(scale_factor=0.7), start=rotate(20, direction), extent=320, style="pieslice",
                           width=0, outline=self.outline_col, fill=self.col, tags=self.tag)
 
         # bot eye
         # first locate eye in the center
-        eye_size = 0.15
-        eye_box = (-eye_size - eye_size * 1j, eye_size + eye_size * 1j)
-        # shift it to the middle of the bot just over the mouth
-        eye_box = [item + 0.4 + 0.6j for item in eye_box]
-        # take also care of flipping
+        eye_size = 0.12
+        eye_location = 0.3 + 0.45j
+        # rotate
+        eye_location = cmath.exp(1j * math.radians(-direction)) * eye_location
+
         if flip:
-            eye_box = [item.conjugate() for item in eye_box]
+            # print(flip)
+            eye_location = eye_location * cmath.exp(1j * math.radians(-120))
         # rotate based on direction
-        eye_box = [cmath.exp(1j * math.radians(-direction)) * item for item in eye_box]
-        eye_box = [self.screen((item.real, item.imag)) for item in eye_box]
+        eye_x, eye_y = eye_location.real, eye_location.imag
+
+        eye_box = [self.screen((eye_x + shift[0], eye_y + shift[1])) for shift in
+            [[-eye_size, -eye_size], [eye_size, eye_size]]
+        ]
+
         canvas.create_oval(eye_box, fill=self.eye_col, width=0, tags=self.tag)
 
     def draw(self, canvas, game_state):
@@ -203,7 +222,7 @@ class BotSprite(TkSprite):
                 self.draw_destroyer(canvas)
 
     def draw_destroyer(self, canvas):
-        box_ll, box_tr = self.bounding_box()
+        box_ll, box_tr = self.bounding_box(scale_factor=0.7)
 
         # ghost head
         canvas.create_arc((box_ll, box_tr), start=0, extent=180, style="pieslice" if not self.shadow else "arc",
@@ -237,16 +256,48 @@ class BotSprite(TkSprite):
             canvas.create_polygon(points, width=1, outline=self.outline_col, fill=self.col, tags=self.tag)
 
         # ghost eyes
-        eye_size = 0.15
+        eye_size = 0.12
         eye_box = (-eye_size -eye_size*1j, eye_size + eye_size*1j)
         # right eye
-        eye_box_r = [item+ 0.4 - 0.5j for item in eye_box]
+        eye_box_r = [item+ 0.25 - 0.4j for item in eye_box]
         eye_box_r = [self.screen((item.real, item.imag)) for item in eye_box_r]
         canvas.create_oval(eye_box_r, fill=self.eye_col, width=0, tags=self.tag)
         # left eye
-        eye_box_l = [item- 0.4 - 0.5j for item in eye_box]
+        eye_box_l = [item- 0.25 - 0.4j for item in eye_box]
         eye_box_l = [self.screen((item.real, item.imag)) for item in eye_box_l]
         canvas.create_oval(eye_box_l, fill=self.eye_col, width=0, tags=self.tag)
+
+
+class Empty(TkSprite):
+    def __init__(self, mesh, wall_neighbors=None, **kwargs):
+        if wall_neighbors is None:
+            self.wall_neighbors = []
+        else:
+            self.wall_neighbors = wall_neighbors
+
+        super(Empty, self).__init__(mesh, **kwargs)
+
+    def draw(self, canvas, game_state=None):
+        scale = (self.mesh.half_scale_x + self.mesh.half_scale_y) * 0.6
+
+        h = math.sqrt(3) / 2
+        coords = [
+            [- 1 / 2, - h],
+            [+ 1 / 2, - h],
+            [+ 1, 0],
+            [+ 1 / 2, + h],
+            [- 1 / 2, + h],
+            [- 1, 0],
+            [- 1 / 2, - h],
+        ]
+        screen_coords = [
+            self.screen((x, y)) for x, y in coords
+        ]
+
+        col = LIGHTER_BLUE if self._position[0] < self.mesh.mesh_width // 2 else LIGHTER_RED
+
+        canvas.create_polygon(*screen_coords, fill=col, outline='',
+                               width=0, tags=(self.tag, "wall"))
 
 class Wall(TkSprite):
     def __init__(self, mesh, wall_neighbors=None, **kwargs):
@@ -260,6 +311,23 @@ class Wall(TkSprite):
 
     def draw(self, canvas, game_state=None):
         scale = (self.mesh.half_scale_x + self.mesh.half_scale_y) * 0.6
+
+        h = math.sqrt(3) / 2
+        coords = [
+            [- 1 / 2, - h],
+            [+ 1 / 2, - h],
+            [+ 1, 0],
+            [+ 1 / 2, + h],
+            [- 1 / 2, + h],
+            [- 1, 0],
+            [- 1 / 2, - h],
+        ]
+        screen_coords = [
+            self.screen((x, y)) for x, y in coords
+        ]
+        canvas.create_polygon(*screen_coords, fill=BROWN,
+                               width=0, tags=(self.tag, "wall"))
+        return
         if not ((0, 1) in self.wall_neighbors or
                 (1, 0) in self.wall_neighbors or
                 (0, -1) in self.wall_neighbors or


### PR DESCRIPTION
⭐⭐⭐ **30% faster diagonals with this one simple trick.** ⭐⭐⭐

Features:
- Make the bots more mobile by adding two additional directions to each cell
- Bots relying on `bot.legal_positions` or `bot.graph` still kind of work
- Mazes are generated as usual; but in an additional step we sprinkle in some more walls to account for the change in connectivity. Ideally, the algorithm would be changed to also generate diagonal lines

To do:
- Make the grid itself non-rectangular
- Play with more than two teams, starting from different corners
- Replace food resources with specific types (wood, brick, wheat, sheep and ore) and make them tradable

https://github.com/user-attachments/assets/123fed34-c8a9-463c-a4f2-9a2bbf42f06f

