### PR TITLE
Get rid of \x04 character in JSONL format and trust json.dump

### DIFF
--- a/pelita/scripts/pelita_main.py
+++ b/pelita/scripts/pelita_main.py
@@ -365,7 +365,7 @@ def main():
         if pelita.game.controller_await(viewer_state, await_action='set_initial'):
             sys.exit(0)
 
-        old_game = Path(args.replayfile).read_text().split("\x04")
+        old_game = Path(args.replayfile).read_text().split("\n")
         for state in old_game:
             if not state.strip():
                 continue

--- a/pelita/viewer.py
+++ b/pelita/viewer.py
@@ -165,18 +165,18 @@ class ReplyToViewer:
 
 
 class ReplayWriter:
-    """ A viewer which dumps to a given stream.
+    """ A viewer which writes JSONL to a given stream.
     """
     def __init__(self, stream):
         self.stream = stream
 
     def _send(self, message):
-        as_json = json.dumps(message, cls=SetEncoder)
-        self.stream.write(as_json)
-        # We use 0x04 (EOT) as a separator between the events.
-        # The additional newline is for improved readability
-        # and should be ignored by the Python json reader.
-        self.stream.write("\x04\n")
+        # Write a record with minimal spacing
+        # indent=None should ensure that no new lines are introduced
+        json.dump(message, self.stream, cls=SetEncoder, indent=None, separators=(',', ':'))
+
+        # Separate records with a new line
+        self.stream.write("\n")
         self.stream.flush()
 
     def show_state(self, game_state):

--- a/test/test_game.py
+++ b/test/test_game.py
@@ -1,4 +1,5 @@
 """Tests for Pelita game module"""
+import tempfile
 import inspect
 import itertools
 import os
@@ -16,6 +17,7 @@ from pelita.game import (add_fatal_error, apply_move, get_legal_positions, initi
                          play_turn, run_game, setup_game)
 from pelita.layout import parse_layout
 from pelita.player import stepping_player, stopping_player
+from pelita.viewer import ReplayWriter
 
 _mswindows = (sys.platform == "win32")
 
@@ -1391,3 +1393,15 @@ def test_games_have_different_uuid():
 
     # remainder of the game state is equal
     assert state1 == state2
+
+
+def test_replay_writer_writes_jsonl():
+    with tempfile.TemporaryDirectory() as dir:
+        replay_file = Path(dir) / "replay"
+        with replay_file.open('w') as f:
+            replay_writer = ReplayWriter(f)
+            replay_writer.show_state({"a": "\n"})
+            replay_writer.show_state({"b": "\r"})
+
+        # Check that records with new lines are correct
+        assert replay_file.read_text().split("\n") == ['{"a":"\\n"}', '{"b":"\\r"}', '']


### PR DESCRIPTION
The `\x04` (EOT) character was introduced by us to separate JSON records, but when a JSON record is properly exported without indents, it is enough to separate them with `\n`. In fact, all external tooling (`jq`) expects a plain `\n` in the JSONL format.

Semi-breaking change: This breaks historic replay files, but then again, historic replay files only work with some manual restructuring anyway (and now we can at least use `jq` to do the restructuring).