### PR TITLE
Make first timeout fatal

### DIFF
--- a/pelita/game.py
+++ b/pelita/game.py
@@ -124,7 +124,7 @@ def controller_await(state, await_action='play_step'):
             return False
 
 def run_game(team_specs, *, layout_dict, max_rounds=300,
-             rng=None, allow_camping=False, error_limit=5, timeout_length=TIMEOUT_SECS,
+             rng=None, allow_camping=False, error_limit=1, timeout_length=TIMEOUT_SECS,
              initial_timeout_length=INITIAL_TIMEOUT_SECS,
              viewers=None, store_output=False,
              team_names=(None, None), team_infos=(None, None),
@@ -161,7 +161,7 @@ def run_game(team_specs, *, layout_dict, max_rounds=300,
                    game is over and the team is disqualified. Non fatal errors are
                    timeouts and returning an illegal move. Fatal errors are raising
                    Exceptions. An error_limit of 0 will disable the limit.
-                   Default: 5.
+                   Default: 1.
 
     timeout_length : int or float
                   Time in seconds to wait for the move function (or for the remote
@@ -304,7 +304,7 @@ def setup_viewers(viewers, print_result=True):
 
 
 def setup_game(team_specs, *, layout_dict, max_rounds=300, rng=None,
-               allow_camping=False, error_limit=5, timeout_length=TIMEOUT_SECS, initial_timeout_length=INITIAL_TIMEOUT_SECS,
+               allow_camping=False, error_limit=1, timeout_length=TIMEOUT_SECS, initial_timeout_length=INITIAL_TIMEOUT_SECS,
                viewers=None, store_output=False,
                team_names=(None, None), team_infos=(None, None),
                raise_bot_exceptions=False, print_result=True):

--- a/pelita/scripts/pelita_main.py
+++ b/pelita/scripts/pelita_main.py
@@ -248,8 +248,8 @@ timeout_opt.add_argument('--no-timeout', const=pelita.game.MAX_TIMEOUT_SECS, act
                          dest='timeout_length', help='Run game without timeouts.')
 game_settings.add_argument('--initial-timeout', type=float,  metavar="SEC", default=pelita.game.INITIAL_TIMEOUT_SECS,
                            dest='initial_timeout_length', help=long_help('Timeout to load a team'))
-game_settings.add_argument('--error-limit', type=int, default=5,
-                           dest='error_limit', help='Error limit. Reaching this limit disqualifies a team (default: 5).')
+game_settings.add_argument('--error-limit', type=int, default=1,
+                           dest='error_limit', help='Error limit. Reaching this limit disqualifies a team (default: 1).')
 parser.set_defaults(timeout_length=pelita.game.TIMEOUT_SECS)
 game_settings.add_argument('--stop-at', dest='stop_at', type=int, metavar="N",
                            help='Stop before playing round N.')

--- a/test/test_game.py
+++ b/test/test_game.py
@@ -908,7 +908,7 @@ def test_error_finishes_game(team_errors, team_wins):
         return b.position
 
     l = maze_generator.generate_maze()
-    state = game.setup_game([move0, move1], max_rounds=20, layout_dict=l)
+    state = game.setup_game([move0, move1], error_limit=5, max_rounds=20, layout_dict=l)
 
     # We must patch apply_move_fn so that RemotePlayerRecvTimeout is not caught
     # and we can actually test timeouts

--- a/test/test_remote_game.py
+++ b/test/test_remote_game.py
@@ -82,7 +82,8 @@ def test_remote_timeout(dummy_layout_dict):
     state = pelita.game.run_game([str(blue), str(red)],
                                  max_rounds=8,
                                  layout_dict=dummy_layout_dict,
-                                 timeout_length=0.4)
+                                 timeout_length=0.4,
+                                 error_limit=5)
 
     assert state['whowins'] == 0
     assert state['fatal_errors'][0] == []


### PR DESCRIPTION
This PR just changes the default `error_limit` to 1.
For a discussion see #959

The natural follow up would be to change the code to remove the concept of "non-fatal" error, remove all the code related to counting timeouts, simplify the UI to stop showing the timeout count, adapt the docs in `pelita_template`.