### PR TITLE
RF: Make small layouts bigger and big layouts smaller.

### DIFF
--- a/pelita/game.py
+++ b/pelita/game.py
@@ -54,16 +54,20 @@ INITIAL_TIMEOUT_SECS = 6
 
 #: Default maze sizes
 MSIZE = {
-         'small' : (16, 8),
+         'tiny': (16, 8),
+         'small': (24, 12),
          'normal': (32, 16),
-         'big'   : (64, 32),
+         'big': (48, 24),
+         'huge': (64, 32),
         }
 
 #: Food pellets (trapped_food, total_food) on left side of the maze for
 #  default maze sizes
 NFOOD = {
-         (16, 8) : (3, 10),
+         (16, 8): (3, 10),
+         (24, 12): (5, 15),
          (32, 16): (10, 30),
+         (48, 24): (15, 50),
          (64, 32): (20, 60),
         }
 

--- a/pelita/scripts/pelita_main.py
+++ b/pelita/scripts/pelita_main.py
@@ -172,8 +172,11 @@ def w_h_string(s):
     if s in pelita.game.MSIZE:
         return pelita.game.MSIZE[s]
     try:
-        x_string, y_string = s.split('x')
-        w_h = (int(x_string), int(y_string))
+        if 'x' in s:
+            x_string, y_string = s.split('x')
+            w_h = (int(x_string), int(y_string))
+        else:
+            w_h = (int(s) * 2, int(s))
     except ValueError:
         msg = "%s is not a valid specification" %s
         raise argparse.ArgumentTypeError(msg) from None
