### PR TITLE
Reset requested moves before writing a new move

### DIFF
--- a/pelita/game.py
+++ b/pelita/game.py
@@ -890,6 +890,9 @@ def play_turn(game_state, raise_bot_exceptions=False):
     else:
         game_state['overlays'][game_state['turn']] = []
 
+    # reset the requested moves so that only the current bot is present
+    game_state['requested_moves'] = [None] * 4
+
     # If the returned move looks okay, we add it to the list of requested moves
     old_position = game_state['bots'][turn]
     game_state['requested_moves'][turn] = {

--- a/test/test_game.py
+++ b/test/test_game.py
@@ -1371,6 +1371,35 @@ def test_requested_moves(move_request, expected_prev, expected_req, expected_suc
     assert state['requested_moves'][1:] == [None, None, None]
     assert state['requested_moves'][0] == {'previous_position': (1, 1), 'requested_position': expected_req, 'success': expected_success}
 
+def test_requested_moves_are_cleared():
+    # test the possible return values of gamestate['requested_moves']
+    test_layout = """
+        ######
+        #a#.y#
+        #.bx #
+        ######
+    """
+    teams = [
+        stopping_player,
+        stopping_player
+    ]
+    state = setup_game(teams, layout_dict=parse_layout(test_layout), max_rounds=2)
+    assert state['requested_moves'] == [None, None, None, None]
+    state = play_turn(state)
+    assert state['requested_moves'][1:] == [None, None, None]
+    assert state['requested_moves'][0] == {'previous_position': (1, 1), 'requested_position': (1, 1), 'success': True}
+    state = play_turn(state)
+    assert state['requested_moves'][0] is None
+    assert state['requested_moves'][2:] == [None, None]
+    assert state['requested_moves'][1] == {'previous_position': (3, 2), 'requested_position': (3, 2), 'success': True}
+    state = play_turn(state)
+    assert state['requested_moves'][0:2] == [None, None]
+    assert state['requested_moves'][3] is None
+    assert state['requested_moves'][2] == {'previous_position': (2, 2), 'requested_position': (2, 2), 'success': True}
+    state = play_turn(state)
+    assert state['requested_moves'][0:3] == [None, None, None]
+    assert state['requested_moves'][3] == {'previous_position': (4, 1), 'requested_position': (4, 1), 'success': True}
+
 def test_games_have_different_uuid():
     state1 = setup_game([dummy_bot, dummy_bot], layout_dict=parse_layout(small_layout), max_rounds=2)
     state2 = setup_game([dummy_bot, dummy_bot], layout_dict=parse_layout(small_layout), max_rounds=2)


### PR DESCRIPTION
Trimming down the `requested_moves` dict a little which keeps track of what position a bot requested and whether it was successful. I think the whole requested_moves list can be rethought a little – now that bad moves fail immediately, it does not really capture a lot of info anymore, but I still would like to record that a move was a success, so I keep it for now.