### PR TITLE
Fix deprecated use of non-Collection iterable in pytest.parametrize

### DIFF
--- a/test/test_game.py
+++ b/test/test_game.py
@@ -1168,7 +1168,7 @@ def test_setup_game_run_game_have_same_args():
 
 @pytest.mark.parametrize('bot_to_move', range(4))
 # all combinations of True False in a list of 4
-@pytest.mark.parametrize('bot_was_killed_flags', itertools.product(*[(True, False)] * 4))
+@pytest.mark.parametrize('bot_was_killed_flags', tuple(itertools.product(*[(True, False)] * 4)))
 def test_apply_move_resets_bot_was_killed(game_state, bot_to_move, bot_was_killed_flags):
     """ Check that `prepare_bot_state` sees the proper bot_was_killed flag
     and that `apply_move` will reset the flag to False. """

--- a/test/test_layout.py
+++ b/test/test_layout.py
@@ -418,7 +418,7 @@ def test_bots_in_same_position():
 
 
 # All combinations of bots that can be switched on/off
-@pytest.mark.parametrize('bots_hidden', itertools.product(*[(True, False)] * 4))
+@pytest.mark.parametrize('bots_hidden', tuple(itertools.product(*[(True, False)] * 4)))
 def test_parse_layout_game_bad_number_of_bots(bots_hidden):
     """ parse_layout should fail when a wrong number of bots is given. """
     test_layout = """


### PR DESCRIPTION
Since pytest 9.1 the use of non-Collection iterables as arguments to parametrize is deprecated. The deprecation warning looks like this:
```
[...]: PytestRemovedIn10Warning: Passing a non-Collection iterable to parametrize is deprecated.
[...]: argvalues type: product
[...]
Please convert to a list or tuple
```