@@ -240,7 +243,7 @@ layout_opt = game_settings.add_mutually_exclusive_group()
 layout_opt.add_argument('--layout', metavar='FILENAME', help='Use layout from FILENAME')
 layout_opt.add_argument('--size', type=w_h_string, metavar="STRING", default='normal',
                         help="Pick a random maze layout of specified size."
-                        " Possible sizes: 'small' (16x8), 'normal' (32x16), 'big' (64x32), 'WxH' where W and H are integers. Default: 'normal'")
+                        " Possible sizes: 'small' (24x12), 'normal' (32x16), 'big' (48x24), 'WxH' where W and H are integers. Default: 'normal'")
 
 timeout_opt = game_settings.add_mutually_exclusive_group()
 timeout_opt.add_argument('--timeout', type=float, metavar="SEC",

--- a/test/test_layout.py
+++ b/test/test_layout.py
@@ -1,8 +1,10 @@
+import argparse
 import itertools
 from textwrap import dedent
 
 import pytest
 
+from pelita.scripts.pelita_main import w_h_string
 from pelita.layout import (BOT_N2I, get_legal_positions, layout_as_str,
                            parse_layout, wall_dimensions)
 
@@ -437,3 +439,20 @@ def test_parse_layout_game_bad_number_of_bots(bots_hidden):
     else:
         with pytest.raises(ValueError):
             parse_layout(test_layout)
+
+
+@pytest.mark.parametrize('spec, check', [
+    ("0x0", (0, 0)),
+    ("1", (2, 1)),
+    ("32x16", (32, 16)),
+    ("16", (32, 16)),
+    ("normal", (32, 16)),
+    ("abc", None),
+    ("abxc", None)
+])
+def test_layout_spec(spec, check):
+    if check is None:
+        with pytest.raises(argparse.ArgumentTypeError):
+            assert w_h_string(spec)
+    else:
+        assert w_h_string(spec) == check

--- a/test/test_libpelita.py
+++ b/test/test_libpelita.py
@@ -23,7 +23,7 @@ def test_firstNN():
 def test_call_pelita():
     rounds = 200
     viewer = 'ascii'
-    size = 'small'
+    size = 'tiny'
 
     teams = ["pelita/player/StoppingPlayer", "pelita/player/StoppingPlayer"]
     (state, stdout, stderr) = call_pelita(teams, rounds=rounds, viewer='null', size=size, seed=None)
@@ -56,7 +56,7 @@ def test_call_pelita():
 def test_bad_seeds(seed, success):
     rounds = 2
     viewer = 'null'
-    size = 'small'
+    size = 'tiny'
 
     teams = ["pelita/player/StoppingPlayer", "pelita/player/StoppingPlayer"]
     if success:
@@ -90,7 +90,7 @@ def test_write_replay_is_idempotent():
 
             cmd = [sys.executable, '-m', 'pelita.scripts.pelita_main',
                     '--write-replay', f.name,
-                    '--size', 'small',
+                    '--size', 'tiny',
                     '--null']
 
             subprocess.run(cmd, check=True)
@@ -123,7 +123,7 @@ def test_store_layout():
 
         cmd = [sys.executable, '-m', 'pelita.scripts.pelita_main',
                 '--store-layout', f.name,
-                '--size', 'small',
+                '--size', 'tiny',
                 '--seed', '12345',
                 '--null']
 
@@ -141,7 +141,7 @@ def test_store_layout():
     with tempfile.NamedTemporaryFile() as g:
         cmd = [sys.executable, '-m', 'pelita.scripts.pelita_main',
                 '--store-layout', g.name,
-                '--size', 'small',
+                '--size', 'tiny',
                 '--seed', '12345',
                 '--null']
 
@@ -161,7 +161,7 @@ def test_random_layout_seed_is_random():
 
     cmd = [sys.executable, '-m', 'pelita.scripts.pelita_main',
             '--store-layout', '-',
-            '--size', 'small',
+            '--size', 'tiny',
             '--null']
 
     res = subprocess.run(cmd, check=True, text=True, stdout=subprocess.PIPE)
@@ -187,7 +187,7 @@ def test_random_layout_seed_is_stable():
 
     cmd = [sys.executable, '-m', 'pelita.scripts.pelita_main',
             '--store-layout', '-',
-            '--size', 'small',
+            '--size', 'tiny',
             '--null']
 
     res = subprocess.run(cmd, check=True, text=True, stdout=subprocess.PIPE)
@@ -201,7 +201,7 @@ def test_random_layout_seed_is_stable():
     # Check that the same seed generates the same layout
     cmd = [sys.executable, '-m', 'pelita.scripts.pelita_main',
             '--store-layout', '-',
-            '--size', 'small',
+            '--size', 'tiny',
             '--seed', seed,
             '--null']
 

--- a/test/test_remote_game.py
+++ b/test/test_remote_game.py
@@ -53,7 +53,7 @@ def dummy_layout_dict(dummy_layout):
 
 
 def test_remote_call_pelita(remote_teams):
-    res, stdout, stderr = call_pelita(remote_teams, rounds=10, size='small', viewer='null', seed='2')
+    res, stdout, stderr = call_pelita(remote_teams, rounds=10, size='tiny', viewer='null', seed='2')
     assert res['whowins'] == 1
     assert res['fatal_errors'] == [[], []]
     # errors for call_pelita only contains the last thrown error, hence None

--- a/test/test_tournament.py
+++ b/test/test_tournament.py
@@ -295,7 +295,7 @@ class TestSingleMatch:
         config.team_spec = lambda x: x
         config.team_group = lambda x: x
         config.viewer = 'ascii'
-        config.size = 'small'
+        config.size = 'tiny'
         config.tournament_log_folder = None
 
         teams = ["pelita/player/StoppingPlayer", "pelita/player/StoppingPlayer"]
@@ -335,7 +335,7 @@ class TestSingleMatch:
         config.team_name = lambda x: teams[x]
         config.team_group = lambda x: x
         config.viewer = 'ascii'
-        config.size = 'small'
+        config.size = 'tiny'
         config.print = mock_print
         config.tournament_log_folder = None
 
@@ -373,7 +373,7 @@ class TestSingleMatch:
         config.team_name = lambda x: teams[x]
         config.team_group = lambda x: x
         config.viewer = 'ascii'
-        config.size = 'small'
+        config.size = 'tiny'
         config.print = mock_print
         config.tournament_log_folder = None
 
@@ -410,7 +410,7 @@ class TestTournament:
                 {"id": "group3", "spec": "pelita/player/StoppingPlayer", "members": []},
                 {"id": "group4", "spec": "pelita/player/StoppingPlayer", "members": []},
             ],
-            "size": "small",
+            "size": "tiny",
         }
         config = tournament.Config(c)
         config.print = mock_print


### PR DESCRIPTION
Closes #954

New sizes: 

         'tiny': (16, 8),
         'small': (24, 12),
         'normal': (32, 16),
         'big': (48, 24),
         'huge': (64, 32),

I didn’t think much about the food specification. Any ideas? Technically this should scale with the area. I chose 50 now for the new big because it is a nice round number.

Also, specifying only the *height* will create a maze with twice the width.